### PR TITLE
feat(api): add list distributions by offering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4879,7 +4879,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5686,6 +5685,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -5826,6 +5826,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6304,7 +6305,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7533,6 +7533,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/offerings/distributionsRoute.test.ts
+++ b/src/offerings/distributionsRoute.test.ts
@@ -1,0 +1,364 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  createListDistributionsByOfferingHandler,
+  DistributionRepository,
+  OfferingOwnershipRepository,
+  DistributionRun,
+} from './distributionsRoute';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockDistributionRepository: jest.Mocked<DistributionRepository> = {
+  listByOffering: jest.fn(),
+};
+
+const mockOfferingOwnershipRepository: jest.Mocked<OfferingOwnershipRepository> = {
+  isOwnedByUser: jest.fn(),
+};
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const createResponse = () => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as unknown as Response & {
+    status: jest.Mock;
+    json: jest.Mock;
+  };
+};
+
+const createNext = (): NextFunction => jest.fn();
+
+const createRequest = (overrides: {
+  params?: Record<string, string>;
+  query?: Record<string, string | undefined>;
+  userId?: string;
+}): Request => {
+  return {
+    params: overrides.params ?? { id: 'offering-1' },
+    query: overrides.query ?? {},
+    user: overrides.userId ? { id: overrides.userId } : undefined,
+  } as unknown as Request;
+};
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const makeRun = (n: number): DistributionRun => ({
+  id: `run-${n}`,
+  offering_id: 'offering-1',
+  total_amount: String(n * 1000),
+  distribution_date: new Date(`2024-0${n}-15T00:00:00.000Z`),
+  status: 'completed',
+  created_at: new Date(`2024-0${n}-15T00:00:00.000Z`),
+  updated_at: new Date(`2024-0${n}-15T00:00:00.000Z`),
+});
+
+const runs: DistributionRun[] = [makeRun(3), makeRun(2), makeRun(1)]; // newest-first (repo ordering)
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('createListDistributionsByOfferingHandler', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // 1. Authentication
+  it('returns 401 when request is unauthenticated', async () => {
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({ userId: undefined });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    expect(mockOfferingOwnershipRepository.isOwnedByUser).not.toHaveBeenCalled();
+    expect(mockDistributionRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  // 2. Offering ownership
+  it('returns 403 when offering is not owned by authenticated issuer', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(false);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({ userId: 'user-1' });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(mockOfferingOwnershipRepository.isOwnedByUser).toHaveBeenCalledWith(
+      'offering-1',
+      'user-1'
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+    expect(mockDistributionRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  // 3. Happy path – default pagination
+  it('returns 200 with distributions and pagination metadata on success', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce(runs);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({ userId: 'user-1' });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(mockDistributionRepository.listByOffering).toHaveBeenCalledWith('offering-1');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: runs,
+      pagination: {
+        page: 1,
+        pageSize: 20,
+        total: 3,
+        totalPages: 1,
+      },
+    });
+  });
+
+  // 4. Pagination – page 1, pageSize 2
+  it('paginates correctly: page 1, pageSize 2', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce(runs);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({
+      userId: 'user-1',
+      query: { page: '1', pageSize: '2' },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [makeRun(3), makeRun(2)],
+      pagination: { page: 1, pageSize: 2, total: 3, totalPages: 2 },
+    });
+  });
+
+  // 5. Pagination – page 2, pageSize 2
+  it('paginates correctly: page 2, pageSize 2', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce(runs);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({
+      userId: 'user-1',
+      query: { page: '2', pageSize: '2' },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [makeRun(1)],
+      pagination: { page: 2, pageSize: 2, total: 3, totalPages: 2 },
+    });
+  });
+
+  // 6. Pagination – page beyond results returns empty data
+  it('returns empty data array when page is beyond total results', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce(runs);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({
+      userId: 'user-1',
+      query: { page: '99', pageSize: '20' },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [],
+      pagination: { page: 99, pageSize: 20, total: 3, totalPages: 1 },
+    });
+  });
+
+  // 7. Empty offering – zero distributions
+  it('returns empty data with totalPages 0 when offering has no distributions', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce([]);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({ userId: 'user-1' });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [],
+      pagination: { page: 1, pageSize: 20, total: 0, totalPages: 0 },
+    });
+  });
+
+  // 8. Invalid page param
+  it('returns 400 when page query param is invalid', async () => {
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({
+      userId: 'user-1',
+      query: { page: 'bad' },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid pagination parameters' });
+    expect(mockDistributionRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  // 9. Invalid pageSize param
+  it('returns 400 when pageSize query param is invalid', async () => {
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({
+      userId: 'user-1',
+      query: { pageSize: '-5' },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid pagination parameters' });
+    expect(mockDistributionRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  // 10. pageSize is capped at MAX_PAGE_SIZE (100)
+  it('caps pageSize at 100', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce(runs);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({
+      userId: 'user-1',
+      query: { pageSize: '999' },
+    });
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const call = (res.json as jest.Mock).mock.calls[0][0];
+    expect(call.pagination.pageSize).toBe(100);
+  });
+
+  // 11. Repository throws – error forwarded to next()
+  it('calls next(error) when distributionRepository throws', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    const boom = new Error('db exploded');
+    mockDistributionRepository.listByOffering.mockRejectedValueOnce(boom);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({ userId: 'user-1' });
+    const res = createResponse();
+    const next = createNext();
+
+    await handler(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  // 12. Ownership check throws – error forwarded to next()
+  it('calls next(error) when ownershipRepository throws', async () => {
+    const boom = new Error('ownership check failed');
+    mockOfferingOwnershipRepository.isOwnedByUser.mockRejectedValueOnce(boom);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    const req = createRequest({ userId: 'user-1' });
+    const res = createResponse();
+    const next = createNext();
+
+    await handler(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(mockDistributionRepository.listByOffering).not.toHaveBeenCalled();
+  });
+
+  // 13. req.auth fallback (Clerk-style auth)
+  it('reads userId from req.auth.userId when req.user is absent', async () => {
+    mockOfferingOwnershipRepository.isOwnedByUser.mockResolvedValueOnce(true);
+    mockDistributionRepository.listByOffering.mockResolvedValueOnce([]);
+
+    const handler = createListDistributionsByOfferingHandler({
+      distributionRepository: mockDistributionRepository,
+      offeringOwnershipRepository: mockOfferingOwnershipRepository,
+    });
+
+    // Build a request that uses req.auth instead of req.user
+    const req = {
+      params: { id: 'offering-1' },
+      query: {},
+      user: undefined,
+      auth: { userId: 'clerk-user-1' },
+    } as unknown as Request;
+
+    const res = createResponse();
+
+    await handler(req, res, createNext());
+
+    expect(mockOfferingOwnershipRepository.isOwnedByUser).toHaveBeenCalledWith(
+      'offering-1',
+      'clerk-user-1'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/offerings/distributionsRoute.ts
+++ b/src/offerings/distributionsRoute.ts
@@ -1,0 +1,162 @@
+import { NextFunction, Request, RequestHandler, Response, Router } from 'express';
+
+// ─── Domain types ────────────────────────────────────────────────────────────
+
+/** Mirrors the DistributionRun shape from distributionRepository.ts */
+export interface DistributionRun {
+  id: string;
+  offering_id: string;
+  total_amount: string;
+  distribution_date: Date;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  created_at: Date;
+  updated_at: Date;
+}
+
+// ─── Repository contracts (interfaces only – no concrete import needed) ──────
+
+export interface DistributionRepository {
+  listByOffering(offeringId: string): Promise<DistributionRun[]>;
+}
+
+export interface OfferingOwnershipRepository {
+  isOwnedByUser(offeringId: string, userId: string): Promise<boolean>;
+}
+
+// ─── Dependency shapes ───────────────────────────────────────────────────────
+
+interface CreateDistributionsRouteDeps {
+  requireAuth: RequestHandler;
+  distributionRepository: DistributionRepository;
+  offeringOwnershipRepository: OfferingOwnershipRepository;
+}
+
+// ─── Pagination ──────────────────────────────────────────────────────────────
+
+interface QueryShape {
+  page: number;
+  pageSize: number;
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+/** Parse a value that must be a positive integer if present. */
+const parsePositiveInt = (value: unknown): number | null => {
+  if (value === undefined) return null;
+  if (Array.isArray(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+};
+
+const parseQuery = (req: Request): QueryShape | null => {
+  const page = parsePositiveInt(req.query.page);
+  const pageSize = parsePositiveInt(req.query.pageSize);
+
+  if (req.query.page !== undefined && page === null) {
+    return null;
+  }
+  if (req.query.pageSize !== undefined && pageSize === null) {
+    return null;
+  }
+
+  return {
+    page: page ?? DEFAULT_PAGE,
+    pageSize: Math.min(pageSize ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE),
+  };
+};
+
+// ─── Auth helper ─────────────────────────────────────────────────────────────
+
+/** Resolves user id from req.user (JWT middleware) or req.auth (Clerk/etc.) */
+const getUserId = (req: Request): string | undefined => {
+  const fromUser = (req as any).user?.id;
+  const fromAuth = (req as any).auth?.userId;
+  return fromUser ?? fromAuth;
+};
+
+// ─── Handler factory (exported for unit tests) ───────────────────────────────
+
+export const createListDistributionsByOfferingHandler = ({
+  distributionRepository,
+  offeringOwnershipRepository,
+}: Omit<CreateDistributionsRouteDeps, 'requireAuth'>): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      // 1. Authentication
+      const userId = getUserId(req);
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      // 2. Path param
+      const offeringId = req.params.id;
+      if (!offeringId) {
+        res.status(400).json({ error: 'Invalid request' });
+        return;
+      }
+
+      // 3. Pagination query params
+      const query = parseQuery(req);
+      if (!query) {
+        res.status(400).json({ error: 'Invalid pagination parameters' });
+        return;
+      }
+
+      // 4. Ownership check — issuer must own the offering
+      const ownsOffering = await offeringOwnershipRepository.isOwnedByUser(
+        offeringId,
+        userId
+      );
+      if (!ownsOffering) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+      }
+
+      // 5. Fetch distributions for this offering
+      const distributions = await distributionRepository.listByOffering(offeringId);
+
+      // 6. Paginate in-memory (listByOffering already orders by distribution_date DESC)
+      const total = distributions.length;
+      const offset = (query.page - 1) * query.pageSize;
+      const data = distributions.slice(offset, offset + query.pageSize);
+
+      // 7. Respond
+      res.status(200).json({
+        data,
+        pagination: {
+          page: query.page,
+          pageSize: query.pageSize,
+          total,
+          totalPages: total === 0 ? 0 : Math.ceil(total / query.pageSize),
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+};
+
+// ─── Router factory ──────────────────────────────────────────────────────────
+
+export const createDistributionsRouter = ({
+  requireAuth,
+  distributionRepository,
+  offeringOwnershipRepository,
+}: CreateDistributionsRouteDeps): Router => {
+  const router = Router();
+
+  router.get(
+    '/api/offerings/:id/distributions',
+    requireAuth,
+    createListDistributionsByOfferingHandler({
+      distributionRepository,
+      offeringOwnershipRepository,
+    })
+  );
+
+  return router;
+};


### PR DESCRIPTION
Title: feat(api): add list distributions by offering

Description: This PR implements the endpoint for issuers to view the history of distribution runs for a specific offering.

Changes:

New Endpoint: GET /api/offerings/:id/distributions
Logic:
Validates that the requesting user owns the offering via OfferingOwnershipRepository.
Fetches all distributions for the offering and performs in-memory pagination.
Supports page and pageSize query parameters (default: page 1, size 20; max size: 100).
Testing:
Added [distributionsRoute.test.ts](code-assist-path:/home/jerry/Desktop/oss-pro/Revora-Backend/src/offerings/distributionsRoute.test.ts) with comprehensive coverage for:
Authentication & Authorization (401/403).
Pagination calculations.
Input validation for query parameters.
Error handling for repository failures.
Checklist:

[x] API endpoint implemented
[x] Ownership verification added
[x] Pagination logic added
[x] Unit tests passed