### PR TITLE
feat(auth): add investor registration API

### DIFF
--- a/src/auth/register/registerHandler.test.ts
+++ b/src/auth/register/registerHandler.test.ts
@@ -1,0 +1,154 @@
+import assert from 'assert';
+import { createRegisterHandler } from './registerHandler';
+import { RegisterService, DuplicateEmailError } from './registerService';
+import { RegisteredUser } from './types';
+
+// ─── Mock RegisterService ─────────────────────────────────────────────────────
+
+class MockRegisterService {
+  result: RegisteredUser | null = null;
+  shouldThrow: unknown = null;
+
+  async register(_email: string, _password: string): Promise<RegisteredUser> {
+    if (this.shouldThrow) throw this.shouldThrow;
+    return this.result!;
+  }
+}
+
+// ─── Request / Response helpers ───────────────────────────────────────────────
+
+function makeReq(body: unknown = {}) {
+  return { body } as any;
+}
+
+function makeRes() {
+  let statusCode = 200;
+  let jsonData: unknown = null;
+  return {
+    status(code: number) { statusCode = code; return this; },
+    json(obj: unknown) { jsonData = obj; return this; },
+    _get() { return { statusCode, jsonData }; },
+  } as any;
+}
+
+function makeUser(overrides: Partial<RegisteredUser> = {}): RegisteredUser {
+  return {
+    id: 'user-1',
+    email: 'investor@example.com',
+    role: 'investor',
+    created_at: new Date('2024-01-01'),
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+(async function run() {
+  // ── 201 on success ─────────────────────────────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    svc.result = makeUser();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 'investor@example.com', password: 'secret123' }), res, (e: unknown) => { throw e; });
+    const { statusCode, jsonData } = res._get();
+    assert.strictEqual(statusCode, 201, `expected 201 got ${statusCode}`);
+    assert.deepStrictEqual((jsonData as any).user, { id: 'user-1', email: 'investor@example.com', role: 'investor' });
+  }
+
+  // ── name is accepted (and silently ignored) ────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    svc.result = makeUser({ email: 'alice@example.com' });
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 'alice@example.com', password: 'password1', name: 'Alice' }), res, (e: unknown) => { throw e; });
+    assert.strictEqual(res._get().statusCode, 201);
+  }
+
+  // ── 400 when email is missing ──────────────────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ password: 'password1' }), res, (e: unknown) => { throw e; });
+    const { statusCode, jsonData } = res._get();
+    assert.strictEqual(statusCode, 400);
+    assert.strictEqual((jsonData as any).error, 'Bad Request');
+  }
+
+  // ── 400 when password is missing ──────────────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 'investor@example.com' }), res, (e: unknown) => { throw e; });
+    assert.strictEqual(res._get().statusCode, 400);
+  }
+
+  // ── 400 when body is entirely absent ──────────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq(undefined), res, (e: unknown) => { throw e; });
+    assert.strictEqual(res._get().statusCode, 400);
+  }
+
+  // ── 400 when email is not a string ────────────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 123, password: 'password1' }), res, (e: unknown) => { throw e; });
+    assert.strictEqual(res._get().statusCode, 400);
+  }
+
+  // ── 400 for invalid email format (no @) ───────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 'notanemail', password: 'password1' }), res, (e: unknown) => { throw e; });
+    const { statusCode, jsonData } = res._get();
+    assert.strictEqual(statusCode, 400);
+    assert.match((jsonData as any).message as string, /email/i);
+  }
+
+  // ── 400 for password shorter than minimum ──────────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 'investor@example.com', password: 'short' }), res, (e: unknown) => { throw e; });
+    const { statusCode, jsonData } = res._get();
+    assert.strictEqual(statusCode, 400);
+    assert.match((jsonData as any).message as string, /password/i);
+  }
+
+  // ── 409 when service throws DuplicateEmailError ────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    svc.shouldThrow = new DuplicateEmailError();
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    const res = makeRes();
+    await handler(makeReq({ email: 'taken@example.com', password: 'password1' }), res, (e: unknown) => { throw e; });
+    const { statusCode, jsonData } = res._get();
+    assert.strictEqual(statusCode, 409);
+    assert.strictEqual((jsonData as any).error, 'Conflict');
+    assert.strictEqual((jsonData as any).message, 'Email already registered');
+  }
+
+  // ── Unexpected errors are forwarded to next() ─────────────────────────────
+  {
+    const svc = new MockRegisterService();
+    svc.shouldThrow = new Error('unexpected DB failure');
+    const handler = createRegisterHandler(svc as unknown as RegisterService);
+    let capturedErr: unknown = null;
+    const res = makeRes();
+    await handler(makeReq({ email: 'investor@example.com', password: 'password1' }), res, (e: unknown) => { capturedErr = e; });
+    assert(capturedErr instanceof Error && capturedErr.message === 'unexpected DB failure');
+  }
+
+  console.log('registerHandler tests passed');
+})();

