### PR TITLE
feat(lib): add structured error codes and response format

### DIFF
--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,222 @@
+import {
+  AppError,
+  ErrorCode,
+  ErrorResponse,
+  Errors,
+  createError,
+  sendAppError,
+  throwError,
+} from './errors';
+
+// ─── ErrorCode ────────────────────────────────────────────────────────────────
+
+describe('ErrorCode', () => {
+  it('exposes all expected codes', () => {
+    expect(ErrorCode.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+    expect(ErrorCode.BAD_REQUEST).toBe('BAD_REQUEST');
+    expect(ErrorCode.UNAUTHORIZED).toBe('UNAUTHORIZED');
+    expect(ErrorCode.FORBIDDEN).toBe('FORBIDDEN');
+    expect(ErrorCode.NOT_FOUND).toBe('NOT_FOUND');
+    expect(ErrorCode.CONFLICT).toBe('CONFLICT');
+    expect(ErrorCode.INTERNAL_ERROR).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── AppError ─────────────────────────────────────────────────────────────────
+
+describe('AppError', () => {
+  describe('constructor', () => {
+    it('sets all properties', () => {
+      const err = new AppError(ErrorCode.NOT_FOUND, 'thing not found', 404);
+      expect(err.code).toBe(ErrorCode.NOT_FOUND);
+      expect(err.message).toBe('thing not found');
+      expect(err.statusCode).toBe(404);
+      expect(err.details).toBeUndefined();
+      expect(err.name).toBe('AppError');
+    });
+
+    it('stores optional details', () => {
+      const details = { field: 'amount', reason: 'must be positive' };
+      const err = new AppError(ErrorCode.VALIDATION_ERROR, 'invalid input', 400, details);
+      expect(err.details).toEqual(details);
+    });
+
+    it('is an instance of Error', () => {
+      const err = new AppError(ErrorCode.INTERNAL_ERROR, 'boom', 500);
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('passes instanceof AppError after transpilation', () => {
+      const err = new AppError(ErrorCode.FORBIDDEN, 'no access', 403);
+      expect(err).toBeInstanceOf(AppError);
+    });
+  });
+
+  describe('toResponse()', () => {
+    it('returns code and message without details when details is undefined', () => {
+      const err = new AppError(ErrorCode.UNAUTHORIZED, 'not logged in', 401);
+      const response: ErrorResponse = err.toResponse();
+      expect(response).toEqual({ code: 'UNAUTHORIZED', message: 'not logged in' });
+      expect(Object.hasOwn(response, 'details')).toBe(false);
+    });
+
+    it('includes details when present', () => {
+      const details = { ids: ['a', 'b'] };
+      const err = new AppError(ErrorCode.CONFLICT, 'duplicate', 409, details);
+      expect(err.toResponse()).toEqual({
+        code: 'CONFLICT',
+        message: 'duplicate',
+        details,
+      });
+    });
+
+    it('includes details even when details is null', () => {
+      const err = new AppError(ErrorCode.BAD_REQUEST, 'bad', 400, null);
+      expect(err.toResponse().details).toBeNull();
+    });
+  });
+});
+
+// ─── createError ──────────────────────────────────────────────────────────────
+
+describe('createError', () => {
+  it('returns an AppError with the given properties', () => {
+    const err = createError(ErrorCode.NOT_FOUND, 'resource missing', 404);
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.code).toBe(ErrorCode.NOT_FOUND);
+    expect(err.message).toBe('resource missing');
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('forwards details', () => {
+    const details = { resource: 'offering' };
+    const err = createError(ErrorCode.NOT_FOUND, 'not found', 404, details);
+    expect(err.details).toEqual(details);
+  });
+});
+
+// ─── Errors convenience factories ─────────────────────────────────────────────
+
+describe('Errors', () => {
+  describe('validationError', () => {
+    it('creates a 400 VALIDATION_ERROR', () => {
+      const err = Errors.validationError('limit must be > 0', { field: 'limit' });
+      expect(err.statusCode).toBe(400);
+      expect(err.code).toBe(ErrorCode.VALIDATION_ERROR);
+      expect(err.message).toBe('limit must be > 0');
+      expect(err.details).toEqual({ field: 'limit' });
+    });
+  });
+
+  describe('badRequest', () => {
+    it('creates a 400 BAD_REQUEST', () => {
+      const err = Errors.badRequest('malformed body');
+      expect(err.statusCode).toBe(400);
+      expect(err.code).toBe(ErrorCode.BAD_REQUEST);
+    });
+  });
+
+  describe('unauthorized', () => {
+    it('uses default message', () => {
+      const err = Errors.unauthorized();
+      expect(err.statusCode).toBe(401);
+      expect(err.code).toBe(ErrorCode.UNAUTHORIZED);
+      expect(err.message).toBe('Unauthorized');
+    });
+
+    it('accepts a custom message', () => {
+      const err = Errors.unauthorized('Token expired');
+      expect(err.message).toBe('Token expired');
+    });
+  });
+
+  describe('forbidden', () => {
+    it('uses default message', () => {
+      const err = Errors.forbidden();
+      expect(err.statusCode).toBe(403);
+      expect(err.code).toBe(ErrorCode.FORBIDDEN);
+      expect(err.message).toBe('Forbidden');
+    });
+
+    it('accepts a custom message', () => {
+      const err = Errors.forbidden('investor role required');
+      expect(err.message).toBe('investor role required');
+    });
+  });
+
+  describe('notFound', () => {
+    it('creates a 404 NOT_FOUND', () => {
+      const err = Errors.notFound('Offering not found');
+      expect(err.statusCode).toBe(404);
+      expect(err.code).toBe(ErrorCode.NOT_FOUND);
+      expect(err.message).toBe('Offering not found');
+    });
+  });
+
+  describe('conflict', () => {
+    it('creates a 409 CONFLICT', () => {
+      const err = Errors.conflict('investor already exists');
+      expect(err.statusCode).toBe(409);
+      expect(err.code).toBe(ErrorCode.CONFLICT);
+    });
+  });
+
+  describe('internal', () => {
+    it('uses default message', () => {
+      const err = Errors.internal();
+      expect(err.statusCode).toBe(500);
+      expect(err.code).toBe(ErrorCode.INTERNAL_ERROR);
+      expect(err.message).toBe('Internal server error');
+    });
+
+    it('accepts a custom message and details', () => {
+      const err = Errors.internal('db unreachable', { host: 'localhost' });
+      expect(err.message).toBe('db unreachable');
+      expect(err.details).toEqual({ host: 'localhost' });
+    });
+  });
+});
+
+// ─── throwError ───────────────────────────────────────────────────────────────
+
+describe('throwError', () => {
+  it('throws an AppError with the correct shape', () => {
+    expect(() =>
+      throwError(ErrorCode.NOT_FOUND, 'missing resource', 404)
+    ).toThrow(AppError);
+  });
+
+  it('thrown error has the right code and statusCode', () => {
+    try {
+      throwError(ErrorCode.FORBIDDEN, 'no access', 403, { reason: 'role' });
+      fail('expected throwError to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppError);
+      const appErr = err as AppError;
+      expect(appErr.code).toBe(ErrorCode.FORBIDDEN);
+      expect(appErr.statusCode).toBe(403);
+      expect(appErr.details).toEqual({ reason: 'role' });
+    }
+  });
+});
+
+// ─── sendAppError ─────────────────────────────────────────────────────────────
+
+describe('sendAppError', () => {
+  it('calls next() with the AppError instance', () => {
+    const next = jest.fn();
+    const err = Errors.unauthorized();
+    sendAppError(next, err);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(err);
+  });
+
+  it('does not modify the error before forwarding', () => {
+    const next = jest.fn();
+    const err = Errors.notFound('Offering 42 not found');
+    sendAppError(next, err);
+    const forwarded = next.mock.calls[0][0] as AppError;
+    expect(forwarded.message).toBe('Offering 42 not found');
+    expect(forwarded.statusCode).toBe(404);
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,159 @@
+import { NextFunction } from 'express';
+
+// ─── Error codes ──────────────────────────────────────────────────────────────
+
+/** Exhaustive set of machine-readable error codes used across the API. */
+export const ErrorCode = {
+  /** One or more input fields failed validation (HTTP 400). */
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  /** Generic malformed or unacceptable request (HTTP 400). */
+  BAD_REQUEST: 'BAD_REQUEST',
+  /** Authentication is required or the supplied credentials are invalid (HTTP 401). */
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  /** Authenticated but not permitted to access the resource (HTTP 403). */
+  FORBIDDEN: 'FORBIDDEN',
+  /** The requested resource does not exist (HTTP 404). */
+  NOT_FOUND: 'NOT_FOUND',
+  /** Resource-state conflict, e.g. duplicate entry (HTTP 409). */
+  CONFLICT: 'CONFLICT',
+  /** Unexpected server-side failure (HTTP 500). */
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+// ─── Wire shape ───────────────────────────────────────────────────────────────
+
+/**
+ * Standard JSON body returned to the client for every error response.
+ *
+ * ```json
+ * { "code": "VALIDATION_ERROR", "message": "limit must be a positive integer", "details": { "field": "limit" } }
+ * ```
+ */
+export interface ErrorResponse {
+  code: ErrorCode;
+  message: string;
+  details?: unknown;
+}
+
+// ─── AppError ─────────────────────────────────────────────────────────────────
+
+/**
+ * Structured application error.  Throw this (or pass it to `next()`) anywhere
+ * in the request lifecycle; the global error handler will serialise it using
+ * {@link ErrorResponse} and set the correct HTTP status code.
+ */
+export class AppError extends Error {
+  readonly code: ErrorCode;
+  readonly statusCode: number;
+  readonly details?: unknown;
+
+  constructor(
+    code: ErrorCode,
+    message: string,
+    statusCode: number,
+    details?: unknown,
+  ) {
+    super(message);
+    this.name = 'AppError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+    // Restore prototype chain so `instanceof AppError` works after transpilation.
+    Object.setPrototypeOf(this, AppError.prototype);
+  }
+
+  /** Serialise to the standard {@link ErrorResponse} wire shape. */
+  toResponse(): ErrorResponse {
+    const body: ErrorResponse = { code: this.code, message: this.message };
+    if (this.details !== undefined) {
+      body.details = this.details;
+    }
+    return body;
+  }
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build an {@link AppError} with an explicit status code.
+ * Prefer the {@link Errors} convenience object for common cases.
+ */
+export function createError(
+  code: ErrorCode,
+  message: string,
+  statusCode: number,
+  details?: unknown,
+): AppError {
+  return new AppError(code, message, statusCode, details);
+}
+
+// ─── Convenience factories ────────────────────────────────────────────────────
+
+/**
+ * Pre-built factories for the most common error scenarios.
+ *
+ * @example
+ *   throw Errors.notFound('Offering not found');
+ *   next(Errors.unauthorized());
+ */
+export const Errors = {
+  /** Input validation failed – HTTP 400. */
+  validationError: (message: string, details?: unknown): AppError =>
+    createError(ErrorCode.VALIDATION_ERROR, message, 400, details),
+
+  /** Generic bad request – HTTP 400. */
+  badRequest: (message: string, details?: unknown): AppError =>
+    createError(ErrorCode.BAD_REQUEST, message, 400, details),
+
+  /** Authentication required or credentials invalid – HTTP 401. */
+  unauthorized: (message = 'Unauthorized'): AppError =>
+    createError(ErrorCode.UNAUTHORIZED, message, 401),
+
+  /** Authenticated but not permitted – HTTP 403. */
+  forbidden: (message = 'Forbidden'): AppError =>
+    createError(ErrorCode.FORBIDDEN, message, 403),
+
+  /** Resource not found – HTTP 404. */
+  notFound: (message: string): AppError =>
+    createError(ErrorCode.NOT_FOUND, message, 404),
+
+  /** Resource-state conflict – HTTP 409. */
+  conflict: (message: string): AppError =>
+    createError(ErrorCode.CONFLICT, message, 409),
+
+  /** Unexpected server error – HTTP 500. */
+  internal: (message = 'Internal server error', details?: unknown): AppError =>
+    createError(ErrorCode.INTERNAL_ERROR, message, 500, details),
+};
+
+// ─── Route helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Throw an {@link AppError} immediately.  Use inside `try/catch` blocks or
+ * async route handlers where Express will catch the thrown error.
+ *
+ * @example
+ *   if (!offering) throwError(ErrorCode.NOT_FOUND, 'Offering not found', 404);
+ */
+export function throwError(
+  code: ErrorCode,
+  message: string,
+  statusCode: number,
+  details?: unknown,
+): never {
+  throw createError(code, message, statusCode, details);
+}
+
+/**
+ * Forward a structured error to Express's `next()` so the global error
+ * handler returns the standard JSON response.  Use when you need to exit
+ * a middleware without throwing (e.g. inside a callback-style flow).
+ *
+ * @example
+ *   if (!user) return sendAppError(next, Errors.unauthorized());
+ */
+export function sendAppError(next: NextFunction, error: AppError): void {
+  next(error);
+}

--- a/src/middleware/errorHandler.test.ts
+++ b/src/middleware/errorHandler.test.ts
@@ -1,0 +1,128 @@
+import { Request, Response, NextFunction } from 'express';
+import { errorHandler } from './errorHandler';
+import { AppError, ErrorCode, Errors } from '../lib/errors';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMockRes(): jest.Mocked<Response> {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as jest.Mocked<Response>;
+}
+
+const req = {} as Request;
+const next = jest.fn() as unknown as NextFunction;
+
+// ─── errorHandler ─────────────────────────────────────────────────────────────
+
+describe('errorHandler', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── AppError handling ──────────────────────────────────────────────────────
+
+  it('sends the AppError status code', () => {
+    const res = makeMockRes();
+    errorHandler(Errors.notFound('Offering 99 not found'), req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('sends the structured error body for AppError', () => {
+    const res = makeMockRes();
+    errorHandler(Errors.unauthorized('Token expired'), req, res, next);
+    expect(res.json).toHaveBeenCalledWith({
+      code: ErrorCode.UNAUTHORIZED,
+      message: 'Token expired',
+    });
+  });
+
+  it('includes details in the body when AppError has them', () => {
+    const res = makeMockRes();
+    const err = Errors.validationError('bad input', { field: 'amount' });
+    errorHandler(err, req, res, next);
+    expect(res.json).toHaveBeenCalledWith({
+      code: ErrorCode.VALIDATION_ERROR,
+      message: 'bad input',
+      details: { field: 'amount' },
+    });
+  });
+
+  it('handles all AppError status codes correctly', () => {
+    const cases: [AppError, number][] = [
+      [Errors.badRequest('x'), 400],
+      [Errors.unauthorized(), 401],
+      [Errors.forbidden(), 403],
+      [Errors.notFound('x'), 404],
+      [Errors.conflict('x'), 409],
+      [Errors.internal(), 500],
+    ];
+
+    for (const [err, expectedStatus] of cases) {
+      const res = makeMockRes();
+      errorHandler(err, req, res, next);
+      expect(res.status).toHaveBeenCalledWith(expectedStatus);
+    }
+  });
+
+  it('does not call next() for AppError', () => {
+    const res = makeMockRes();
+    errorHandler(Errors.forbidden(), req, res, next);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // ── Unknown error handling ─────────────────────────────────────────────────
+
+  it('returns 500 for a plain Error', () => {
+    const res = makeMockRes();
+    errorHandler(new Error('something exploded'), req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      code: ErrorCode.INTERNAL_ERROR,
+      message: 'Internal server error',
+    });
+  });
+
+  it('returns 500 for a thrown string', () => {
+    const res = makeMockRes();
+    errorHandler('oops', req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      code: ErrorCode.INTERNAL_ERROR,
+      message: 'Internal server error',
+    });
+  });
+
+  it('returns 500 for null', () => {
+    const res = makeMockRes();
+    errorHandler(null, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('does not leak error internals for unknown errors', () => {
+    const res = makeMockRes();
+    errorHandler(new Error('secret db password in stack'), req, res, next);
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.message).toBe('Internal server error');
+    expect(body.details).toBeUndefined();
+  });
+
+  it('does not call next() for unknown errors', () => {
+    const res = makeMockRes();
+    errorHandler(new Error('random'), req, res, next);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // ── AppError created via createError ──────────────────────────────────────
+
+  it('handles AppError created via createError factory', () => {
+    const res = makeMockRes();
+    const err = new AppError(ErrorCode.CONFLICT, 'already exists', 409, { id: 'abc' });
+    errorHandler(err, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 'CONFLICT',
+      message: 'already exists',
+      details: { id: 'abc' },
+    });
+  });
+});

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from 'express';
+import { AppError, ErrorCode, ErrorResponse } from '../lib/errors';
+
+/**
+ * Express 4-argument global error handler.
+ *
+ * Mount **after** all routes so unhandled errors bubble up here:
+ * ```ts
+ * app.use(errorHandler);
+ * ```
+ *
+ * - {@link AppError} instances are serialised via {@link AppError.toResponse}
+ *   and the correct HTTP status code is used.
+ * - Any other thrown value is treated as an unexpected server error (500),
+ *   logged, and returned as `{ code: 'INTERNAL_ERROR', message: 'Internal server error' }`.
+ */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction,
+): void {
+  if (err instanceof AppError) {
+    res.status(err.statusCode).json(err.toResponse());
+    return;
+  }
+
+  // Unknown / unexpected error — log and return an opaque 500.
+  console.error('[errorHandler] Unhandled error:', err);
+
+  const body: ErrorResponse = {
+    code: ErrorCode.INTERNAL_ERROR,
+    message: 'Internal server error',
+  };
+  res.status(500).json(body);
+}


### PR DESCRIPTION
- src/lib/errors.ts • ErrorCode const object (VALIDATION_ERROR, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND, CONFLICT, INTERNAL_ERROR) • ErrorResponse interface { code, message, details? } — canonical wire shape • AppError extends Error with code, statusCode, details and toResponse() (prototype chain restored for reliable instanceof after transpilation) • createError(code, message, statusCode, details?) factory • Errors.* convenience builders (validationError, badRequest, unauthorized, forbidden, notFound, conflict, internal) with sensible defaults • throwError() — throws AppError; for use in async handlers / try blocks • sendAppError(next, err) — forwards AppError to Express next()

- src/middleware/errorHandler.ts • 4-argument Express error handler • AppError → toResponse() + correct HTTP status • Unknown errors → opaque 500, logged to console.error

- Tests: 100 % of the exported surface covered (AppError, all factories, throwError, sendAppError, errorHandler with AppError / plain Error / string / null inputs)
closes #63 