### PR TITLE
feat: mount API under versioned /api/v1 prefix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
 
 const app = express();
 const port = process.env.PORT ?? 3000;
+const API_VERSION_PREFIX = process.env.API_VERSION_PREFIX ?? '/api/v1';
+const apiRouter = express.Router();
 
 class InMemoryMilestoneRepository implements MilestoneRepository {
   constructor(private readonly milestones = new Map<string, Milestone>()) {}
@@ -129,7 +131,9 @@ const domainEventPublisher = new ConsoleDomainEventPublisher();
 app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
-app.use(
+app.use(API_VERSION_PREFIX, apiRouter);
+
+apiRouter.use(
   createMilestoneValidationRouter({
     requireAuth,
     milestoneRepository,
@@ -148,7 +152,7 @@ app.get('/health', async (_req: Request, res: Response) => {
   });
 });
 
-app.get('/api/overview', (_req: Request, res: Response) => {
+apiRouter.get('/overview', (_req: Request, res: Response) => {
   res.json({
     name: 'Stellar RevenueShare (Revora) Backend',
     description:

--- a/src/routes/README.md
+++ b/src/routes/README.md
@@ -56,9 +56,10 @@ All fields are optional. Only provided fields will be updated.
 
 ## Usage Example
 
-To integrate this route into your Express app:
+To integrate this route into your Express app (with versioned API prefix):
 
 ```typescript
+import express from 'express';
 import { Pool } from 'pg';
 import { createNotificationPreferencesRouter } from './routes/notificationPreferences';
 import { NotificationPreferencesRepository } from './db/repositories/notificationPreferencesRepository';
@@ -66,12 +67,20 @@ import { NotificationPreferencesRepository } from './db/repositories/notificatio
 const db = new Pool({ /* your config */ });
 const notificationPreferencesRepository = new NotificationPreferencesRepository(db);
 
+const app = express();
+
+// All API routes are mounted under a versioned prefix.
+const API_VERSION_PREFIX = process.env.API_VERSION_PREFIX ?? '/api/v1';
+const apiRouter = express.Router();
+app.use(API_VERSION_PREFIX, apiRouter);
+
 const router = createNotificationPreferencesRouter({
   requireAuth: yourAuthMiddleware,
   notificationPreferencesRepository,
 });
 
-app.use(router);
+// Mount the feature router under the versioned API router
+apiRouter.use(router);
 ```
 
 ## Database Migration


### PR DESCRIPTION
**Description**

**Summary**

- **Add versioned API router**: Introduces `API_VERSION_PREFIX` (default `/api/v1`) and a shared `apiRouter` in `src/index.ts`, mounted via `app.use(API_VERSION_PREFIX, apiRouter)`.
- **Version existing endpoints**: Moves the overview and milestone validation routes under `apiRouter`, so they are consistently exposed under `/api/v1`.
- **Document convention**: Updates `src/routes/README.md` to show how feature routers should be mounted beneath the versioned `apiRouter` instead of directly on `app`.

**Details**

- In `index.ts`, defines:
  - `const API_VERSION_PREFIX = process.env.API_VERSION_PREFIX ?? '/api/v1';`
  - `const apiRouter = express.Router();`
  - `app.use(API_VERSION_PREFIX, apiRouter);`
- Attaches:
  - `createMilestoneValidationRouter(...)` via `apiRouter.use(...)` (now served at `/api/v1/vaults/:id/milestones/:mid/validate`).
  - Overview handler via `apiRouter.get('/overview', ...)` (now `/api/v1/overview`).
- Leaves `/health` as a top-level, unversioned endpoint for health checks.
- Updates the notification preferences README usage example to:
  - Create an `apiRouter` under `API_VERSION_PREFIX`.
  - Mount feature routers with `apiRouter.use(router)`.

**Breaking changes**

- **Endpoint paths**:
  - `POST /vaults/:id/milestones/:mid/validate` → `POST /api/v1/vaults/:id/milestones/:mid/validate`.
  - `GET /api/overview` → `GET /api/v1/overview`.
- Any consumers should update their base URL to include `/api/v1` (or the configured `API_VERSION_PREFIX`).

**Test plan**

- **Unit / lint**  
  - Run `npm run lint` and ensure no errors in `src/index.ts` and docs changes.
- **Manual verification**
  - Start the app: `npm run dev`.
  - Hit `GET /health` → returns health status (unchanged, no prefix).
  - Hit `GET /api/v1/overview` → returns service metadata JSON.
  - Hit `POST /api/v1/vaults/vault-1/milestones/milestone-1/validate` with appropriate headers → returns 200 and updated milestone as before.
  
Closes: #60 