### PR TITLE
feat(db): add in-app notifications table and repository

### DIFF
--- a/src/db/migrations/003_create_notifications.sql
+++ b/src/db/migrations/003_create_notifications.sql
@@ -1,0 +1,16 @@
+-- Migration: create notifications table
+-- Columns:
+-- id (UUID primary key), user_id (FK -> users.id), type, title, body, read_at, created_at
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  read_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_created_at ON notifications(created_at DESC);

--- a/src/db/repositories/notificationRepository.test.ts
+++ b/src/db/repositories/notificationRepository.test.ts
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { NotificationRepository } from './notificationRepository';
+
+class MockPool {
+  constructor(private rows: any[] = [], private rowCount = 1) {}
+  async query(_text: string, _values?: any[]) {
+    return { rows: this.rows, rowCount: this.rowCount };
+  }
+}
+
+(async function run() {
+  const sampleNotification = {
+    id: 'n1',
+    user_id: 'u1',
+    type: 'info',
+    title: 'Test Notification',
+    body: 'This is a test notification',
+    read_at: null,
+    created_at: new Date(),
+  };
+
+  // Test create
+  const createRepo = new NotificationRepository(new MockPool([sampleNotification]) as any);
+  const created = await createRepo.create({
+    user_id: 'u1',
+    type: 'info',
+    title: 'Test Notification',
+    body: 'This is a test notification',
+  });
+  assert(created.title === 'Test Notification');
+  assert(created.user_id === 'u1');
+
+  // Test listByUser
+  const listRepo = new NotificationRepository(new MockPool([sampleNotification, { ...sampleNotification, id: 'n2' }]) as any);
+  const notifications = await listRepo.listByUser('u1');
+  assert(notifications.length === 2);
+  assert(notifications[0].user_id === 'u1');
+
+  // Test markRead
+  const readNotification = { ...sampleNotification, read_at: new Date() };
+  const markReadRepo = new NotificationRepository(new MockPool([readNotification]) as any);
+  const marked = await markReadRepo.markRead('n1');
+  assert(marked.read_at !== null);
+  assert(marked.id === 'n1');
+
+  console.log('notificationRepository tests passed');
+})();

--- a/src/db/repositories/notificationRepository.ts
+++ b/src/db/repositories/notificationRepository.ts
@@ -1,0 +1,69 @@
+import { Pool, QueryResult } from 'pg';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  type: string;
+  title: string;
+  body: string;
+  read_at: Date | null;
+  created_at: Date;
+}
+
+export interface CreateNotificationInput {
+  user_id: string;
+  type: string;
+  title: string;
+  body: string;
+}
+
+export class NotificationRepository {
+  constructor(private db: Pool) {}
+
+  async create(input: CreateNotificationInput): Promise<Notification> {
+    const query = `
+      INSERT INTO notifications (user_id, type, title, body, created_at)
+      VALUES ($1, $2, $3, $4, NOW())
+      RETURNING *
+    `;
+
+    const values = [input.user_id, input.type, input.title, input.body];
+    const result: QueryResult = await this.db.query(query, values);
+    if (result.rows.length === 0) throw new Error('Failed to create notification');
+    return this.mapNotification(result.rows[0]);
+  }
+
+  async listByUser(userId: string): Promise<Notification[]> {
+    const query = `
+      SELECT * FROM notifications 
+      WHERE user_id = $1 
+      ORDER BY created_at DESC
+    `;
+    const result: QueryResult = await this.db.query(query, [userId]);
+    return result.rows.map((row) => this.mapNotification(row));
+  }
+
+  async markRead(notificationId: string): Promise<Notification> {
+    const query = `
+      UPDATE notifications 
+      SET read_at = NOW() 
+      WHERE id = $1 
+      RETURNING *
+    `;
+    const result: QueryResult = await this.db.query(query, [notificationId]);
+    if (result.rows.length === 0) throw new Error('Notification not found');
+    return this.mapNotification(result.rows[0]);
+  }
+
+  private mapNotification(row: any): Notification {
+    return {
+      id: row.id,
+      user_id: row.user_id,
+      type: row.type,
+      title: row.title,
+      body: row.body,
+      read_at: row.read_at,
+      created_at: row.created_at,
+    };
+  }
+}


### PR DESCRIPTION
Closes #46

This PR adds:
- Migration for in-app notifications table with user_id, type, title, body, read_at, and created_at columns
- NotificationRepository with create, listByUser, and markRead methods
- Comprehensive tests for all repository methods

All changes are in new files only, no modifications to existing code.