### PR TITLE
feat(api): Implement List Revenue Reports by Offering (Startup Dashboard) (#29)

### DIFF
--- a/src/offerings/revenueReportsRoute.test.ts
+++ b/src/offerings/revenueReportsRoute.test.ts
@@ -1,0 +1,182 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  createListRevenueReportsHandler,
+  OfferingOwnershipRepository,
+  RevenueReport,
+  RevenueReportRepository,
+} from './revenueReportsRoute';
+
+const mockRevenueReportRepository: jest.Mocked<RevenueReportRepository> = {
+  listByOffering: jest.fn(),
+};
+
+const mockOfferingOwnershipRepository: jest.Mocked<OfferingOwnershipRepository> = {
+  isOwnedByUser: jest.fn(),
+};
+
+const createResponse = (): Response => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const createNext = (): NextFunction => jest.fn();
+
+const createRequest = (
+  overrides: Partial<Request> & {
+    params?: Record<string, string>;
+    query?: Record<string, string | undefined>;
+    userId?: string;
+  }
+): Request => {
+  const req = {
+    params: overrides.params ?? { id: 'offering-1' },
+    query: overrides.query ?? {},
+    user: overrides.userId ? { id: overrides.userId } : undefined,
+  } as unknown as Request;
+
+  return req;
+};
+
+const reports: RevenueReport[] = [
+  {
+    id: 'report-1',
+    offering_id: 'offering-1',
+    period_id: '2024-01',
+    total_revenue: '100.00',
+    created_at: new Date('2024-01-31T00:00:00.000Z'),
+    updated_at: new Date('2024-01-31T00:00:00.000Z'),
+  },
+  {
+    id: 'report-2',
+    offering_id: 'offering-1',
+    period_id: '2024-02',
+    total_revenue: '120.00',
+    created_at: new Date('2024-02-29T00:00:00.000Z'),
+    updated_at: new Date('2024-02-29T00:00:00.000Z'),
+  },
+  {
+    id: 'report-3',
+    offering_id: 'offering-1',
+    period_id: '2024-03',
+    total_revenue: '140.00',
+    created_at: new Date('2024-03-31T00:00:00.000Z'),
+    updated_at: new Date('2024-03-31T00:00:00.000Z'),
+  },
+];
+
+describe('createListRevenueReportsHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when request is unauthenticated', async () => {
+    const handler = createListRevenueReportsHandler({
+      revenueReportRepository: mockRevenueReportRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+    const req = createRequest({ userId: undefined });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    expect(mockOfferingOwnershipRepository.isOwnedByUser).not.toHaveBeenCalled();
+    expect(mockRevenueReportRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when offering is not owned by authenticated issuer', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(false);
+
+    const handler = createListRevenueReportsHandler({
+      revenueReportRepository: mockRevenueReportRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+    const req = createRequest({ userId: 'issuer-1' });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(mockOfferingOwnershipRepository.isOwnedByUser).toHaveBeenCalledWith(
+      'offering-1',
+      'issuer-1'
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+    expect(mockRevenueReportRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  it('returns paginated list filtered by optional period range', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockRevenueReportRepository.listByOffering.mockResolvedValueOnce(reports);
+
+    const handler = createListRevenueReportsHandler({
+      revenueReportRepository: mockRevenueReportRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+    const req = createRequest({
+      userId: 'issuer-1',
+      query: {
+        periodFrom: '2024-02',
+        periodTo: '2024-03',
+        page: '1',
+        pageSize: '1',
+      },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [reports[1]],
+      pagination: {
+        page: 1,
+        pageSize: 1,
+        total: 2,
+        totalPages: 2,
+      },
+    });
+  });
+
+  it('returns 400 for invalid pagination inputs', async () => {
+    const handler = createListRevenueReportsHandler({
+      revenueReportRepository: mockRevenueReportRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+    const req = createRequest({
+      userId: 'issuer-1',
+      query: {
+        page: '0',
+      },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid request' });
+  });
+
+  it('returns 400 for invalid period range', async () => {
+    const handler = createListRevenueReportsHandler({
+      revenueReportRepository: mockRevenueReportRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+    const req = createRequest({
+      userId: 'issuer-1',
+      query: {
+        periodFrom: '2024-05',
+        periodTo: '2024-03',
+      },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid request' });
+  });
+});

--- a/src/offerings/revenueReportsRoute.ts
+++ b/src/offerings/revenueReportsRoute.ts
@@ -1,0 +1,163 @@
+import { NextFunction, Request, RequestHandler, Response, Router } from 'express';
+
+export interface RevenueReport {
+  id: string;
+  offering_id: string;
+  period_id: string;
+  total_revenue: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface RevenueReportRepository {
+  listByOffering(offeringId: string): Promise<RevenueReport[]>;
+}
+
+export interface OfferingOwnershipRepository {
+  isOwnedByUser(offeringId: string, userId: string): Promise<boolean>;
+}
+
+interface CreateRevenueReportsRouteDeps {
+  requireAuth: RequestHandler;
+  revenueReportRepository: RevenueReportRepository;
+  offeringOwnershipRepository: OfferingOwnershipRepository;
+}
+
+interface QueryShape {
+  periodFrom?: string;
+  periodTo?: string;
+  page: number;
+  pageSize: number;
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+const getStringQueryParam = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return undefined;
+};
+
+const parsePositiveInt = (value: unknown): number | null => {
+  if (value === undefined) return null;
+  if (Array.isArray(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+};
+
+const parseQuery = (req: Request): QueryShape | null => {
+  const page = parsePositiveInt(req.query.page);
+  const pageSize = parsePositiveInt(req.query.pageSize);
+
+  if (req.query.page !== undefined && page === null) {
+    return null;
+  }
+
+  if (req.query.pageSize !== undefined && pageSize === null) {
+    return null;
+  }
+
+  const periodFrom = getStringQueryParam(req.query.periodFrom);
+  const periodTo = getStringQueryParam(req.query.periodTo);
+
+  if (periodFrom && periodTo && periodFrom > periodTo) {
+    return null;
+  }
+
+  return {
+    periodFrom,
+    periodTo,
+    page: page ?? DEFAULT_PAGE,
+    pageSize: Math.min(pageSize ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE),
+  };
+};
+
+const getUserId = (req: Request): string | undefined => {
+  const fromUser = (req as any).user?.id;
+  const fromAuth = (req as any).auth?.userId;
+  return fromUser ?? fromAuth;
+};
+
+export const createListRevenueReportsHandler = ({
+  revenueReportRepository,
+  offeringOwnershipRepository,
+}: Omit<CreateRevenueReportsRouteDeps, 'requireAuth'>): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const userId = getUserId(req);
+
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const offeringId = req.params.id;
+      const query = parseQuery(req);
+
+      if (!offeringId || !query) {
+        res.status(400).json({ error: 'Invalid request' });
+        return;
+      }
+
+      const ownsOffering = await offeringOwnershipRepository.isOwnedByUser(
+        offeringId,
+        userId
+      );
+
+      if (!ownsOffering) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+      }
+
+      const reports = await revenueReportRepository.listByOffering(offeringId);
+      const filteredReports = reports.filter((report) => {
+        if (query.periodFrom && report.period_id < query.periodFrom) {
+          return false;
+        }
+        if (query.periodTo && report.period_id > query.periodTo) {
+          return false;
+        }
+        return true;
+      });
+
+      const offset = (query.page - 1) * query.pageSize;
+      const paginatedReports = filteredReports.slice(offset, offset + query.pageSize);
+      const total = filteredReports.length;
+
+      res.status(200).json({
+        data: paginatedReports,
+        pagination: {
+          page: query.page,
+          pageSize: query.pageSize,
+          total,
+          totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+};
+
+export const createRevenueReportsRouter = ({
+  requireAuth,
+  revenueReportRepository,
+  offeringOwnershipRepository,
+}: CreateRevenueReportsRouteDeps): Router => {
+  const router = Router();
+
+  router.get(
+    '/api/offerings/:id/revenue-reports',
+    requireAuth,
+    createListRevenueReportsHandler({
+      revenueReportRepository,
+      offeringOwnershipRepository,
+    })
+  );
+
+  return router;
+};


### PR DESCRIPTION

## Overview
This PR implements the issuer-facing listing endpoint for revenue reports:

`GET /api/offerings/:id/revenue-reports`

The endpoint supports optional period range filtering and pagination, and enforces that the offering belongs to the authenticated issuer before returning data.

## Related Issue
Closes #29

## Changes

### ⚙️ API Route
- **[NEW]** `src/offerings/revenueReportsRoute.ts`
  - Added `createRevenueReportsRouter(...)` with:
    - `GET /api/offerings/:id/revenue-reports`
  - Added `createListRevenueReportsHandler(...)` that:
    - validates auth (`req.user.id` or `req.auth.userId`)
    - validates request params/query
    - verifies offering ownership via injected repository
    - fetches reports via `revenueReportRepository.listByOffering(offeringId)`
    - applies optional range filters: `periodFrom`, `periodTo`
    - applies pagination: `page`, `pageSize` (max `100`)
    - returns `200` with `{ data, pagination }`

### 🧪 Tests
- **[NEW]** `src/offerings/revenueReportsRoute.test.ts`
  - Added tests covering:
    - `401` for unauthenticated request
    - `403` when offering is not owned by issuer
    - `200` successful filtered + paginated response
    - `400` invalid pagination input
    - `400` invalid period range (`periodFrom > periodTo`)

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| `GET /api/offerings/:id/revenue-reports` route implemented | ✅ |
| Uses revenue report repository to list reports | ✅ |
| Verifies offering belongs to authenticated user | ✅ |
| Supports optional period range filtering | ✅ |
| Supports pagination | ✅ |
| Route tests added and passing | ✅ |

## How to Test

```bash
# 1. Run targeted tests for this PR
npx jest src/offerings/revenueReportsRoute.test.ts

# 2. (If route is mounted in your runtime wiring) test endpoint
curl -X GET "http://localhost:4000/api/offerings/offering-1/revenue-reports?page=1&pageSize=20" \
  -H "Authorization: Bearer <token>"

# 3. Test optional period range
curl -X GET "http://localhost:4000/api/offerings/offering-1/revenue-reports?periodFrom=2024-01&periodTo=2024-03&page=1&pageSize=10" \
  -H "Authorization: Bearer <token>"
```

## Screenshots

<img width="639" height="254" alt="image" src="https://github.com/user-attachments/assets/fc88636a-83a1-41d7-a881-1e28e51f3e8b" />
