### PR TITLE
feat(api): add get and update notification preferences

### DIFF
--- a/src/db/migrations/002_create_notification_preferences.sql
+++ b/src/db/migrations/002_create_notification_preferences.sql
@@ -1,0 +1,11 @@
+-- Migration: Create notification_preferences table
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  user_id UUID PRIMARY KEY,
+  email_notifications BOOLEAN DEFAULT TRUE,
+  push_notifications BOOLEAN DEFAULT TRUE,
+  sms_notifications BOOLEAN DEFAULT FALSE,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create index on updated_at for faster queries
+CREATE INDEX IF NOT EXISTS idx_notification_preferences_updated_at ON notification_preferences(updated_at);

--- a/src/db/repositories/notificationPreferencesRepository.ts
+++ b/src/db/repositories/notificationPreferencesRepository.ts
@@ -1,0 +1,53 @@
+import { Pool, QueryResult } from 'pg';
+
+export interface NotificationPreferences {
+  user_id: string;
+  email_notifications: boolean;
+  push_notifications: boolean;
+  sms_notifications: boolean;
+  updated_at: Date;
+}
+
+export interface UpdateNotificationPreferencesInput {
+  email_notifications?: boolean;
+  push_notifications?: boolean;
+  sms_notifications?: boolean;
+}
+
+export class NotificationPreferencesRepository {
+  constructor(private db: Pool) {}
+
+  async getByUserId(userId: string): Promise<NotificationPreferences | null> {
+    const query = `
+      SELECT * FROM notification_preferences
+      WHERE user_id = $1
+    `;
+    const result: QueryResult<NotificationPreferences> = await this.db.query(query, [userId]);
+    return result.rows[0] || null;
+  }
+
+  async upsert(userId: string, input: UpdateNotificationPreferencesInput): Promise<NotificationPreferences> {
+    const query = `
+      INSERT INTO notification_preferences (user_id, email_notifications, push_notifications, sms_notifications, updated_at)
+      VALUES ($1, $2, $3, $4, NOW())
+      ON CONFLICT (user_id)
+      DO UPDATE SET
+        email_notifications = COALESCE($2, notification_preferences.email_notifications),
+        push_notifications = COALESCE($3, notification_preferences.push_notifications),
+        sms_notifications = COALESCE($4, notification_preferences.sms_notifications),
+        updated_at = NOW()
+      RETURNING *
+    `;
+    const values = [
+      userId,
+      input.email_notifications,
+      input.push_notifications,
+      input.sms_notifications,
+    ];
+    const result: QueryResult<NotificationPreferences> = await this.db.query(query, values);
+    if (result.rows.length === 0) {
+      throw new Error('Failed to update notification preferences');
+    }
+    return result.rows[0];
+  }
+}

--- a/src/routes/README.md
+++ b/src/routes/README.md
@@ -1,0 +1,83 @@
+# Notification Preferences API
+
+## Endpoints
+
+### GET /api/users/me/notification-preferences
+Get the authenticated user's notification preferences.
+
+**Authentication:** Required (JWT)
+
+**Response:**
+```json
+{
+  "user_id": "uuid",
+  "email_notifications": true,
+  "push_notifications": true,
+  "sms_notifications": false,
+  "updated_at": "2026-02-25T20:00:00Z"
+}
+```
+
+If no preferences exist, returns default values:
+```json
+{
+  "email_notifications": true,
+  "push_notifications": true,
+  "sms_notifications": false
+}
+```
+
+### PATCH /api/users/me/notification-preferences
+Update the authenticated user's notification preferences.
+
+**Authentication:** Required (JWT)
+
+**Request Body:**
+```json
+{
+  "email_notifications": false,
+  "push_notifications": true,
+  "sms_notifications": false
+}
+```
+
+All fields are optional. Only provided fields will be updated.
+
+**Response:**
+```json
+{
+  "user_id": "uuid",
+  "email_notifications": false,
+  "push_notifications": true,
+  "sms_notifications": false,
+  "updated_at": "2026-02-25T20:00:00Z"
+}
+```
+
+## Usage Example
+
+To integrate this route into your Express app:
+
+```typescript
+import { Pool } from 'pg';
+import { createNotificationPreferencesRouter } from './routes/notificationPreferences';
+import { NotificationPreferencesRepository } from './db/repositories/notificationPreferencesRepository';
+
+const db = new Pool({ /* your config */ });
+const notificationPreferencesRepository = new NotificationPreferencesRepository(db);
+
+const router = createNotificationPreferencesRouter({
+  requireAuth: yourAuthMiddleware,
+  notificationPreferencesRepository,
+});
+
+app.use(router);
+```
+
+## Database Migration
+
+Run the migration to create the notification_preferences table:
+
+```sql
+-- See src/db/migrations/002_create_notification_preferences.sql
+```

