### PR TITLE
feat(lib): add reusable pagination helper for list endpoints

### DIFF
--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -1,0 +1,97 @@
+import { Request } from 'express';
+import { parsePagination, formatPage } from './pagination';
+
+describe('Pagination Helper', () => {
+    describe('parsePagination', () => {
+        it('should use defaults when no query params are provided', () => {
+            const req = { query: {} } as unknown as Request;
+            const result = parsePagination(req);
+            expect(result).toEqual({
+                limit: 20,
+                offset: 0,
+                cursor: undefined,
+            });
+        });
+
+        it('should parse valid limit and offset', () => {
+            const req = {
+                query: { limit: '50', offset: '10' },
+            } as unknown as Request;
+            const result = parsePagination(req);
+            expect(result).toEqual({
+                limit: 50,
+                offset: 10,
+                cursor: undefined,
+            });
+        });
+
+        it('should cap limit at MAX_LIMIT (100)', () => {
+            const req = {
+                query: { limit: '200' },
+            } as unknown as Request;
+            const result = parsePagination(req);
+            expect(result.limit).toBe(100);
+        });
+
+        it('should ensure limit is at least 1', () => {
+            const req = {
+                query: { limit: '0' },
+            } as unknown as Request;
+            const result = parsePagination(req);
+            expect(result.limit).toBe(1);
+        });
+
+        it('should parse cursor', () => {
+            const req = {
+                query: { cursor: 'abc-123' },
+            } as unknown as Request;
+            const result = parsePagination(req);
+            expect(result.cursor).toBe('abc-123');
+        });
+
+        it('should handle invalid numbers by using defaults', () => {
+            const req = {
+                query: { limit: 'foo', offset: 'bar' },
+            } as unknown as Request;
+            const result = parsePagination(req);
+            expect(result).toEqual({
+                limit: 20,
+                offset: 0,
+                cursor: undefined,
+            });
+        });
+    });
+
+    describe('formatPage', () => {
+        const mockData = [{ id: 1 }, { id: 2 }];
+        const params = { limit: 10, offset: 0 };
+
+        it('should format page metadata correctly for offset-based pagination', () => {
+            const result = formatPage(mockData, 100, params);
+            expect(result.meta).toEqual({
+                total: 100,
+                limit: 10,
+                offset: 0,
+                nextCursor: undefined,
+                hasMore: true,
+            });
+            expect(result.data).toEqual(mockData);
+        });
+
+        it('should set hasMore to false when at the end of data', () => {
+            const result = formatPage(mockData, 2, params);
+            expect(result.meta.hasMore).toBe(false);
+        });
+
+        it('should set hasMore to true when nextCursor is provided', () => {
+            const result = formatPage(mockData, 100, params, 'next-token');
+            expect(result.meta.hasMore).toBe(true);
+            expect(result.meta.nextCursor).toBe('next-token');
+        });
+
+        it('should use provided offset from params', () => {
+            const result = formatPage(mockData, 100, { limit: 10, offset: 20 });
+            expect(result.meta.offset).toBe(20);
+        });
+    });
+});

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,91 @@
+import { Request } from 'express';
+
+/**
+ * Interface for pagination parameters.
+ * Supports both offset-based and cursor-based pagination.
+ */
+export interface PaginationParams {
+  limit: number;
+  offset?: number;
+  cursor?: string;
+}
+
+/**
+ * Interface for a paginated response.
+ */
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: {
+    total: number;
+    limit: number;
+    offset?: number;
+    nextCursor?: string;
+    hasMore: boolean;
+  };
+}
+
+/**
+ * Default pagination constants.
+ */
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/**
+ * Parses pagination parameters from an Express request query.
+ * 
+ * Expected query parameters:
+ * - limit: number (default: 20, max: 100)
+ * - offset: number (default: 0)
+ * - cursor: string (optional)
+ * 
+ * @param req Express Request object
+ * @returns PaginationParams
+ */
+export function parsePagination(req: Request): PaginationParams {
+  const queryLimit = parseInt(req.query.limit as string, 10);
+  const limit = isNaN(queryLimit) ? DEFAULT_LIMIT : Math.min(Math.max(1, queryLimit), MAX_LIMIT);
+
+  const queryOffset = parseInt(req.query.offset as string, 10);
+  const offset = isNaN(queryOffset) ? 0 : Math.max(0, queryOffset);
+
+  const cursor = req.query.cursor as string;
+
+  return {
+    limit,
+    offset,
+    cursor: cursor || undefined,
+  };
+}
+
+/**
+ * Formats a list of data into a paginated response.
+ * 
+ * @param data The array of items for the current page
+ * @param total Total number of items across all pages
+ * @param params The pagination parameters used for this query
+ * @param nextCursor Optional cursor for the next page (for cursor-based pagination)
+ * @returns PaginatedResponse<T>
+ */
+export function formatPage<T>(
+  data: T[],
+  total: number,
+  params: PaginationParams,
+  nextCursor?: string
+): PaginatedResponse<T> {
+  const { limit, offset = 0 } = params;
+
+  // For offset-based, hasMore is true if offset + limit < total
+  // For cursor-based, hasMore is true if nextCursor is provided
+  const hasMore = nextCursor ? true : offset + data.length < total;
+
+  return {
+    data,
+    meta: {
+      total,
+      limit,
+      offset,
+      nextCursor,
+      hasMore,
+    },
+  };
+}


### PR DESCRIPTION
## Description
This PR introduces a reusable pagination utility in [src/lib/pagination.ts](cci:7://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/lib/pagination.ts:0:0-0:0) to standardize pagination contracts across the API. It provides helpers to parse incoming request parameters and format outgoing paginated responses, supporting both **offset-based** and **cursor-based** strategies.

## Requirements and Context
- Implement a consistent pagination contract for list endpoints.
- Avoid modifying existing route files or [src/index.ts](cci:7://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/index.ts:0:0-0:0).
- Ensure strict validation of limit and offset.

## Proposed Changes
### [src/lib/pagination.ts](cci:7://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/lib/pagination.ts:0:0-0:0)
- Added [PaginationParams](cci:2://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/lib/pagination.ts:6:0-10:1) and `PaginatedResponse<T>` interfaces.
- Implemented [parsePagination(req)](cci:1://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/lib/pagination.ts:32:0-57:1):
    - Extracts `limit`, `offset`, and `cursor` from query strings.
    - Clamps `limit` between 1 and 100 (default 20).
    - Defaults `offset` to 0.
- Implemented [formatPage(data, total, params, nextCursor)](cci:1://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/lib/pagination.ts:59:0-90:1):
    - Standardizes the response metadata.
    - Automates `hasMore` logic based on data length or presence of a `nextCursor`.

### [src/lib/pagination.test.ts](cci:7://file:///home/jahrulez/Desktop/Projects/Revora-Backend/src/lib/pagination.test.ts:0:0-0:0)
- Added comprehensive unit tests covering:
    - Default parameter handling.
    - Parameter validation and clamping.
    - Response formatting for both offset and cursor strategies.

## Verification Plan
### Automated Tests
Run the newly added unit tests:
```bash
npx jest src/lib/pagination.test.ts


Closes #39 