### PR TITLE
feat(auth): add login API and token issue

### DIFF
--- a/src/auth/login/loginHandler.ts
+++ b/src/auth/login/loginHandler.ts
@@ -1,0 +1,52 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { LoginService } from './loginService';
+import { LoginRequestBody } from './types';
+
+/**
+ * Express handler factory for `POST /api/auth/login`.
+ *
+ * Validates the request body, delegates to `LoginService`, and returns
+ * either 200 with the JWT + user payload, or 401 for invalid credentials.
+ */
+export const createLoginHandler = (
+    loginService: LoginService,
+): RequestHandler => {
+    return async (
+        req: Request<unknown, unknown, LoginRequestBody>,
+        res: Response,
+        next: NextFunction,
+    ): Promise<void> => {
+        try {
+            const { email, password } = req.body ?? {};
+
+            // ── Input validation ────────────────────────────────────────────
+            if (!email || !password) {
+                res.status(400).json({
+                    error: 'Bad Request',
+                    message: 'Both "email" and "password" are required.',
+                });
+                return;
+            }
+
+            if (typeof email !== 'string' || typeof password !== 'string') {
+                res.status(400).json({
+                    error: 'Bad Request',
+                    message: '"email" and "password" must be strings.',
+                });
+                return;
+            }
+
+            // ── Attempt login ───────────────────────────────────────────────
+            const result = await loginService.login(email, password);
+
+            if (!result) {
+                res.status(401).json({ error: 'Invalid email or password' });
+                return;
+            }
+
+            res.status(200).json(result);
+        } catch (error) {
+            next(error);
+        }
+    };
+};