--- a/src/routes/notificationPreferences.test.ts
+++ b/src/routes/notificationPreferences.test.ts
@@ -1,0 +1,141 @@
+import { NextFunction, Response } from 'express';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createNotificationPreferencesRouter } from './notificationPreferences';
+import {
+  NotificationPreferences,
+  NotificationPreferencesRepository,
+  UpdateNotificationPreferencesInput,
+} from '../db/repositories/notificationPreferencesRepository';
+
+class InMemoryNotificationPreferencesRepository implements NotificationPreferencesRepository {
+  constructor(private preferences = new Map<string, NotificationPreferences>()) {}
+
+  async getByUserId(userId: string): Promise<NotificationPreferences | null> {
+    return this.preferences.get(userId) || null;
+  }
+
+  async upsert(userId: string, input: UpdateNotificationPreferencesInput): Promise<NotificationPreferences> {
+    const existing = this.preferences.get(userId);
+    const updated: NotificationPreferences = {
+      user_id: userId,
+      email_notifications: input.email_notifications ?? existing?.email_notifications ?? true,
+      push_notifications: input.push_notifications ?? existing?.push_notifications ?? true,
+      sms_notifications: input.sms_notifications ?? existing?.sms_notifications ?? false,
+      updated_at: new Date(),
+    };
+    this.preferences.set(userId, updated);
+    return updated;
+  }
+}
+
+class MockResponse {
+  statusCode = 200;
+  payload: unknown;
+
+  status(code: number): this {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(payload: unknown): this {
+    this.payload = payload;
+    return this;
+  }
+}
+
+const createAuthMiddleware = (userId?: string) => {
+  return (req: any, _res: Response, next: NextFunction) => {
+    if (userId) {
+      req.user = { id: userId };
+    }
+    next();
+  };
+};
+
+test('GET /api/users/me/notification-preferences returns default preferences when none exist', async () => {
+  const repo = new InMemoryNotificationPreferencesRepository();
+  const requireAuth = createAuthMiddleware('user-123');
+  const router = createNotificationPreferencesRouter({ requireAuth, notificationPreferencesRepository: repo });
+
+  const req = { user: { id: 'user-123' } } as any;
+  const res = new MockResponse() as any;
+
+  const handler = router.stack.find((layer: any) => layer.route?.path === '/api/users/me/notification-preferences' && layer.route?.methods.get)?.route.stack[1].handle;
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload, {
+    email_notifications: true,
+    push_notifications: true,
+    sms_notifications: false,
+  });
+});
+
+test('GET /api/users/me/notification-preferences returns existing preferences', async () => {
+  const repo = new InMemoryNotificationPreferencesRepository();
+  await repo.upsert('user-123', { email_notifications: false, push_notifications: true, sms_notifications: true });
+
+  const requireAuth = createAuthMiddleware('user-123');
+  const router = createNotificationPreferencesRouter({ requireAuth, notificationPreferencesRepository: repo });
+
+  const req = { user: { id: 'user-123' } } as any;
+  const res = new MockResponse() as any;
+
+  const handler = router.stack.find((layer: any) => layer.route?.path === '/api/users/me/notification-preferences' && layer.route?.methods.get)?.route.stack[1].handle;
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal((res.payload as any).email_notifications, false);
+  assert.equal((res.payload as any).push_notifications, true);
+  assert.equal((res.payload as any).sms_notifications, true);
+});
+
+test('PATCH /api/users/me/notification-preferences updates preferences', async () => {
+  const repo = new InMemoryNotificationPreferencesRepository();
+  const requireAuth = createAuthMiddleware('user-123');
+  const router = createNotificationPreferencesRouter({ requireAuth, notificationPreferencesRepository: repo });
+
+  const req = {
+    user: { id: 'user-123' },
+    body: { email_notifications: false, push_notifications: false },
+  } as any;
+  const res = new MockResponse() as any;
+
+  const handler = router.stack.find((layer: any) => layer.route?.path === '/api/users/me/notification-preferences' && layer.route?.methods.patch)?.route.stack[1].handle;
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal((res.payload as any).email_notifications, false);
+  assert.equal((res.payload as any).push_notifications, false);
+});
+
+test('GET /api/users/me/notification-preferences returns 401 when not authenticated', async () => {
+  const repo = new InMemoryNotificationPreferencesRepository();
+  const requireAuth = createAuthMiddleware();
+  const router = createNotificationPreferencesRouter({ requireAuth, notificationPreferencesRepository: repo });
+
+  const req = {} as any;
+  const res = new MockResponse() as any;
+
+  const handler = router.stack.find((layer: any) => layer.route?.path === '/api/users/me/notification-preferences' && layer.route?.methods.get)?.route.stack[1].handle;
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Unauthorized' });
+});
+
+test('PATCH /api/users/me/notification-preferences returns 401 when not authenticated', async () => {
+  const repo = new InMemoryNotificationPreferencesRepository();
+  const requireAuth = createAuthMiddleware();
+  const router = createNotificationPreferencesRouter({ requireAuth, notificationPreferencesRepository: repo });
+
+  const req = { body: { email_notifications: false } } as any;
+  const res = new MockResponse() as any;
+
+  const handler = router.stack.find((layer: any) => layer.route?.path === '/api/users/me/notification-preferences' && layer.route?.methods.patch)?.route.stack[1].handle;
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { error: 'Unauthorized' });
+});

