### PR TITLE
add webhook payload and delivery service

### DIFF
--- a/src/db/migrations/003_create_webhook_endpoints.sql
+++ b/src/db/migrations/003_create_webhook_endpoints.sql
@@ -1,0 +1,39 @@
+-- Migration: Create webhook_endpoints table
+-- Description: Stores webhook endpoint registrations per owner with event subscriptions
+
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id   UUID        NOT NULL,
+  url        TEXT        NOT NULL,
+  secret     TEXT        NOT NULL,
+  events     TEXT[]      NOT NULL DEFAULT '{}',
+  active     BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_owner_id
+  ON webhook_endpoints (owner_id);
+
+-- Partial index for active-only queries
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_active
+  ON webhook_endpoints (active)
+  WHERE active = TRUE;
+
+-- GIN index to efficiently query endpoints subscribed to a given event
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_events
+  ON webhook_endpoints USING GIN (events);
+
+-- Reuse update_updated_at_column() if already defined, otherwise create it
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE TRIGGER update_webhook_endpoints_updated_at
+    BEFORE UPDATE ON webhook_endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/src/db/repositories/webhookEndpointRepository.ts
+++ b/src/db/repositories/webhookEndpointRepository.ts
@@ -1,0 +1,86 @@
+import { Pool, QueryResult } from 'pg';
+
+export interface WebhookEndpoint {
+  id: string;
+  owner_id: string;
+  url: string;
+  secret: string;
+  events: string[];
+  active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreateWebhookEndpointInput {
+  owner_id: string;
+  url: string;
+  secret: string;
+  events: string[];
+}
+
+export class WebhookEndpointRepository {
+  constructor(private readonly db: Pool) {}
+
+  async create(input: CreateWebhookEndpointInput): Promise<WebhookEndpoint> {
+    const result: QueryResult<WebhookEndpoint> = await this.db.query(
+      `INSERT INTO webhook_endpoints (owner_id, url, secret, events)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [input.owner_id, input.url, input.secret, input.events]
+    );
+    return this.map(result.rows[0]);
+  }
+
+  async findById(id: string): Promise<WebhookEndpoint | null> {
+    const result: QueryResult<WebhookEndpoint> = await this.db.query(
+      `SELECT * FROM webhook_endpoints WHERE id = $1`,
+      [id]
+    );
+    return result.rows[0] ? this.map(result.rows[0]) : null;
+  }
+
+  async listByOwner(ownerId: string): Promise<WebhookEndpoint[]> {
+    const result: QueryResult<WebhookEndpoint> = await this.db.query(
+      `SELECT * FROM webhook_endpoints WHERE owner_id = $1 ORDER BY created_at DESC`,
+      [ownerId]
+    );
+    return result.rows.map((row) => this.map(row));
+  }
+
+  async listActiveByEvent(event: string): Promise<WebhookEndpoint[]> {
+    const result: QueryResult<WebhookEndpoint> = await this.db.query(
+      `SELECT * FROM webhook_endpoints
+       WHERE active = TRUE AND $1 = ANY(events)
+       ORDER BY created_at ASC`,
+      [event]
+    );
+    return result.rows.map((row) => this.map(row));
+  }
+
+  async deactivate(id: string): Promise<void> {
+    await this.db.query(
+      `UPDATE webhook_endpoints SET active = FALSE WHERE id = $1`,
+      [id]
+    );
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.query(
+      `DELETE FROM webhook_endpoints WHERE id = $1`,
+      [id]
+    );
+  }
+
+  private map(row: WebhookEndpoint): WebhookEndpoint {
+    return {
+      id: row.id,
+      owner_id: row.owner_id,
+      url: row.url,
+      secret: row.secret,
+      events: row.events,
+      active: row.active,
+      created_at: new Date(row.created_at),
+      updated_at: new Date(row.updated_at),
+    };
+  }
+}

--- a/src/services/webhookService.test.ts
+++ b/src/services/webhookService.test.ts
@@ -1,0 +1,276 @@
+import { createHmac } from 'crypto';
+import {
+  WebhookService,
+  WebhookEventType,
+  WebhookPayload,
+  IWebhookEndpointRepository,
+  WebhookEndpointRecord,
+  signPayload,
+} from './webhookService';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+function makeEndpoint(overrides: Partial<WebhookEndpointRecord> = {}): WebhookEndpointRecord {
+  return { id: 'ep-1', url: 'https://example.com/hook', secret: 'shhh', ...overrides };
+}
+
+function makePayload<T>(data: T, event: WebhookEventType = WebhookEventType.OFFERING_CREATED): WebhookPayload<T> {
+  return { id: 'test-id', event, payload: data, timestamp: '2024-01-01T00:00:00.000Z' };
+}
+
+function makeRepo(endpoints: WebhookEndpointRecord[] = []): jest.Mocked<IWebhookEndpointRepository> {
+  return { listActiveByEvent: jest.fn().mockResolvedValue(endpoints) };
+}
+
+function makeOkResponse(status = 200): Response {
+  return { ok: true, status } as Response;
+}
+
+function makeErrorResponse(status: number): Response {
+  return { ok: false, status } as Response;
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── signPayload ─────────────────────────────────────────────────────────────
+
+describe('signPayload', () => {
+  it('returns sha256=<hex> using HMAC-SHA256', () => {
+    const secret = 'mysecret';
+    const body = '{"hello":"world"}';
+    const expected = 'sha256=' + createHmac('sha256', secret).update(body).digest('hex');
+    expect(signPayload(secret, body)).toBe(expected);
+  });
+
+  it('produces different signatures for different secrets', () => {
+    const body = 'same body';
+    expect(signPayload('secret-a', body)).not.toBe(signPayload('secret-b', body));
+  });
+
+  it('produces different signatures for different bodies', () => {
+    const secret = 'same-secret';
+    expect(signPayload(secret, 'body-a')).not.toBe(signPayload(secret, 'body-b'));
+  });
+});
+
+// ─── WebhookService.deliver ──────────────────────────────────────────────────
+
+describe('WebhookService.deliver', () => {
+  const endpoint = makeEndpoint();
+  // Use initialDelayMs: 0 to skip actual wait in tests
+  const svc = new WebhookService(makeRepo(), { initialDelayMs: 0, maxRetries: 3, timeoutMs: 5000 });
+
+  it('returns success on 200 response', async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse(200));
+    const payload = makePayload({ id: 'offer-1' });
+    const result = await svc.deliver(endpoint, payload);
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.attempts).toBe(1);
+    expect(result.endpointId).toBe(endpoint.id);
+    expect(result.url).toBe(endpoint.url);
+  });
+
+  it('sends correct headers including signature and event type', async () => {
+    mockFetch.mockResolvedValueOnce(makeOkResponse());
+    const payload = makePayload({ id: 'offer-1' }, WebhookEventType.REVENUE_REPORTED);
+    const body = JSON.stringify(payload);
+
+    await svc.deliver(endpoint, payload);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      endpoint.url,
+      expect.objectContaining({
+        method: 'POST',
+        body,
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Revora-Signature': signPayload(endpoint.secret, body),
+          'X-Revora-Event': WebhookEventType.REVENUE_REPORTED,
+        }),
+      })
+    );
+  });
+
+  it('retries on 500 and succeeds on second attempt', async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeErrorResponse(500))
+      .mockResolvedValueOnce(makeOkResponse(200));
+    const result = await svc.deliver(endpoint, makePayload({}));
+
+    expect(result.success).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on 429 and succeeds on second attempt', async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeErrorResponse(429))
+      .mockResolvedValueOnce(makeOkResponse(200));
+    const result = await svc.deliver(endpoint, makePayload({}));
+
+    expect(result.success).toBe(true);
+    expect(result.attempts).toBe(2);
+  });
+
+  it('does NOT retry on 400 (non-retryable 4xx)', async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(400));
+    const result = await svc.deliver(endpoint, makePayload({}));
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(result.statusCode).toBe(400);
+    expect(result.error).toMatch(/Non-retryable HTTP 400/);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT retry on 404 (non-retryable 4xx)', async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(404));
+    const result = await svc.deliver(endpoint, makePayload({}));
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('exhausts maxRetries on persistent 500 errors', async () => {
+    mockFetch.mockResolvedValue(makeErrorResponse(500));
+    const result = await svc.deliver(endpoint, makePayload({}));
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.statusCode).toBe(500);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on network error and exhausts retries', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await svc.deliver(endpoint, makePayload({}));
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.error).toBe('ECONNREFUSED');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects maxRetries option', async () => {
+    const svc1 = new WebhookService(makeRepo(), { maxRetries: 1, initialDelayMs: 0 });
+    mockFetch.mockResolvedValue(makeErrorResponse(503));
+    const result = await svc1.deliver(endpoint, makePayload({}));
+
+    expect(result.attempts).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── WebhookService.emit ─────────────────────────────────────────────────────
+
+describe('WebhookService.emit', () => {
+  it('dispatches payload to each subscribed endpoint (fire-and-forget)', async () => {
+    const ep1 = makeEndpoint({ id: 'ep-1', url: 'https://a.example.com/hook' });
+    const ep2 = makeEndpoint({ id: 'ep-2', url: 'https://b.example.com/hook' });
+    const repo = makeRepo([ep1, ep2]);
+    const svc = new WebhookService(repo, { initialDelayMs: 0 });
+
+    mockFetch.mockResolvedValue(makeOkResponse());
+
+    await svc.emit(WebhookEventType.OFFERING_CREATED, { id: 'offer-1' });
+    await flushPromises();
+
+    expect(repo.listActiveByEvent).toHaveBeenCalledWith(WebhookEventType.OFFERING_CREATED);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith(ep1.url, expect.anything());
+    expect(mockFetch).toHaveBeenCalledWith(ep2.url, expect.anything());
+  });
+
+  it('sends same payload id to all endpoints', async () => {
+    const ep1 = makeEndpoint({ id: 'ep-1', url: 'https://a.example.com/hook' });
+    const ep2 = makeEndpoint({ id: 'ep-2', url: 'https://b.example.com/hook' });
+    const repo = makeRepo([ep1, ep2]);
+    const svc = new WebhookService(repo, { initialDelayMs: 0 });
+
+    mockFetch.mockResolvedValue(makeOkResponse());
+
+    await svc.emit(WebhookEventType.PAYOUT_COMPLETED, { amount: '100' });
+    await flushPromises();
+
+    const bodies = mockFetch.mock.calls.map((call) => JSON.parse(call[1]!.body as string));
+    expect(bodies[0].id).toBe(bodies[1].id);
+    expect(bodies[0].event).toBe(WebhookEventType.PAYOUT_COMPLETED);
+  });
+
+  it('does nothing when no endpoints are subscribed', async () => {
+    const repo = makeRepo([]);
+    const svc = new WebhookService(repo, { initialDelayMs: 0 });
+
+    await svc.emit(WebhookEventType.OFFERING_CREATED, {});
+    await flushPromises();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('logs error and returns when repo throws', async () => {
+    const repo: jest.Mocked<IWebhookEndpointRepository> = {
+      listActiveByEvent: jest.fn().mockRejectedValue(new Error('DB down')),
+    };
+    const svc = new WebhookService(repo, { initialDelayMs: 0 });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(svc.emit(WebhookEventType.REVENUE_REPORTED, {})).resolves.toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[WebhookService]'),
+      WebhookEventType.REVENUE_REPORTED,
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('continues other deliveries if one endpoint fetch rejects', async () => {
+    const ep1 = makeEndpoint({ id: 'ep-1', url: 'https://a.example.com/hook' });
+    const ep2 = makeEndpoint({ id: 'ep-2', url: 'https://b.example.com/hook' });
+    const repo = makeRepo([ep1, ep2]);
+    const svc = new WebhookService(repo, { initialDelayMs: 0 });
+
+    // ep1 fails, ep2 succeeds
+    mockFetch
+      .mockRejectedValueOnce(new Error('network fail'))
+      .mockResolvedValueOnce(makeOkResponse());
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await svc.emit(WebhookEventType.PAYOUT_FAILED, { reason: 'test' });
+    await flushPromises();
+
+    // Both endpoints were still attempted (maxRetries=3 on ep1, then ep2)
+    expect(mockFetch).toHaveBeenCalledWith(ep1.url, expect.anything());
+    expect(mockFetch).toHaveBeenCalledWith(ep2.url, expect.anything());
+
+    jest.restoreAllMocks();
+  });
+});
+
+// ─── WebhookEventType constants ──────────────────────────────────────────────
+
+describe('WebhookEventType', () => {
+  it('exposes all expected event type strings', () => {
+    expect(WebhookEventType.OFFERING_CREATED).toBe('offering.created');
+    expect(WebhookEventType.OFFERING_UPDATED).toBe('offering.updated');
+    expect(WebhookEventType.REVENUE_REPORTED).toBe('revenue.reported');
+    expect(WebhookEventType.DISTRIBUTION_STARTED).toBe('distribution.started');
+    expect(WebhookEventType.DISTRIBUTION_COMPLETED).toBe('distribution.completed');
+    expect(WebhookEventType.PAYOUT_COMPLETED).toBe('payout.completed');
+    expect(WebhookEventType.PAYOUT_FAILED).toBe('payout.failed');
+  });
+});

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -1,0 +1,187 @@
+import { createHmac, randomUUID } from 'crypto';
+
+export const WebhookEventType = {
+  OFFERING_CREATED: 'offering.created',
+  OFFERING_UPDATED: 'offering.updated',
+  REVENUE_REPORTED: 'revenue.reported',
+  DISTRIBUTION_STARTED: 'distribution.started',
+  DISTRIBUTION_COMPLETED: 'distribution.completed',
+  PAYOUT_COMPLETED: 'payout.completed',
+  PAYOUT_FAILED: 'payout.failed',
+} as const;
+
+export type WebhookEventType = (typeof WebhookEventType)[keyof typeof WebhookEventType];
+
+export interface WebhookPayload<T = unknown> {
+  id: string;
+  event: WebhookEventType;
+  payload: T;
+  timestamp: string;
+}
+
+export interface DeliveryResult {
+  endpointId: string;
+  url: string;
+  success: boolean;
+  attempts: number;
+  statusCode?: number;
+  error?: string;
+}
+
+export interface WebhookEndpointRecord {
+  id: string;
+  url: string;
+  secret: string;
+}
+
+export interface IWebhookEndpointRepository {
+  listActiveByEvent(event: string): Promise<WebhookEndpointRecord[]>;
+}
+
+export interface WebhookServiceOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  timeoutMs?: number;
+}
+
+/**
+ * Signs a webhook payload body with HMAC-SHA256.
+ * Returns a string of the form `sha256=<hex>`.
+ */
+export function signPayload(secret: string, body: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex');
+}
+
+/**
+ * Fire-and-forget webhook delivery service with retry logic.
+ *
+ * Callers invoke `emit(event, data)`. The service fetches all active endpoints
+ * subscribed to that event and attempts delivery to each asynchronously.
+ *
+ * Delivery is retried up to `maxRetries` times using exponential backoff:
+ *   attempt 1 – no wait
+ *   attempt 2 – initialDelayMs
+ *   attempt 3 – initialDelayMs * 2
+ *
+ * 4xx responses (except 429) are not retried; 5xx and network errors are.
+ */
+export class WebhookService {
+  private readonly maxRetries: number;
+  private readonly initialDelayMs: number;
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly endpointRepo: IWebhookEndpointRepository,
+    options: WebhookServiceOptions = {}
+  ) {
+    this.maxRetries = options.maxRetries ?? 3;
+    this.initialDelayMs = options.initialDelayMs ?? 1000;
+    this.timeoutMs = options.timeoutMs ?? 10000;
+  }
+
+  /**
+   * Emits a webhook event to all subscribed endpoints (fire-and-forget).
+   */
+  async emit<T>(event: WebhookEventType, data: T): Promise<void> {
+    let endpoints: WebhookEndpointRecord[];
+    try {
+      endpoints = await this.endpointRepo.listActiveByEvent(event);
+    } catch (err) {
+      console.error('[WebhookService] Failed to fetch endpoints for event:', event, err);
+      return;
+    }
+
+    const payload: WebhookPayload<T> = {
+      id: randomUUID(),
+      event,
+      payload: data,
+      timestamp: new Date().toISOString(),
+    };
+
+    for (const endpoint of endpoints) {
+      void this.deliver(endpoint, payload).catch((err) => {
+        console.error('[WebhookService] Delivery error for endpoint', endpoint.id, err);
+      });
+    }
+  }
+
+  /**
+   * Delivers a webhook payload to a single endpoint with retry logic.
+   */
+  async deliver<T>(
+    endpoint: WebhookEndpointRecord,
+    payload: WebhookPayload<T>
+  ): Promise<DeliveryResult> {
+    const body = JSON.stringify(payload);
+    let attempts = 0;
+    let lastStatusCode: number | undefined;
+    let lastError: string | undefined;
+
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      if (attempt > 1) {
+        const delay = this.initialDelayMs * Math.pow(2, attempt - 2);
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      }
+
+      attempts = attempt;
+
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+        let response: Response;
+        try {
+          response = await fetch(endpoint.url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Revora-Signature': signPayload(endpoint.secret, body),
+              'X-Revora-Event': payload.event,
+            },
+            body,
+            signal: controller.signal,
+          });
+        } finally {
+          clearTimeout(timeoutId);
+        }
+
+        lastStatusCode = response.status;
+
+        if (response.ok) {
+          return {
+            endpointId: endpoint.id,
+            url: endpoint.url,
+            success: true,
+            attempts,
+            statusCode: response.status,
+          };
+        }
+
+        // 4xx (except 429 Too Many Requests) are non-retryable
+        if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+          return {
+            endpointId: endpoint.id,
+            url: endpoint.url,
+            success: false,
+            attempts,
+            statusCode: response.status,
+            error: `Non-retryable HTTP ${response.status}`,
+          };
+        }
+
+        lastError = `HTTP ${response.status}`;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    return {
+      endpointId: endpoint.id,
+      url: endpoint.url,
+      success: false,
+      attempts,
+      statusCode: lastStatusCode,
+      error: lastError ?? 'Max retries exceeded',
+    };
+  }
+}


### PR DESCRIPTION




src/db/migrations/003_create_webhook_endpoints.sql

webhook_endpoints table with owner_id, url, secret, events TEXT[], active BOOLEAN
GIN index on events for efficient $1 = ANY(events) queries
Partial index on active = TRUE
src/db/repositories/webhookEndpointRepository.ts

WebhookEndpointRepository with: create, findById, listByOwner, listActiveByEvent, deactivate, delete
listActiveByEvent uses $1 = ANY(events) with the GIN index
src/services/webhookService.ts

WebhookEventType — 7 event constants (offering.created, revenue.reported, payout.completed, etc.)
signPayload(secret, body) — HMAC-SHA256, returns sha256=<hex>
WebhookService.emit(event, data) — fetches subscribed endpoints, fires deliver() for each (fire-and-forget)
WebhookService.deliver(endpoint, payload) — retries up to maxRetries (default 3) with exponential backoff; aborts immediately on 4xx except 429
src/services/webhookService.test.ts

signPayload — signature correctness, secret/body isolation
deliver — success, correct headers, retry on 500/429, no-retry on 400/404, exhausted retries, network error, maxRetries option
emit — dispatches to multiple endpoints, same payload id, no endpoints, repo error, delivery failure doesn't block other endpoints

closes #48 