--- a/src/auth/login/loginRoute.test.ts
+++ b/src/auth/login/loginRoute.test.ts
@@ -1,0 +1,276 @@
+import { createHash } from 'node:crypto';
+import { Response, NextFunction } from 'express';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createLoginHandler } from './loginHandler';
+import { LoginService } from './loginService';
+import {
+    JwtIssuer,
+    SessionRepository,
+    UserRecord,
+    UserRepository,
+    UserRole,
+} from './types';
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const hashPassword = (plain: string): string =>
+    createHash('sha256').update(plain).digest('hex');
+
+// ── In-memory fakes ─────────────────────────────────────────────────────
+
+class InMemoryUserRepository implements UserRepository {
+    private users: UserRecord[] = [];
+
+    add(user: UserRecord): void {
+        this.users.push(user);
+    }
+
+    async findByEmail(email: string): Promise<UserRecord | null> {
+        return this.users.find((u) => u.email === email) ?? null;
+    }
+}
+
+class InMemorySessionRepository implements SessionRepository {
+    private sessions = new Map<string, string>();
+    private counter = 0;
+
+    async createSession(userId: string): Promise<string> {
+        const id = `session-${++this.counter}`;
+        this.sessions.set(id, userId);
+        return id;
+    }
+
+    getSession(sessionId: string): string | undefined {
+        return this.sessions.get(sessionId);
+    }
+}
+
+class FakeJwtIssuer implements JwtIssuer {
+    lastPayload: { userId: string; sessionId: string; role: UserRole } | null =
+        null;
+
+    sign(payload: { userId: string; sessionId: string; role: UserRole }): string {
+        this.lastPayload = payload;
+        return `fake-jwt-for-${payload.userId}-${payload.sessionId}`;
+    }
+}
+
+// ── Mock Express plumbing ───────────────────────────────────────────────
+
+class MockResponse {
+    statusCode = 200;
+    payload: unknown;
+
+    status(code: number): this {
+        this.statusCode = code;
+        return this;
+    }
+
+    json(payload: unknown): this {
+        this.payload = payload;
+        return this;
+    }
+
+    send(payload?: unknown): this {
+        this.payload = payload;
+        return this;
+    }
+}
+
+function buildRequest(body: unknown): any {
+    return { body } as any;
+}
+
+const noop: NextFunction = () => undefined;
+
+// ── Fixture factory ─────────────────────────────────────────────────────
+
+function createFixture() {
+    const userRepo = new InMemoryUserRepository();
+    const sessionRepo = new InMemorySessionRepository();
+    const jwtIssuer = new FakeJwtIssuer();
+    const service = new LoginService(userRepo, sessionRepo, jwtIssuer);
+    const handler = createLoginHandler(service);
+    return { userRepo, sessionRepo, jwtIssuer, service, handler };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+test('successful login for startup user returns 200 with token and user', async () => {
+    const { userRepo, handler, jwtIssuer } = createFixture();
+
+    userRepo.add({
+        id: 'user-1',
+        email: 'founder@startup.io',
+        role: 'startup',
+        passwordHash: hashPassword('s3cret!'),
+    });
+
+    const req = buildRequest({ email: 'founder@startup.io', password: 's3cret!' });
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 200);
+
+    const body = res.payload as any;
+    assert.equal(body.token, 'fake-jwt-for-user-1-session-1');
+    assert.equal(body.user.id, 'user-1');
+    assert.equal(body.user.email, 'founder@startup.io');
+    assert.equal(body.user.role, 'startup');
+
+    // JWT payload should include session
+    assert.ok(jwtIssuer.lastPayload);
+    assert.equal(jwtIssuer.lastPayload!.userId, 'user-1');
+    assert.equal(jwtIssuer.lastPayload!.role, 'startup');
+    assert.match(jwtIssuer.lastPayload!.sessionId, /^session-/);
+});
+
+test('successful login for investor user returns 200 with token and user', async () => {
+    const { userRepo, handler } = createFixture();
+
+    userRepo.add({
+        id: 'user-2',
+        email: 'investor@funds.co',
+        role: 'investor',
+        passwordHash: hashPassword('inv3st0r!'),
+    });
+
+    const req = buildRequest({
+        email: 'investor@funds.co',
+        password: 'inv3st0r!',
+    });
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 200);
+
+    const body = res.payload as any;
+    assert.equal(body.user.role, 'investor');
+    assert.equal(body.user.email, 'investor@funds.co');
+});
+
+test('login with wrong password returns 401', async () => {
+    const { userRepo, handler } = createFixture();
+
+    userRepo.add({
+        id: 'user-1',
+        email: 'founder@startup.io',
+        role: 'startup',
+        passwordHash: hashPassword('correctPassword'),
+    });
+
+    const req = buildRequest({
+        email: 'founder@startup.io',
+        password: 'wrongPassword',
+    });
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 401);
+    assert.deepStrictEqual(res.payload, { error: 'Invalid email or password' });
+});
+
+test('login with non-existent email returns 401', async () => {
+    const { handler } = createFixture();
+
+    const req = buildRequest({
+        email: 'nobody@example.com',
+        password: 'anything',
+    });
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 401);
+    assert.deepStrictEqual(res.payload, { error: 'Invalid email or password' });
+});
+
+test('login with missing email returns 400', async () => {
+    const { handler } = createFixture();
+
+    const req = buildRequest({ password: 'something' });
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 400);
+    assert.ok((res.payload as any).error);
+});
+
+test('login with missing password returns 400', async () => {
+    const { handler } = createFixture();
+
+    const req = buildRequest({ email: 'test@example.com' });
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 400);
+    assert.ok((res.payload as any).error);
+});
+
+test('login with empty body returns 400', async () => {
+    const { handler } = createFixture();
+
+    const req = buildRequest(undefined);
+    const res = new MockResponse();
+    await handler(req, res as unknown as Response, noop);
+
+    assert.equal(res.statusCode, 400);
+});
+
+test('login creates a new session for each successful login', async () => {
+    const { userRepo, sessionRepo, handler } = createFixture();
+
+    userRepo.add({
+        id: 'user-1',
+        email: 'founder@startup.io',
+        role: 'startup',
+        passwordHash: hashPassword('s3cret!'),
+    });
+
+    // First login
+    const res1 = new MockResponse();
+    await handler(
+        buildRequest({ email: 'founder@startup.io', password: 's3cret!' }),
+        res1 as unknown as Response,
+        noop,
+    );
+    assert.equal(res1.statusCode, 200);
+    assert.ok(sessionRepo.getSession('session-1'));
+
+    // Second login — should get a fresh session
+    const res2 = new MockResponse();
+    await handler(
+        buildRequest({ email: 'founder@startup.io', password: 's3cret!' }),
+        res2 as unknown as Response,
+        noop,
+    );
+    assert.equal(res2.statusCode, 200);
+    assert.ok(sessionRepo.getSession('session-2'));
+
+    // Tokens should differ (different sessions)
+    assert.notEqual(
+        (res1.payload as any).token,
+        (res2.payload as any).token,
+    );
+});
+
+test('LoginService.login returns null for unknown user (unit)', async () => {
+    const { service } = createFixture();
+
+    const result = await service.login('ghost@example.com', 'anything');
+    assert.equal(result, null);
+});
+
+test('LoginService.login returns null for wrong password (unit)', async () => {
+    const { userRepo, service } = createFixture();
+
+    userRepo.add({
+        id: 'user-1',
+        email: 'test@example.com',
+        role: 'investor',
+        passwordHash: hashPassword('right'),
+    });
+
+    const result = await service.login('test@example.com', 'wrong');
+    assert.equal(result, null);
+});