--- a/src/routes/notificationPreferences.ts
+++ b/src/routes/notificationPreferences.ts
@@ -1,0 +1,61 @@
+import { RequestHandler, Router } from 'express';
+import { NotificationPreferencesRepository } from '../db/repositories/notificationPreferencesRepository';
+
+interface AuthenticatedRequest {
+  user?: { id: string };
+}
+
+interface CreateNotificationPreferencesRouterDeps {
+  requireAuth: RequestHandler;
+  notificationPreferencesRepository: NotificationPreferencesRepository;
+}
+
+export const createNotificationPreferencesRouter = ({
+  requireAuth,
+  notificationPreferencesRepository,
+}: CreateNotificationPreferencesRouterDeps): Router => {
+  const router = Router();
+
+  router.get('/api/users/me/notification-preferences', requireAuth, async (req, res) => {
+    const userId = (req as any).user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    try {
+      const preferences = await notificationPreferencesRepository.getByUserId(userId);
+      if (!preferences) {
+        return res.json({
+          email_notifications: true,
+          push_notifications: true,
+          sms_notifications: false,
+        });
+      }
+      res.json(preferences);
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to fetch notification preferences' });
+    }
+  });
+
+  router.patch('/api/users/me/notification-preferences', requireAuth, async (req, res) => {
+    const userId = (req as any).user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const { email_notifications, push_notifications, sms_notifications } = req.body;
+
+    try {
+      const updated = await notificationPreferencesRepository.upsert(userId, {
+        email_notifications,
+        push_notifications,
+        sms_notifications,
+      });
+      res.json(updated);
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to update notification preferences' });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
Closes #45 
Key Features
- **GET /api/users/me/notification-preferences** - View notification settings
- **PATCH /api/users/me/notification-preferences** - Update notification settings
- JWT authentication required (via requireAuth middleware)
- Returns default preferences if none exist
- Partial updates supported (only provided fields are updated)
- All tests passing (5/5) ✅

