### PR TITLE
feat(auth): add logout and session invalidation

### DIFF
--- a/src/auth/logout/logoutHandler.ts
+++ b/src/auth/logout/logoutHandler.ts
@@ -1,0 +1,25 @@
+import { NextFunction, RequestHandler, Response } from 'express';
+import { LogoutService } from './logoutService';
+import { AuthenticatedRequest } from './types';
+
+export const createLogoutHandler = (logoutService: LogoutService): RequestHandler => {
+  return async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    try {
+      const sessionId = req.auth?.sessionId;
+
+      if (!sessionId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      await logoutService.logout(sessionId);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  };
+};

--- a/src/auth/logout/logoutRoute.test.ts
+++ b/src/auth/logout/logoutRoute.test.ts
@@ -1,0 +1,139 @@
+import { NextFunction, Response } from 'express';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createLogoutHandler } from './logoutHandler';
+import { LogoutService } from './logoutService';
+import { AuthenticatedRequest, SessionRepository } from './types';
+
+class InMemorySessionRepository implements SessionRepository {
+  constructor(private readonly tokenToSession = new Map<string, string>()) {}
+
+  add(token: string, sessionId: string): void {
+    this.tokenToSession.set(token, sessionId);
+  }
+
+  getSessionId(token: string): string | undefined {
+    return this.tokenToSession.get(token);
+  }
+
+  async deleteSessionById(sessionId: string): Promise<void> {
+    for (const [token, storedSessionId] of this.tokenToSession.entries()) {
+      if (storedSessionId === sessionId) {
+        this.tokenToSession.delete(token);
+        return;
+      }
+    }
+  }
+}
+
+class MockResponse {
+  statusCode = 200;
+  payload: unknown;
+
+  status(code: number): this {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(payload: unknown): this {
+    this.payload = payload;
+    return this;
+  }
+
+  send(payload?: unknown): this {
+    this.payload = payload;
+    return this;
+  }
+}
+
+const createBearerHeader = (token: string): string => `Bearer ${token}`;
+
+const createProtectedAuthMiddleware = (sessions: InMemorySessionRepository) => {
+  return (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ): void => {
+    const bearer = req.headers.authorization;
+    const token = bearer?.startsWith('Bearer ') ? bearer.slice(7) : undefined;
+
+    if (!token) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const sessionId = sessions.getSessionId(token);
+
+    if (!sessionId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    req.auth = {
+      userId: 'user-1',
+      sessionId,
+      tokenId: token,
+    };
+
+    next();
+  };
+};
+
+const login = (sessions: InMemorySessionRepository): string => {
+  const token = 'jwt-token-1';
+  sessions.add(token, 'session-1');
+  return token;
+};
+
+test('logout invalidates current session and token can no longer be used', async () => {
+  const sessions = new InMemorySessionRepository();
+  const requireAuth = createProtectedAuthMiddleware(sessions);
+  const logoutHandler = createLogoutHandler(new LogoutService(sessions));
+
+  const token = login(sessions);
+
+  const authorizedRequestBeforeLogout = {
+    headers: { authorization: createBearerHeader(token) },
+  } as AuthenticatedRequest;
+
+  const authorizedResponseBeforeLogout = new MockResponse() as unknown as Response;
+
+  let nextCalledBeforeLogout = false;
+  requireAuth(
+    authorizedRequestBeforeLogout,
+    authorizedResponseBeforeLogout,
+    () => {
+      nextCalledBeforeLogout = true;
+    }
+  );
+
+  assert.equal(nextCalledBeforeLogout, true);
+  assert.equal(authorizedRequestBeforeLogout.auth?.sessionId, 'session-1');
+
+  const logoutResponse = new MockResponse();
+  await logoutHandler(
+    authorizedRequestBeforeLogout,
+    logoutResponse as unknown as Response,
+    () => undefined
+  );
+
+  assert.equal(logoutResponse.statusCode, 204);
+
+  const authorizedRequestAfterLogout = {
+    headers: { authorization: createBearerHeader(token) },
+  } as AuthenticatedRequest;
+
+  const unauthorizedResponseAfterLogout = new MockResponse();
+
+  let nextCalledAfterLogout = false;
+  requireAuth(
+    authorizedRequestAfterLogout,
+    unauthorizedResponseAfterLogout as unknown as Response,
+    () => {
+      nextCalledAfterLogout = true;
+    }
+  );
+
+  assert.equal(nextCalledAfterLogout, false);
+  assert.equal(unauthorizedResponseAfterLogout.statusCode, 401);
+});

--- a/src/auth/logout/logoutRoute.ts
+++ b/src/auth/logout/logoutRoute.ts
@@ -1,0 +1,21 @@
+import { RequestHandler, Router } from 'express';
+import { createLogoutHandler } from './logoutHandler';
+import { LogoutService } from './logoutService';
+import { SessionRepository } from './types';
+
+interface CreateLogoutRouterDeps {
+  requireAuth: RequestHandler;
+  sessionRepository: SessionRepository;
+}
+
+export const createLogoutRouter = ({
+  requireAuth,
+  sessionRepository,
+}: CreateLogoutRouterDeps): Router => {
+  const router = Router();
+  const logoutService = new LogoutService(sessionRepository);
+
+  router.post('/api/auth/logout', requireAuth, createLogoutHandler(logoutService));
+
+  return router;
+};

--- a/src/auth/logout/logoutService.ts
+++ b/src/auth/logout/logoutService.ts
@@ -1,0 +1,9 @@
+import { SessionRepository } from './types';
+
+export class LogoutService {
+  constructor(private readonly sessionRepository: SessionRepository) {}
+
+  async logout(sessionId: string): Promise<void> {
+    await this.sessionRepository.deleteSessionById(sessionId);
+  }
+}

--- a/src/auth/logout/types.ts
+++ b/src/auth/logout/types.ts
@@ -1,0 +1,15 @@
+import { Request } from 'express';
+
+export interface AuthContext {
+  userId: string;
+  sessionId: string;
+  tokenId?: string;
+}
+
+export type AuthenticatedRequest = Request & {
+  auth?: AuthContext;
+};
+
+export interface SessionRepository {
+  deleteSessionById(sessionId: string): Promise<void>;
+}


### PR DESCRIPTION
##Summary

  - Implements a protected POST /api/auth/logout route via src/auth/logout/logoutRoute.ts, wiring a dedicated handler/service pair that deletes the session
    using the existing repository contract defined in src/auth/logout/types.ts.
  - Adds LogoutService + handler to enforce the req.auth session requirement and respond 204 No Content after invalidation (logoutHandler.ts).
  - Covers the new flow with src/auth/logout/logoutRoute.test.ts, simulating auth middleware + logout so a token works before logout and is rejected
    afterwards.

  Tests

  - npx tsc --module commonjs --target ES2020 --esModuleInterop --strict --skipLibCheck src/auth/logout/* --outDir .tmp-logout-dist && node --test .tmp-
    logout-dist/logoutRoute.test.js

closes #13 
@thlpkee20-wq 