--- a/src/auth/login/loginRoute.ts
+++ b/src/auth/login/loginRoute.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import { createLoginHandler } from './loginHandler';
+import { LoginService } from './loginService';
+import { JwtIssuer, SessionRepository, UserRepository } from './types';
+
+/**
+ * Dependencies required to wire the login route.
+ *
+ * These are satisfied by concrete implementations at composition-root
+ * level (e.g. inside `src/index.ts`), keeping this module decoupled
+ * from database drivers, JWT libraries, etc.
+ */
+export interface CreateLoginRouterDeps {
+    userRepository: UserRepository;
+    sessionRepository: SessionRepository;
+    jwtIssuer: JwtIssuer;
+}
+
+/**
+ * Create an Express router that exposes:
+ *
+ *   POST /api/auth/login   { email, password }
+ *
+ * Returns 200 with `{ token, user: { id, email, role } }` on success,
+ * or 401 for invalid credentials.
+ */
+export const createLoginRouter = ({
+    userRepository,
+    sessionRepository,
+    jwtIssuer,
+}: CreateLoginRouterDeps): Router => {
+    const router = Router();
+    const loginService = new LoginService(
+        userRepository,
+        sessionRepository,
+        jwtIssuer,
+    );
+
+    router.post('/api/auth/login', createLoginHandler(loginService));
+
+    return router;
+};