--- a/src/auth/register/registerHandler.ts
+++ b/src/auth/register/registerHandler.ts
@@ -1,0 +1,77 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { DuplicateEmailError, RegisterService } from './registerService';
+import { RegisterRequestBody } from './types';
+
+/** Minimal RFC-5322-ish email pattern – same rigour used across the auth module. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+
+/**
+ * Express handler factory for `POST /api/auth/investor/register`.
+ *
+ * Validates the request body, delegates to `RegisterService`, and returns:
+ *   201  { user: { id, email, role } }   – created
+ *   400  { error, message }              – validation failure
+ *   409  { error, message }              – email already registered
+ */
+export const createRegisterHandler = (
+  registerService: RegisterService,
+): RequestHandler => {
+  return async (
+    req: Request<unknown, unknown, RegisterRequestBody>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const { email, password } = req.body ?? {};
+
+      // ── Presence ────────────────────────────────────────────────────────
+      if (!email || !password) {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: 'Both "email" and "password" are required.',
+        });
+        return;
+      }
+
+      // ── Type guards ──────────────────────────────────────────────────────
+      if (typeof email !== 'string' || typeof password !== 'string') {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: '"email" and "password" must be strings.',
+        });
+        return;
+      }
+
+      // ── Email format ─────────────────────────────────────────────────────
+      if (!EMAIL_RE.test(email)) {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: 'Invalid email address.',
+        });
+        return;
+      }
+
+      // ── Password length ──────────────────────────────────────────────────
+      if (password.length < MIN_PASSWORD_LENGTH) {
+        res.status(400).json({
+          error: 'Bad Request',
+          message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+        });
+        return;
+      }
+
+      const user = await registerService.register(email, password);
+
+      res.status(201).json({
+        user: { id: user.id, email: user.email, role: user.role },
+      });
+    } catch (error) {
+      if (error instanceof DuplicateEmailError) {
+        res.status(409).json({ error: 'Conflict', message: error.message });
+        return;
+      }
+      next(error);
+    }
+  };
+};

--- a/src/auth/register/registerRoute.ts
+++ b/src/auth/register/registerRoute.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { createRegisterHandler } from './registerHandler';
+import { RegisterService } from './registerService';
+import { IUserRepository } from './types';
+
+export interface CreateRegisterRouterDeps {
+  userRepository: IUserRepository;
+}
+
+/**
+ * Creates an Express router that exposes:
+ *
+ *   POST /api/auth/investor/register   { email, password, name? }
+ *
+ * Returns 201 with `{ user: { id, email, role } }` on success.
+ *
+ * Wire up at the composition root (src/index.ts) by supplying a concrete
+ * `userRepository` that satisfies `IUserRepository`.  The concrete
+ * `UserRepository` class exposes `findUserByEmail`; an adapter is needed:
+ *
+ *   createRegisterRouter({
+ *     userRepository: {
+ *       findByEmail: (email) => userRepo.findUserByEmail(email),
+ *       createUser:  (input) => userRepo.createUser(input),
+ *     },
+ *   })
+ */
+export const createRegisterRouter = ({
+  userRepository,
+}: CreateRegisterRouterDeps): Router => {
+  const router = Router();
+  const registerService = new RegisterService(userRepository);
+
+  router.post('/api/auth/investor/register', createRegisterHandler(registerService));
+
+  return router;
+};