--- a/src/auth/login/loginService.ts
+++ b/src/auth/login/loginService.ts
@@ -1,0 +1,94 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import {
+    JwtIssuer,
+    LoginSuccessResponse,
+    SessionRepository,
+    UserRepository,
+} from './types';
+
+/**
+ * Domain service that orchestrates the login flow:
+ *
+ *  1. Look up the user by email.
+ *  2. Compare the provided password against the stored hash.
+ *  3. Create a new session.
+ *  4. Issue a JWT that embeds the session.
+ *
+ * All I/O is pushed to injected collaborators so this class can be
+ * unit-tested with in-memory fakes.
+ */
+export class LoginService {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly sessionRepository: SessionRepository,
+        private readonly jwtIssuer: JwtIssuer,
+    ) { }
+
+    /**
+     * Attempt to log a user in.
+     *
+     * @returns The signed JWT and a subset of user data on success,
+     *          or `null` when the credentials are invalid.
+     */
+    async login(
+        email: string,
+        password: string,
+    ): Promise<LoginSuccessResponse | null> {
+        // 1. Resolve user
+        const user = await this.userRepository.findByEmail(email);
+
+        if (!user) {
+            return null;
+        }
+
+        // 2. Verify password
+        if (!this.verifyPassword(password, user.passwordHash)) {
+            return null;
+        }
+
+        // 3. Create session
+        const sessionId = await this.sessionRepository.createSession(user.id);
+
+        // 4. Issue JWT
+        const token = this.jwtIssuer.sign({
+            userId: user.id,
+            sessionId,
+            role: user.role,
+        });
+
+        return {
+            token,
+            user: {
+                id: user.id,
+                email: user.email,
+                role: user.role,
+            },
+        };
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────
+
+    /**
+     * Timing-safe comparison of a plain-text password against a SHA-256
+     * hex digest.
+     *
+     * SHA-256 is used here because the existing project has no bcrypt /
+     * argon2 dependency and `package.json` must not be modified.
+     * In production you would swap this for a proper password-hashing
+     * algorithm (bcrypt / argon2) via the same interface boundary.
+     */
+    private verifyPassword(plaintext: string, storedHash: string): boolean {
+        const candidateHash = createHash('sha256')
+            .update(plaintext)
+            .digest('hex');
+
+        const a = Buffer.from(candidateHash, 'utf-8');
+        const b = Buffer.from(storedHash, 'utf-8');
+
+        if (a.length !== b.length) {
+            return false;
+        }
+
+        return timingSafeEqual(a, b);
+    }
+}

--- a/src/auth/login/types.ts
+++ b/src/auth/login/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Login module type definitions.
+ *
+ * All external dependencies (user store, session store, JWT issuer) are
+ * expressed as narrow interfaces so the login service stays testable
+ * without any concrete implementations.
+ */
+
+// ── User ────────────────────────────────────────────────────────────────
+
+export type UserRole = 'startup' | 'investor';
+
+export interface UserRecord {
+  id: string;
+  email: string;
+  role: UserRole;
+  passwordHash: string;
+}
+
+// ── Repositories ────────────────────────────────────────────────────────
+
+export interface UserRepository {
+  /** Return the user for a given email, or `null` if not found. */
+  findByEmail(email: string): Promise<UserRecord | null>;
+}
+
+export interface SessionRepository {
+  /** Persist a new session and return its unique ID. */
+  createSession(userId: string): Promise<string>;
+}
+
+// ── JWT helper ──────────────────────────────────────────────────────────
+
+export interface JwtIssuer {
+  /**
+   * Create a signed JWT.
+   *
+   * The token payload should at minimum include the user ID, session ID,
+   * and role so downstream middleware can authorise requests.
+   */
+  sign(payload: { userId: string; sessionId: string; role: UserRole }): string;
+}
+
+// ── DTOs ────────────────────────────────────────────────────────────────
+
+export interface LoginRequestBody {
+  email: string;
+  password: string;
+}
+
+export interface LoginSuccessResponse {
+  token: string;
+  user: {
+    id: string;
+    email: string;
+    role: UserRole;
+  };
+}


### PR DESCRIPTION
Implement POST /api/auth/login endpoint that:
- Validates email + password credentials
- Verifies password hash (timing-safe SHA-256 comparison)
- Creates a new session on successful authentication
- Issues a JWT via the injected JwtIssuer interface
- Returns 200 with { token, user: { id, email, role } }
- Returns 401 for invalid credentials (wrong password or missing user)
- Returns 400 for malformed requests (missing email/password)
- Supports both startup and investor roles (single endpoint)

All dependencies are expressed as interfaces (UserRepository, SessionRepository, JwtIssuer) following the existing logout module's dependency-injection pattern. No existing files modified.

Tests: 10 tests covering success, wrong password, missing user, input validation, and session uniqueness.

Closes #12

@thlpkee20-wq 