--- a/src/auth/register/registerService.test.ts
+++ b/src/auth/register/registerService.test.ts
@@ -1,0 +1,120 @@
+import assert from 'assert';
+import { createHash } from 'node:crypto';
+import { RegisterService, DuplicateEmailError } from './registerService';
+import { IUserRepository, RegisteredUser } from './types';
+
+// ─── In-memory fake repository ───────────────────────────────────────────────
+
+class FakeUserRepository implements IUserRepository {
+  private users: Map<string, RegisteredUser & { password_hash: string }> = new Map();
+
+  async findByEmail(email: string) {
+    return this.users.get(email) ?? null;
+  }
+
+  async createUser(input: { email: string; password_hash: string; role: 'investor' }): Promise<RegisteredUser> {
+    const user: RegisteredUser & { password_hash: string } = {
+      id: `user-${this.users.size + 1}`,
+      email: input.email,
+      role: input.role,
+      password_hash: input.password_hash,
+      created_at: new Date(),
+    };
+    this.users.set(input.email, user);
+    return user;
+  }
+
+  getStoredHash(email: string): string | undefined {
+    return this.users.get(email)?.password_hash;
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+(async function run() {
+  // ── Success: creates investor with hashed password ──────────────────────────
+  {
+    const repo = new FakeUserRepository();
+    const svc = new RegisterService(repo);
+    const user = await svc.register('Alice@Example.COM', 'secret123');
+
+    assert(user.id, 'user should have an id');
+    assert.strictEqual(user.email, 'alice@example.com', 'email should be lowercased + trimmed');
+    assert.strictEqual(user.role, 'investor', 'role must be investor');
+
+    const expectedHash = createHash('sha256').update('secret123').digest('hex');
+    assert.strictEqual(repo.getStoredHash('alice@example.com'), expectedHash, 'password must be SHA-256 hashed');
+  }
+
+  // ── Email normalisation: trim whitespace ─────────────────────────────────────
+  {
+    const repo = new FakeUserRepository();
+    const svc = new RegisterService(repo);
+    const user = await svc.register('  bob@example.com  ', 'password1');
+    assert.strictEqual(user.email, 'bob@example.com', 'leading/trailing spaces must be stripped');
+  }
+
+  // ── Duplicate email throws DuplicateEmailError ────────────────────────────────
+  {
+    const repo = new FakeUserRepository();
+    const svc = new RegisterService(repo);
+    await svc.register('carol@example.com', 'password1');
+
+    let threw = false;
+    try {
+      await svc.register('carol@example.com', 'different-password');
+    } catch (err) {
+      threw = true;
+      assert(err instanceof DuplicateEmailError, 'should throw DuplicateEmailError');
+      assert.strictEqual((err as DuplicateEmailError).message, 'Email already registered');
+    }
+    assert(threw, 'should have thrown');
+  }
+
+  // ── Duplicate email is case-insensitive ───────────────────────────────────────
+  {
+    const repo = new FakeUserRepository();
+    const svc = new RegisterService(repo);
+    await svc.register('Dave@Example.com', 'password1');
+
+    let threw = false;
+    try {
+      await svc.register('dave@example.com', 'password2');
+    } catch (err) {
+      threw = true;
+      assert(err instanceof DuplicateEmailError, 'duplicate check is case-insensitive');
+    }
+    assert(threw, 'should have thrown on case-variant duplicate');
+  }
+
+  // ── Different users can register independently ──────────────────────────────
+  {
+    const repo = new FakeUserRepository();
+    const svc = new RegisterService(repo);
+    const u1 = await svc.register('eve@example.com', 'password-eve');
+    const u2 = await svc.register('frank@example.com', 'password-frank');
+
+    assert.notStrictEqual(u1.id, u2.id, 'each user gets a unique id');
+    assert.strictEqual(u1.role, 'investor');
+    assert.strictEqual(u2.role, 'investor');
+  }
+
+  // ── Repository error propagates ───────────────────────────────────────────────
+  {
+    const failRepo: IUserRepository = {
+      async findByEmail() { return null; },
+      async createUser() { throw new Error('DB connection lost'); },
+    };
+    const svc = new RegisterService(failRepo);
+    let threw = false;
+    try {
+      await svc.register('grace@example.com', 'password1');
+    } catch (err) {
+      threw = true;
+      assert(err instanceof Error && err.message === 'DB connection lost');
+    }
+    assert(threw, 'DB error should propagate');
+  }
+
+  console.log('registerService tests passed');
+})();

--- a/src/auth/register/registerService.ts
+++ b/src/auth/register/registerService.ts
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto';
+import { IUserRepository, RegisteredUser } from './types';
+
+/**
+ * Thrown when a registration attempt is made with an email address that is
+ * already associated with an existing account.
+ */
+export class DuplicateEmailError extends Error {
+  constructor() {
+    super('Email already registered');
+    this.name = 'DuplicateEmailError';
+    // Restore prototype chain after TypeScript's `extends Error` transpilation.
+    Object.setPrototypeOf(this, DuplicateEmailError.prototype);
+  }
+}
+
+/**
+ * Domain service that orchestrates the investor registration flow:
+ *
+ *  1. Normalise the email address (lowercase + trim).
+ *  2. Reject duplicate emails.
+ *  3. Hash the password with SHA-256 (consistent with LoginService).
+ *  4. Persist the new user with role = 'investor'.
+ *
+ * Note: SHA-256 is used here because `package.json` must not be modified
+ * (no bcrypt / argon2 available).  In production swap this for a proper
+ * adaptive password-hashing algorithm behind the same interface boundary.
+ */
+export class RegisterService {
+  constructor(private readonly userRepository: IUserRepository) {}
+
+  async register(rawEmail: string, password: string): Promise<RegisteredUser> {
+    const email = rawEmail.toLowerCase().trim();
+
+    const existing = await this.userRepository.findByEmail(email);
+    if (existing) {
+      throw new DuplicateEmailError();
+    }
+
+    const password_hash = createHash('sha256').update(password).digest('hex');
+
+    return this.userRepository.createUser({ email, password_hash, role: 'investor' });
+  }
+}

--- a/src/auth/register/types.ts
+++ b/src/auth/register/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Investor registration module – type definitions.
+ *
+ * All external dependencies are expressed as narrow interfaces so the
+ * service can be unit-tested with in-memory fakes, consistent with the
+ * login / logout modules.
+ */
+
+// ── User ─────────────────────────────────────────────────────────────────────
+
+export type UserRole = 'startup' | 'investor';
+
+export interface RegisteredUser {
+  id: string;
+  email: string;
+  role: UserRole;
+  created_at: Date;
+}
+
+// ── Repository ────────────────────────────────────────────────────────────────
+
+/**
+ * Narrow user-repository interface required by the register service.
+ *
+ * NOTE: The concrete `UserRepository` class exposes `findUserByEmail`, not
+ * `findByEmail`.  The composition root supplies an adapter that satisfies
+ * this interface, keeping this module consistent with the login module's
+ * naming conventions.
+ */
+export interface IUserRepository {
+  findByEmail(email: string): Promise<{ id: string } | null>;
+  createUser(input: {
+    email: string;
+    password_hash: string;
+    role: 'investor';
+  }): Promise<RegisteredUser>;
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+export interface RegisterRequestBody {
+  email?: unknown;
+  password?: unknown;
+  /** Optional display name – accepted but not currently persisted (schema v1). */
+  name?: unknown;
+}
+
+export interface RegisterSuccessResponse {
+  user: {
+    id: string;
+    email: string;
+    role: UserRole;
+  };
+}


### PR DESCRIPTION
iles created in src/auth/register/
[types.ts](vscode-webview://1l7bkr9e721m2lokmiqj0kgoi37h2svp2s2iofs4v05bp9fhnctl/src/auth/register/types.ts)

UserRole, RegisteredUser, RegisterRequestBody, RegisterSuccessResponse
IUserRepository — narrow duck-typed interface (findByEmail + createUser). The concrete UserRepository class uses findUserByEmail, so the route comment documents the 2-line adapter needed at the composition root.
[registerService.ts](vscode-webview://1l7bkr9e721m2lokmiqj0kgoi37h2svp2s2iofs4v05bp9fhnctl/src/auth/register/registerService.ts)

DuplicateEmailError — custom error with prototype-chain fix (Object.setPrototypeOf)
RegisterService.register(email, password) — normalises email (lowercase + trim), checks for duplicates, hashes with SHA-256 (matching LoginService), creates user with role: 'investor'
[registerHandler.ts](vscode-webview://1l7bkr9e721m2lokmiqj0kgoi37h2svp2s2iofs4v05bp9fhnctl/src/auth/register/registerHandler.ts)

createRegisterHandler(service) — validates presence, types, email format (RFC-5322-ish regex), password ≥ 8 chars, maps DuplicateEmailError → 409, all other errors → next(err)
Response shapes match loginHandler.ts: 400 { error, message }, 409 { error, message }, 201 { user: { id, email, role } }
[registerRoute.ts](vscode-webview://1l7bkr9e721m2lokmiqj0kgoi37h2svp2s2iofs4v05bp9fhnctl/src/auth/register/registerRoute.ts)

createRegisterRouter({ userRepository }) — mounts POST /api/auth/investor/register, follows createLoginRouter/createLogoutRouter factory pattern
[registerService.test.ts](vscode-webview://1l7bkr9e721m2lokmiqj0kgoi37h2svp2s2iofs4v05bp9fhnctl/src/auth/register/registerService.test.ts) — 6 cases: success + email normalisation, duplicate email throws, case-insensitive duplicate, multiple independent users, DB error propagates

[registerHandler.test.ts](vscode-webview://1l7bkr9e721m2lokmiqj0kgoi37h2svp2s2iofs4v05bp9fhnctl/src/auth/register/registerHandler.test.ts) — 10 cases: 201 success, name accepted, missing email/password/body → 400, non-string email → 400, bad email format → 400, short password → 400, duplicate → 409, unexpected error → next(err)

closes #11 