### PR TITLE
feat: implement JWT key rotation, clock skew tolerance, and issuer/au…

### DIFF
--- a/docs/jwt-key-rotation.md
+++ b/docs/jwt-key-rotation.md
@@ -1,0 +1,109 @@
+# JWT Key Rotation & Claim Validation
+
+## Overview
+
+The Revora-Backend JWT subsystem supports **key rotation**, **clock skew tolerance**, and **issuer/audience claim invariants**. These features ensure seamless secret transitions, resilience against clock drift, and defense against token misuse across services.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `JWT_SECRET` | Yes (prod) | Current signing secret. Minimum 32 characters. |
+| `JWT_SECRET_PREVIOUS` | No | Previous secret for key rotation. Must be ≥32 chars to be accepted. |
+| `JWT_ISSUER` | No | Expected `iss` claim value. When set, tokens without a matching issuer are rejected. |
+| `JWT_AUDIENCE` | No | Expected `aud` claim value. When set, tokens without a matching audience are rejected. |
+| `JWT_CLOCK_TOLERANCE_SECONDS` | No | Clock skew window for `exp`, `iat`, `nbf` claims. Defaults to 30 seconds. Must be ≥0. |
+
+## Key Rotation
+
+### How It Works
+
+1. `getJwtSecretsForVerification()` returns `[JWT_SECRET, JWT_SECRET_PREVIOUS?]` — current secret first.
+2. `verifyToken()` iterates through all secrets; the first one that produces a valid signature wins.
+3. When a token is verified with the previous secret, a structured log entry is emitted at `info` level for operational visibility.
+4. When all secrets fail, a `warn`-level log is emitted before throwing.
+
+### Rotation Procedure
+
+1. Generate a new secret (≥32 characters).
+2. Set `JWT_SECRET_PREVIOUS` to the current `JWT_SECRET` value.
+3. Set `JWT_SECRET` to the new secret.
+4. Deploy. Tokens signed with the old secret remain valid until they expire naturally.
+5. After all old-secret tokens have expired, remove `JWT_SECRET_PREVIOUS`.
+
+### Security Assumptions
+
+- Both secrets must be ≥32 characters. Shorter previous secrets are silently ignored.
+- The current secret is always tried first, ensuring minimal latency for the common case.
+- Key rotation does **not** extend token lifetime — old tokens still expire at their original `exp`.
+- There is no limit on the number of rotation secrets. Only one previous secret is supported to keep the attack surface small.
+
+## Clock Skew Tolerance
+
+### Why
+
+Distributed systems may have minor clock drift between servers. Without tolerance, a token issued by server A might appear expired to server B even though it's still within its intended lifetime.
+
+### Implementation
+
+- `jsonwebtoken`'s built-in `exp`/`nbf` checks are **disabled** (`ignoreExpiration: true`, `ignoreNotBefore: true`).
+- `validateClaims()` performs explicit time-based checks with a configurable tolerance window:
+  - **`exp`**: token is expired if `exp < now - tolerance`
+  - **`iat`**: token is rejected if `iat > now + tolerance`
+  - **`nbf`**: token is rejected if `nbf > now + tolerance`
+- Default tolerance: **30 seconds**. Configurable via `JWT_CLOCK_TOLERANCE_SECONDS`.
+
+### Abuse Considerations
+
+- Setting tolerance too high effectively extends token lifetime. The default of 30s is a reasonable trade-off.
+- Zero tolerance is supported for environments requiring strict time enforcement.
+- Negative or non-numeric values are silently ignored, falling back to the 30s default.
+
+## Issuer & Audience Invariants
+
+### Issuer (`iss`)
+
+- When `JWT_ISSUER` is set, every verified token **must** contain an `iss` claim matching the configured value.
+- Tokens without an `iss` claim are rejected when validation is enabled.
+- `issueToken()` includes `iss` when the `issuer` option is provided.
+
+### Audience (`aud`)
+
+- When `JWT_AUDIENCE` is set, every verified token **must** contain an `aud` claim matching the configured value.
+- Both string and array `aud` values are supported (per JWT spec).
+- Tokens without an `aud` claim are rejected when validation is enabled.
+- `issueToken()` includes `aud` when the `audience` option is provided.
+
+## Error Handling
+
+All JWT verification errors in middleware are propagated as `AppError` instances via `next()`:
+
+| Condition | Error Code | HTTP Status |
+|---|---|---|
+| Missing Authorization header | `UNAUTHORIZED` | 401 |
+| Invalid token format | `UNAUTHORIZED` | 401 |
+| Expired token (beyond tolerance) | `UNAUTHORIZED` | 401 |
+| Issuer/audience mismatch | `UNAUTHORIZED` | 401 |
+| Non-investor role | `FORBIDDEN` | 403 |
+| JWT_SECRET not configured | `INTERNAL_ERROR` | 500 |
+
+The global `errorHandler` middleware (mounted in `app.ts`) converts these into structured JSON responses. Non-`AppError` thrown values are always downgraded to a generic 500 to prevent information leakage.
+
+## Structured Logging
+
+| Event | Level | Context |
+|---|---|---|
+| Token verified with previous secret | `info` | `{ secretIndex }` |
+| All secrets failed verification | `warn` | `{ error, secretCount }` |
+| JWT verification failed in middleware | `warn` | `{ error }` |
+
+## Test Coverage
+
+Tests cover the following scenarios in `src/lib/jwt.test.ts` and `src/middleware/auth.test.ts`:
+
+- **Key rotation**: current secret, previous secret, missing previous, unknown secret, short previous secret
+- **Clock skew**: within tolerance, beyond tolerance, zero tolerance, large tolerance, default 30s boundary
+- **Issuer/audience**: match, mismatch, missing claim, string aud, array aud, both together
+- **validateClaims**: missing sub, whitespace sub, non-string sub, expired, future iat, future nbf
+- **getDefaultClaimValidationOptions**: empty env, each env var individually, all together, non-numeric tolerance, negative tolerance, Infinity, zero
+- **Middleware**: AppError propagation via `next()`, correct status codes, session validation edge cases

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,8 @@ import { createHealthRouter } from './routes/health';
 import { UserRepository } from './db/repositories/userRepository';
 import { JwtIssuer, UserRole, UserRepository as IUserRepository, SessionRepository as ISessionRepository } from './auth/login/types';
 import { LoginService } from './auth/login/loginService';
-import { issueToken } from './lib/jwt';
+import { issueToken, getDefaultClaimValidationOptions } from './lib/jwt';
+import { errorHandler } from './middleware/errorHandler';
 
 // Adapter to convert database User to login service UserRecord
 class UserRepositoryAdapter implements IUserRepository {
@@ -89,6 +90,9 @@ export function createApp() {
   app.use(createLogoutRouter({ requireAuth, sessionRepository }));
   app.use(createChangePasswordRouter({ requireAuth, db: pool }));
   app.use('/api/v1/health', createHealthRouter(pool));
+
+  // Global error handler — must be mounted after all routes
+  app.use(errorHandler);
 
   return app;
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,10 @@ type Config = {
   PORT: number;
   DATABASE_URL?: string;
   JWT_SECRET?: string;
+  JWT_SECRET_PREVIOUS?: string;
+  JWT_ISSUER?: string;
+  JWT_AUDIENCE?: string;
+  JWT_CLOCK_TOLERANCE_SECONDS?: number;
   STELLAR_NETWORK: "testnet" | "public";
   STELLAR_HORIZON_URL?: string;
   STELLAR_NETWORK_PASSPHRASE?: string;
@@ -49,11 +53,22 @@ function buildConfig(): Config {
   const STELLAR_NETWORK = normalizeStellarNetwork(process.env.STELLAR_NETWORK);
   const ALLOWED_ORIGINS = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
 
+  const jwtClockTolerance = process.env.JWT_CLOCK_TOLERANCE_SECONDS
+    ? parseInt(process.env.JWT_CLOCK_TOLERANCE_SECONDS, 10)
+    : undefined;
+
   const cfg: Config = {
     NODE_ENV,
     PORT,
     DATABASE_URL: process.env.DATABASE_URL,
     JWT_SECRET: process.env.JWT_SECRET,
+    JWT_SECRET_PREVIOUS: process.env.JWT_SECRET_PREVIOUS,
+    JWT_ISSUER: process.env.JWT_ISSUER,
+    JWT_AUDIENCE: process.env.JWT_AUDIENCE,
+    JWT_CLOCK_TOLERANCE_SECONDS:
+      jwtClockTolerance !== undefined && Number.isFinite(jwtClockTolerance) && jwtClockTolerance >= 0
+        ? jwtClockTolerance
+        : undefined,
     STELLAR_NETWORK,
     STELLAR_HORIZON_URL: process.env.STELLAR_HORIZON_URL,
     STELLAR_NETWORK_PASSPHRASE: process.env.STELLAR_NETWORK_PASSPHRASE,

--- a/src/lib/jwt.test.ts
+++ b/src/lib/jwt.test.ts
@@ -8,6 +8,8 @@ import {
   issueRefreshToken,
   getJwtSecret,
   getJwtAlgorithm,
+  getJwtSecretsForVerification,
+  getDefaultClaimValidationOptions,
   validateClaims,
   TOKEN_EXPIRY,
   REFRESH_TOKEN_EXPIRY,
@@ -20,12 +22,20 @@ const DEFAULT_JWT_SECRET =
   process.env.JWT_SECRET ||
   "test-secret-key-that-is-at-least-32-characters-long!";
 
+const PREVIOUS_SECRET = "previous-secret-key-that-is-at-least-32-chars!";
+
 describe("jwt utilities", () => {
   beforeEach(() => {
     // Several tests in this file intentionally mutate JWT_SECRET; always reset
     // between cases so ordering can't leak failures into later tests.
     process.env.JWT_SECRET = DEFAULT_JWT_SECRET;
+    delete process.env.JWT_SECRET_PREVIOUS;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+    delete process.env.JWT_CLOCK_TOLERANCE_SECONDS;
   });
+
+  // ── getJwtSecret ────────────────────────────────────────────────────────────
 
   describe("getJwtSecret", () => {
     const originalSecret = process.env.JWT_SECRET;
@@ -55,11 +65,122 @@ describe("jwt utilities", () => {
     });
   });
 
+  // ── getJwtAlgorithm ─────────────────────────────────────────────────────────
+
   describe("getJwtAlgorithm", () => {
     it("should return HS256 algorithm", () => {
       expect(getJwtAlgorithm()).toBe("HS256");
     });
   });
+
+  // ── getJwtSecretsForVerification ────────────────────────────────────────────
+
+  describe("getJwtSecretsForVerification", () => {
+    afterEach(() => {
+      delete process.env.JWT_SECRET_PREVIOUS;
+    });
+
+    it("should return only current secret when JWT_SECRET_PREVIOUS is not set", () => {
+      const secrets = getJwtSecretsForVerification();
+      expect(secrets).toEqual([DEFAULT_JWT_SECRET]);
+    });
+
+    it("should include previous secret when JWT_SECRET_PREVIOUS is set and >= 32 chars", () => {
+      process.env.JWT_SECRET_PREVIOUS = PREVIOUS_SECRET;
+      const secrets = getJwtSecretsForVerification();
+      expect(secrets).toEqual([DEFAULT_JWT_SECRET, PREVIOUS_SECRET]);
+    });
+
+    it("should exclude previous secret when it is shorter than 32 chars", () => {
+      process.env.JWT_SECRET_PREVIOUS = "too-short";
+      const secrets = getJwtSecretsForVerification();
+      expect(secrets).toEqual([DEFAULT_JWT_SECRET]);
+    });
+
+    it("should exclude previous secret when it is empty string", () => {
+      process.env.JWT_SECRET_PREVIOUS = "";
+      const secrets = getJwtSecretsForVerification();
+      expect(secrets).toEqual([DEFAULT_JWT_SECRET]);
+    });
+
+    it("should throw when current JWT_SECRET is missing", () => {
+      delete process.env.JWT_SECRET;
+      expect(() => getJwtSecretsForVerification()).toThrow(
+        "JWT_SECRET environment variable is not set",
+      );
+    });
+  });
+
+  // ── getDefaultClaimValidationOptions ─────────────────────────────────────────
+
+  describe("getDefaultClaimValidationOptions", () => {
+    afterEach(() => {
+      delete process.env.JWT_ISSUER;
+      delete process.env.JWT_AUDIENCE;
+      delete process.env.JWT_CLOCK_TOLERANCE_SECONDS;
+    });
+
+    it("should return empty options when no env vars are set", () => {
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts).toEqual({});
+    });
+
+    it("should include issuer when JWT_ISSUER is set", () => {
+      process.env.JWT_ISSUER = "revora-backend";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.issuer).toBe("revora-backend");
+    });
+
+    it("should include audience when JWT_AUDIENCE is set", () => {
+      process.env.JWT_AUDIENCE = "revora-api";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.audience).toBe("revora-api");
+    });
+
+    it("should include clockToleranceSeconds when JWT_CLOCK_TOLERANCE_SECONDS is valid", () => {
+      process.env.JWT_CLOCK_TOLERANCE_SECONDS = "60";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.clockToleranceSeconds).toBe(60);
+    });
+
+    it("should ignore non-numeric JWT_CLOCK_TOLERANCE_SECONDS", () => {
+      process.env.JWT_CLOCK_TOLERANCE_SECONDS = "abc";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.clockToleranceSeconds).toBeUndefined();
+    });
+
+    it("should ignore negative JWT_CLOCK_TOLERANCE_SECONDS", () => {
+      process.env.JWT_CLOCK_TOLERANCE_SECONDS = "-5";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.clockToleranceSeconds).toBeUndefined();
+    });
+
+    it("should ignore non-finite JWT_CLOCK_TOLERANCE_SECONDS", () => {
+      process.env.JWT_CLOCK_TOLERANCE_SECONDS = "Infinity";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.clockToleranceSeconds).toBeUndefined();
+    });
+
+    it("should include all options when all env vars are set", () => {
+      process.env.JWT_ISSUER = "revora-backend";
+      process.env.JWT_AUDIENCE = "revora-api";
+      process.env.JWT_CLOCK_TOLERANCE_SECONDS = "45";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts).toEqual({
+        issuer: "revora-backend",
+        audience: "revora-api",
+        clockToleranceSeconds: 45,
+      });
+    });
+
+    it("should accept zero as valid clockToleranceSeconds", () => {
+      process.env.JWT_CLOCK_TOLERANCE_SECONDS = "0";
+      const opts = getDefaultClaimValidationOptions();
+      expect(opts.clockToleranceSeconds).toBe(0);
+    });
+  });
+
+  // ── issueToken ──────────────────────────────────────────────────────────────
 
   describe("issueToken", () => {
     it("should issue a valid JWT token", () => {
@@ -114,7 +235,39 @@ describe("jwt utilities", () => {
       // exp - iat should be approximately 1800 seconds (30 minutes)
       expect(payload!.exp! - payload!.iat!).toBeCloseTo(1800, 0);
     });
+
+    it("should include issuer claim when issuer option is provided", () => {
+      const token = issueToken({ subject: "user-1", issuer: "revora-backend" });
+      const payload = decodePayload(token);
+      expect(payload?.iss).toBe("revora-backend");
+    });
+
+    it("should include audience claim when audience option is provided", () => {
+      const token = issueToken({ subject: "user-1", audience: "revora-api" });
+      const payload = decodePayload(token);
+      expect(payload?.aud).toBe("revora-api");
+    });
+
+    it("should include both issuer and audience when both are provided", () => {
+      const token = issueToken({
+        subject: "user-1",
+        issuer: "revora-backend",
+        audience: "revora-api",
+      });
+      const payload = decodePayload(token);
+      expect(payload?.iss).toBe("revora-backend");
+      expect(payload?.aud).toBe("revora-api");
+    });
+
+    it("should not include iss/aud claims when options are omitted", () => {
+      const token = issueToken({ subject: "user-1" });
+      const payload = decodePayload(token);
+      expect(payload?.iss).toBeUndefined();
+      expect(payload?.aud).toBeUndefined();
+    });
   });
+
+  // ── verifyToken ─────────────────────────────────────────────────────────────
 
   describe("verifyToken", () => {
     it("should verify valid token and return payload", () => {
@@ -156,7 +309,162 @@ describe("jwt utilities", () => {
 
       expect(() => verifyToken(modifiedToken)).toThrow();
     });
+
+    // ── Key rotation ──────────────────────────────────────────────────────────
+
+    describe("key rotation", () => {
+      afterEach(() => {
+        delete process.env.JWT_SECRET_PREVIOUS;
+      });
+
+      it("should verify token signed with current secret", () => {
+        const token = issueToken({ subject: "user-1" });
+        const payload = verifyToken(token);
+        expect(payload.sub).toBe("user-1");
+      });
+
+      it("should verify token signed with previous secret when JWT_SECRET_PREVIOUS is set", () => {
+        // Sign a token with the previous secret
+        process.env.JWT_SECRET = PREVIOUS_SECRET;
+        const token = issueToken({ subject: "user-rotated" });
+
+        // Now switch to a new current secret and set previous
+        process.env.JWT_SECRET = DEFAULT_JWT_SECRET;
+        process.env.JWT_SECRET_PREVIOUS = PREVIOUS_SECRET;
+
+        const payload = verifyToken(token);
+        expect(payload.sub).toBe("user-rotated");
+      });
+
+      it("should reject token signed with previous secret when JWT_SECRET_PREVIOUS is not set", () => {
+        // Sign a token with a different secret
+        process.env.JWT_SECRET = PREVIOUS_SECRET;
+        const token = issueToken({ subject: "user-stale" });
+
+        // Switch to current secret without setting previous
+        process.env.JWT_SECRET = DEFAULT_JWT_SECRET;
+        delete process.env.JWT_SECRET_PREVIOUS;
+
+        expect(() => verifyToken(token)).toThrow();
+      });
+
+      it("should reject token signed with an unknown secret even with rotation", () => {
+        process.env.JWT_SECRET = PREVIOUS_SECRET;
+        const token = issueToken({ subject: "user-unknown" });
+
+        process.env.JWT_SECRET = DEFAULT_JWT_SECRET;
+        process.env.JWT_SECRET_PREVIOUS = "another-previous-secret-key-that-is-32-chars!!";
+
+        expect(() => verifyToken(token)).toThrow();
+      });
+
+      it("should prefer current secret over previous when both match", () => {
+        // Token signed with current secret
+        const token = issueToken({ subject: "user-current" });
+        process.env.JWT_SECRET_PREVIOUS = PREVIOUS_SECRET;
+
+        const payload = verifyToken(token);
+        expect(payload.sub).toBe("user-current");
+      });
+
+      it("should reject token signed with a short previous secret", () => {
+        // Sign with a short secret (not actually possible via issueToken, but
+        // we construct the scenario by setting JWT_SECRET_PREVIOUS to short)
+        process.env.JWT_SECRET_PREVIOUS = "too-short";
+        const token = issueToken({ subject: "user-1" });
+        // Token was signed with current, so it should still verify
+        const payload = verifyToken(token);
+        expect(payload.sub).toBe("user-1");
+      });
+    });
+
+    // ── Clock skew tolerance ──────────────────────────────────────────────────
+
+    describe("clock skew tolerance", () => {
+      it("should accept a token that expired within clock tolerance", () => {
+        // Issue a token that expired 10 seconds ago
+        const token = issueToken({ subject: "user-1", expiresIn: "-10s" });
+
+        // With default 30s tolerance, this should still be valid
+        const payload = verifyToken(token, { clockToleranceSeconds: 30 });
+        expect(payload.sub).toBe("user-1");
+      });
+
+      it("should reject a token that expired beyond clock tolerance", () => {
+        const token = issueToken({ subject: "user-1", expiresIn: "-60s" });
+
+        expect(() => verifyToken(token, { clockToleranceSeconds: 30 })).toThrow(
+          "Token has expired",
+        );
+      });
+
+      it("should reject an expired token with zero tolerance", () => {
+        const token = issueToken({ subject: "user-1", expiresIn: "-1s" });
+
+        expect(() => verifyToken(token, { clockToleranceSeconds: 0 })).toThrow(
+          "Token has expired",
+        );
+      });
+
+      it("should accept a barely-expired token with large tolerance", () => {
+        const token = issueToken({ subject: "user-1", expiresIn: "-90s" });
+
+        const payload = verifyToken(token, { clockToleranceSeconds: 120 });
+        expect(payload.sub).toBe("user-1");
+      });
+    });
+
+    // ── Issuer/audience validation via verifyToken ────────────────────────────
+
+    describe("issuer and audience validation", () => {
+      it("should reject token with wrong issuer when options.issuer is set", () => {
+        const token = issueToken({ subject: "user-1", issuer: "wrong-issuer" });
+        expect(() =>
+          verifyToken(token, { issuer: "revora-backend" }),
+        ).toThrow(/issuer mismatch/i);
+      });
+
+      it("should accept token with matching issuer", () => {
+        const token = issueToken({ subject: "user-1", issuer: "revora-backend" });
+        const payload = verifyToken(token, { issuer: "revora-backend" });
+        expect(payload.sub).toBe("user-1");
+      });
+
+      it("should reject token with wrong audience when options.audience is set", () => {
+        const token = issueToken({ subject: "user-1", audience: "wrong-api" });
+        expect(() =>
+          verifyToken(token, { audience: "revora-api" }),
+        ).toThrow(/audience mismatch/i);
+      });
+
+      it("should accept token with matching audience", () => {
+        const token = issueToken({ subject: "user-1", audience: "revora-api" });
+        const payload = verifyToken(token, { audience: "revora-api" });
+        expect(payload.sub).toBe("user-1");
+      });
+
+      it("should skip issuer/audience checks when options are not provided", () => {
+        const token = issueToken({ subject: "user-1" });
+        const payload = verifyToken(token);
+        expect(payload.sub).toBe("user-1");
+      });
+
+      it("should validate both issuer and audience together", () => {
+        const token = issueToken({
+          subject: "user-1",
+          issuer: "revora-backend",
+          audience: "revora-api",
+        });
+        const payload = verifyToken(token, {
+          issuer: "revora-backend",
+          audience: "revora-api",
+        });
+        expect(payload.sub).toBe("user-1");
+      });
+    });
   });
+
+  // ── decodePayload ──────────────────────────────────────────────────────────
 
   describe("decodePayload", () => {
     it("should decode valid token without verification", () => {
@@ -186,6 +494,8 @@ describe("jwt utilities", () => {
     });
   });
 
+  // ── issueRefreshToken ──────────────────────────────────────────────────────
+
   describe("issueRefreshToken", () => {
     it("should issue refresh token with 7 day expiry", () => {
       const token = issueRefreshToken("user-123");
@@ -198,12 +508,16 @@ describe("jwt utilities", () => {
     });
   });
 
+  // ── TOKEN_EXPIRY and REFRESH_TOKEN_EXPIRY ──────────────────────────────────
+
   describe("TOKEN_EXPIRY and REFRESH_TOKEN_EXPIRY", () => {
     it("should have correct default values", () => {
       expect(TOKEN_EXPIRY).toBe("1h");
       expect(REFRESH_TOKEN_EXPIRY).toBe("7d");
     });
   });
+
+  // ── validateClaims ─────────────────────────────────────────────────────────
 
   describe("validateClaims", () => {
     const now = Math.floor(Date.now() / 1000);
@@ -225,6 +539,11 @@ describe("jwt utilities", () => {
 
     it("should throw when sub is whitespace only", () => {
       const payload = { ...basePayload, sub: "   " };
+      expect(() => validateClaims(payload)).toThrow(/subject.*sub/i);
+    });
+
+    it("should throw when sub is not a string", () => {
+      const payload = { ...basePayload, sub: 123 as unknown as string };
       expect(() => validateClaims(payload)).toThrow(/subject.*sub/i);
     });
 
@@ -270,6 +589,12 @@ describe("jwt utilities", () => {
       expect(() => validateClaims(payload)).not.toThrow();
     });
 
+    it("should throw when issuer is expected but payload has no iss claim", () => {
+      const payload: JwtPayload = { ...basePayload }; // no iss
+      const opts: ClaimValidationOptions = { issuer: "revora-backend" };
+      expect(() => validateClaims(payload, opts)).toThrow(/issuer mismatch/i);
+    });
+
     it("should throw on audience mismatch (string aud)", () => {
       const payload: JwtPayload = { ...basePayload, aud: "other-app" };
       const opts: ClaimValidationOptions = { audience: "revora-api" };
@@ -299,12 +624,28 @@ describe("jwt utilities", () => {
       expect(() => validateClaims(payload)).not.toThrow();
     });
 
+    it("should throw when audience is expected but payload has no aud claim", () => {
+      const payload: JwtPayload = { ...basePayload }; // no aud
+      const opts: ClaimValidationOptions = { audience: "revora-api" };
+      expect(() => validateClaims(payload, opts)).toThrow(/audience mismatch/i);
+    });
+
     it("should respect custom clockToleranceSeconds", () => {
       const payload: JwtPayload = { ...basePayload, exp: now - 60 };
       // With 0s tolerance, should throw
       expect(() => validateClaims(payload, { clockToleranceSeconds: 0 })).toThrow("Token has expired");
       // With 120s tolerance, should pass
       expect(() => validateClaims(payload, { clockToleranceSeconds: 120 })).not.toThrow();
+    });
+
+    it("should use default 30s tolerance when clockToleranceSeconds is not specified", () => {
+      // Token expired 20s ago — within default 30s tolerance
+      const payloadOk: JwtPayload = { ...basePayload, exp: now - 20 };
+      expect(() => validateClaims(payloadOk)).not.toThrow();
+
+      // Token expired 40s ago — beyond default 30s tolerance
+      const payloadFail: JwtPayload = { ...basePayload, exp: now - 40 };
+      expect(() => validateClaims(payloadFail)).toThrow("Token has expired");
     });
   });
 });

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,13 +1,22 @@
 import jwt from "jsonwebtoken";
+import { globalLogger } from "./logger";
 
 /**
  * JWT Configuration
  *
  * Secret: Must be set via JWT_SECRET environment variable
+ * Key Rotation: Set JWT_SECRET_PREVIOUS for seamless secret rotation
  * Algorithm: HS256 (HMAC SHA256)
+ * Clock Skew: Configurable via JWT_CLOCK_TOLERANCE_SECONDS (default 30s)
+ * Issuer: Optional, set via JWT_ISSUER
+ * Audience: Optional, set via JWT_AUDIENCE
  *
- * Example .env entry:
+ * Example .env entries:
  * JWT_SECRET=your-secure-secret-key-min-32-chars
+ * JWT_SECRET_PREVIOUS=your-previous-secret-key-min-32-chars
+ * JWT_ISSUER=revora-backend
+ * JWT_AUDIENCE=revora-api
+ * JWT_CLOCK_TOLERANCE_SECONDS=30
  */
 
 // Default expiry times
@@ -36,6 +45,10 @@ export interface TokenOptions {
   expiresIn?: string;
   subject: string;
   email?: string;
+  /** @param issuer Value for the `iss` claim. When set, included in the signed token. */
+  issuer?: string;
+  /** @param audience Value for the `aud` claim. When set, included in the signed token. */
+  audience?: string;
   additionalPayload?: Record<string, unknown>;
 }
 
@@ -128,6 +141,49 @@ export function getJwtAlgorithm(): jwt.Algorithm {
 }
 
 /**
+ * @notice Returns all valid JWT secrets for token verification, supporting key rotation.
+ * @dev The current JWT_SECRET is always first. If JWT_SECRET_PREVIOUS is set and meets
+ *      the minimum length requirement (32 chars), it is appended as a fallback.
+ *      Tokens signed with the previous secret remain valid until they naturally expire,
+ *      enabling seamless key rotation without forcing re-authentication.
+ * @returns Array of secrets ordered by priority (current first).
+ * @throws {Error} If the current JWT_SECRET is missing or too short.
+ */
+export function getJwtSecretsForVerification(): string[] {
+  const current = getJwtSecret();
+  const previous = process.env.JWT_SECRET_PREVIOUS;
+  if (previous && previous.length >= 32) {
+    return [current, previous];
+  }
+  return [current];
+}
+
+/**
+ * @notice Returns default claim validation options derived from environment variables.
+ * @dev Used by middleware to consistently enforce issuer, audience, and clock skew
+ *      across all verification points without manual configuration at each call site.
+ *      When JWT_CLOCK_TOLERANCE_SECONDS is not set or invalid, the validateClaims
+ *      default of 30 seconds applies.
+ * @returns ClaimValidationOptions with values from JWT_ISSUER, JWT_AUDIENCE, and
+ *          JWT_CLOCK_TOLERANCE_SECONDS when set.
+ */
+export function getDefaultClaimValidationOptions(): ClaimValidationOptions {
+  const opts: ClaimValidationOptions = {};
+  const issuer = process.env.JWT_ISSUER;
+  const audience = process.env.JWT_AUDIENCE;
+  const tolerance = process.env.JWT_CLOCK_TOLERANCE_SECONDS;
+  if (issuer) opts.issuer = issuer;
+  if (audience) opts.audience = audience;
+  if (tolerance) {
+    const parsed = parseInt(tolerance, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      opts.clockToleranceSeconds = parsed;
+    }
+  }
+  return opts;
+}
+
+/**
  * Issue a new JWT token
  *
  * @param options - Token generation options
@@ -155,6 +211,8 @@ export function issueToken(options: TokenOptions): string {
   const signOptions: jwt.SignOptions = {
     algorithm,
     expiresIn: (options.expiresIn || TOKEN_EXPIRY) as jwt.SignOptions["expiresIn"],
+    ...(options.issuer && { issuer: options.issuer }),
+    ...(options.audience && { audience: options.audience }),
   };
 
   return jwt.sign(payload, secret, signOptions);
@@ -191,8 +249,19 @@ export function decodePayload(token: string): JwtPayload | null {
 
 /**
  * @notice Verify and decode a JWT token, then validate its standard claims.
- * @dev Uses jsonwebtoken for HMAC-HS256 signature verification, then calls
- *      validateClaims for explicit per-claim enforcement.
+ * @dev Uses jsonwebtoken for HMAC-HS256 signature verification across all
+ *      configured secrets (current + previous for key rotation), then calls
+ *      validateClaims for explicit per-claim enforcement including clock skew.
+ *
+ *      Clock skew handling: jsonwebtoken's built-in time checks (exp, nbf) are
+ *      disabled so that validateClaims can enforce them with the configurable
+ *      clock-skew tolerance window. This ensures tokens that are slightly expired
+ *      due to clock drift between servers are not incorrectly rejected.
+ *
+ *      Key rotation: When JWT_SECRET_PREVIOUS is configured, tokens signed with
+ *      the old secret remain valid. The first secret that successfully verifies
+ *      the signature wins. Structured logging records which secret was used.
+ *
  * @param token JWT token string to verify.
  * @param options Optional claim validation configuration.
  * @returns Decoded and validated JwtPayload.
@@ -202,19 +271,48 @@ export function verifyToken(
   token: string,
   options?: ClaimValidationOptions,
 ): JwtPayload {
-  const secret = getJwtSecret();
+  const secrets = getJwtSecretsForVerification();
   const algorithm = getJwtAlgorithm();
 
-  let payload: JwtPayload;
-  try {
-    payload = jwt.verify(token, secret, {
-      algorithms: [algorithm],
-    }) as JwtPayload;
-  } catch (err: unknown) {
-    if (err instanceof Error && err.name === 'TokenExpiredError') {
-      throw new Error('Token has expired');
+  let payload: JwtPayload | null = null;
+  let lastError: Error | null = null;
+  let usedSecretIndex = -1;
+
+  for (let i = 0; i < secrets.length; i++) {
+    try {
+      // Disable jsonwebtoken's built-in time-based checks; validateClaims
+      // handles exp, nbf, and iat with configurable clock-skew tolerance.
+      payload = jwt.verify(token, secrets[i], {
+        algorithms: [algorithm],
+        ignoreExpiration: true,
+        ignoreNotBefore: true,
+      }) as JwtPayload;
+      usedSecretIndex = i;
+      break;
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        lastError = err;
+      } else {
+        lastError = new Error(String(err));
+      }
+      // Signature mismatch — try next secret for key rotation.
+      continue;
     }
-    throw err;
+  }
+
+  if (!payload) {
+    globalLogger.warn('JWT signature verification failed against all configured secrets', {
+      error: lastError?.message,
+      secretCount: secrets.length,
+    });
+    throw lastError ?? new Error('Token verification failed');
+  }
+
+  // Log key rotation usage for operational visibility
+  if (secrets.length > 1 && usedSecretIndex > 0) {
+    globalLogger.info('JWT verified with previous secret (key rotation in progress)', {
+      secretIndex: usedSecretIndex,
+    });
   }
 
   validateClaims(payload, options);

--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -5,6 +5,7 @@ import { hashSessionToken } from '../auth/session';
 import { signJwt } from '../utils/jwt';
 import { issueToken } from '../lib/jwt';
 import { AuthenticatedRequest as LogoutAuthenticatedRequest } from '../auth/logout/types';
+import { AppError } from '../lib/errors';
 
 // ── Shared secret setup ───────────────────────────────────────────────────────
 beforeAll(() => {
@@ -13,6 +14,7 @@ beforeAll(() => {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const SECRET = process.env.JWT_SECRET ?? 'test-secret-that-is-long-enough-32chars!';
+const PREVIOUS_SECRET = 'previous-secret-that-is-long-enough-32chars!!';
 
 function makeJwtToken(
   payload: Record<string, unknown>,
@@ -31,6 +33,15 @@ function mockRes() {
   } as unknown as Response;
 }
 
+/** Helper: assert next() was called with an AppError having the given statusCode */
+function expectAppError(next: jest.Mock, statusCode: number): AppError {
+  expect(next).toHaveBeenCalled();
+  const err = next.mock.calls[0][0] as AppError;
+  expect(err).toBeInstanceOf(AppError);
+  expect(err.statusCode).toBe(statusCode);
+  return err;
+}
+
 // ── requireAuth (feature/change-password-api) ─────────────────────────────────
 describe('requireAuth middleware', () => {
   const mockNext: NextFunction = jest.fn();
@@ -43,6 +54,7 @@ describe('requireAuth middleware', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.JWT_SECRET_PREVIOUS;
 
     sessionRepo = {
       findById: jest.fn().mockResolvedValue(null),
@@ -67,57 +79,136 @@ describe('requireAuth middleware', () => {
 
     await requireAuth(req as Request, res, mockNext);
 
-    expect(mockNext).toHaveBeenCalled();
+    expect(mockNext).toHaveBeenCalledWith();
     expect(req.auth?.userId).toBe('user-123');
     expect(req.auth?.sessionId).toBe('session-abc');
     expect(req.auth?.tokenId).toBe(token);
   });
 
-  it('returns 401 when Authorization header is missing', async () => {
+  it('calls next with 401 AppError when Authorization header is missing', async () => {
     const req = makeReq();
     const res = mockRes();
 
     await requireAuth(req as Request, res, mockNext);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockNext).not.toHaveBeenCalled();
+    expectAppError(mockNext, 401);
   });
 
-  it('returns 401 when the header is not Bearer scheme', async () => {
+  it('calls next with 401 AppError when the header is not Bearer scheme', async () => {
     const req = makeReq('Basic dXNlcjpwYXNz');
     const res = mockRes();
 
     await requireAuth(req as Request, res, mockNext);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockNext).not.toHaveBeenCalled();
+    expectAppError(mockNext, 401);
   });
 
-  it('returns 401 for an invalid/tampered token', async () => {
+  it('calls next with 401 AppError for an invalid/tampered token', async () => {
     const req = makeReq('Bearer invalid.token.here');
     const res = mockRes();
 
     await requireAuth(req as Request, res, mockNext);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockNext).not.toHaveBeenCalled();
+    expectAppError(mockNext, 401);
   });
 
-  it('returns 401 for an expired token', async () => {
+  it('calls next with 401 AppError for an expired token', async () => {
     const token = signJwt({ sub: 'user-123', sid: 'session-abc' }, '-1s');
     const req = makeReq(`Bearer ${token}`);
     const res = mockRes();
 
     await requireAuth(req as Request, res, mockNext);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockNext).not.toHaveBeenCalled();
+    expectAppError(mockNext, 401);
+  });
+
+  it('calls next with 401 AppError when session is not found', async () => {
+    const token = signJwt({ sub: 'user-123', sid: 'session-abc' });
+    sessionRepo.findById.mockResolvedValueOnce(null);
+
+    const req = makeReq(`Bearer ${token}`);
+    const res = mockRes();
+
+    await requireAuth(req as Request, res, mockNext);
+
+    expectAppError(mockNext, 401);
+  });
+
+  it('calls next with 401 AppError when session user_id mismatches', async () => {
+    const token = signJwt({ sub: 'user-123', sid: 'session-abc' });
+    sessionRepo.findById.mockResolvedValueOnce({
+      id: 'session-abc',
+      user_id: 'different-user',
+      token_hash: hashSessionToken(token),
+      expires_at: new Date(Date.now() + 10 * 60 * 1000),
+      created_at: new Date(),
+    });
+
+    const req = makeReq(`Bearer ${token}`);
+    const res = mockRes();
+
+    await requireAuth(req as Request, res, mockNext);
+
+    expectAppError(mockNext, 401);
+  });
+
+  it('calls next with 401 AppError when session is expired', async () => {
+    const token = signJwt({ sub: 'user-123', sid: 'session-abc' });
+    sessionRepo.findById.mockResolvedValueOnce({
+      id: 'session-abc',
+      user_id: 'user-123',
+      token_hash: hashSessionToken(token),
+      expires_at: new Date(Date.now() - 10 * 60 * 1000),
+      created_at: new Date(),
+    });
+
+    const req = makeReq(`Bearer ${token}`);
+    const res = mockRes();
+
+    await requireAuth(req as Request, res, mockNext);
+
+    expectAppError(mockNext, 401);
+  });
+
+  it('calls next with 401 AppError when token hash mismatches', async () => {
+    const token = signJwt({ sub: 'user-123', sid: 'session-abc' });
+    sessionRepo.findById.mockResolvedValueOnce({
+      id: 'session-abc',
+      user_id: 'user-123',
+      token_hash: 'wrong-hash',
+      expires_at: new Date(Date.now() + 10 * 60 * 1000),
+      created_at: new Date(),
+    });
+
+    const req = makeReq(`Bearer ${token}`);
+    const res = mockRes();
+
+    await requireAuth(req as Request, res, mockNext);
+
+    expectAppError(mockNext, 401);
+  });
+
+  it('calls next with 500 AppError when JWT_SECRET is not configured', async () => {
+    delete process.env.JWT_SECRET;
+    const token = makeJwtToken({ sub: 'user-1', role: 'investor' });
+    const req = makeReq(`Bearer ${token}`);
+    const res = mockRes();
+
+    await requireAuth(req as Request, res, mockNext);
+
+    expectAppError(mockNext, 500);
+    process.env.JWT_SECRET = SECRET;
   });
 });
 
 // ── authMiddleware (master — JWT factory fn) ──────────────────────────────────
 describe('authMiddleware', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.JWT_SECRET_PREVIOUS;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+  });
 
   describe('valid token', () => {
     it('attaches user to request with valid token', () => {
@@ -128,7 +219,7 @@ describe('authMiddleware', () => {
 
       authMiddleware()(req, res, next);
 
-      expect(next).toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith();
       expect((req as AuthenticatedRequest).user?.sub).toBe('user-123');
       expect((req as AuthenticatedRequest).user?.email).toBe('test@example.com');
     });
@@ -140,52 +231,46 @@ describe('authMiddleware', () => {
 
       authMiddleware()(req, mockRes(), next);
 
-      expect(next).toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith();
       expect((req as AuthenticatedRequest).user?.sub).toBe('user-456');
     });
   });
 
   describe('missing token', () => {
-    it('returns 401 when Authorization header is missing', () => {
+    it('calls next with 401 AppError when Authorization header is missing', () => {
       const req = { headers: {} } as Request;
       const res = mockRes();
       const next = jest.fn();
 
       authMiddleware()(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Unauthorized',
-        message: 'Authorization header missing',
-      });
-      expect(next).not.toHaveBeenCalled();
+      const err = expectAppError(next, 401);
+      expect(err.message).toBe('Authorization header missing');
     });
   });
 
   describe('invalid token', () => {
-    it('returns 401 with invalid token format', () => {
+    it('calls next with 401 AppError for invalid token format', () => {
       const req = { headers: { authorization: 'InvalidFormat token123' } } as Request;
       const res = mockRes();
       const next = jest.fn();
 
       authMiddleware()(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(next).not.toHaveBeenCalled();
+      expectAppError(next, 401);
     });
 
-    it('returns 401 with malformed token', () => {
+    it('calls next with 401 AppError for malformed token', () => {
       const req = { headers: { authorization: 'Bearer not-a-valid-jwt' } } as Request;
       const res = mockRes();
       const next = jest.fn();
 
       authMiddleware()(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(next).not.toHaveBeenCalled();
+      expectAppError(next, 401);
     });
 
-    it('returns 401 with wrong secret', () => {
+    it('calls next with 401 AppError for wrong secret', () => {
       const req = {
         headers: {
           authorization:
@@ -197,13 +282,12 @@ describe('authMiddleware', () => {
 
       authMiddleware()(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(next).not.toHaveBeenCalled();
+      expectAppError(next, 401);
     });
   });
 
   describe('expired token', () => {
-    it('returns 401 with expired token', () => {
+    it('calls next with 401 AppError for expired token', () => {
       const token = issueToken({ subject: 'user-123', expiresIn: '-1s' });
       const req = { headers: { authorization: `Bearer ${token}` } } as Request;
       const res = mockRes();
@@ -211,8 +295,26 @@ describe('authMiddleware', () => {
 
       authMiddleware()(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(next).not.toHaveBeenCalled();
+      expectAppError(next, 401);
+    });
+  });
+
+  describe('JWT_SECRET misconfiguration', () => {
+    it('calls next with 500 AppError when JWT_SECRET is not set', () => {
+      const original = process.env.JWT_SECRET;
+      delete process.env.JWT_SECRET;
+      const token = issueToken({ subject: 'user-1' });
+      process.env.JWT_SECRET = original;
+      delete process.env.JWT_SECRET;
+
+      const req = { headers: { authorization: `Bearer ${token}` } } as Request;
+      const res = mockRes();
+      const next = jest.fn();
+
+      authMiddleware()(req, res, next);
+
+      expectAppError(next, 500);
+      process.env.JWT_SECRET = original;
     });
   });
 });
@@ -246,13 +348,43 @@ describe('verifyJwt', () => {
     const token = makeJwtToken({ sub: 'user-1', role: 'investor', exp: futureExp });
     expect(verifyJwt(token, SECRET).sub).toBe('user-1');
   });
+
+  // ── Key rotation for verifyJwt ──────────────────────────────────────────────
+
+  describe('key rotation', () => {
+    it('verifies token with current secret when given an array of secrets', () => {
+      const token = makeJwtToken({ sub: 'user-1', role: 'investor' }, SECRET);
+      const payload = verifyJwt(token, [SECRET, PREVIOUS_SECRET]);
+      expect(payload.sub).toBe('user-1');
+    });
+
+    it('verifies token with previous secret when current fails', () => {
+      const token = makeJwtToken({ sub: 'user-rotated', role: 'investor' }, PREVIOUS_SECRET);
+      const payload = verifyJwt(token, [SECRET, PREVIOUS_SECRET]);
+      expect(payload.sub).toBe('user-rotated');
+    });
+
+    it('throws when no secret in the array matches', () => {
+      const token = makeJwtToken({ sub: 'user-1', role: 'investor' }, 'third-secret-not-in-array');
+      expect(() => verifyJwt(token, [SECRET, PREVIOUS_SECRET])).toThrow('Invalid token signature');
+    });
+
+    it('works with a single-element array', () => {
+      const token = makeJwtToken({ sub: 'user-1', role: 'investor' }, SECRET);
+      const payload = verifyJwt(token, [SECRET]);
+      expect(payload.sub).toBe('user-1');
+    });
+  });
 });
 
 // ── requireInvestor ───────────────────────────────────────────────────────────
 describe('requireInvestor', () => {
   const originalSecret = process.env.JWT_SECRET;
 
-  beforeEach(() => { process.env.JWT_SECRET = SECRET; });
+  beforeEach(() => {
+    process.env.JWT_SECRET = SECRET;
+    delete process.env.JWT_SECRET_PREVIOUS;
+  });
   afterEach(() => {
     if (originalSecret === undefined) delete process.env.JWT_SECRET;
     else process.env.JWT_SECRET = originalSecret;
@@ -268,60 +400,63 @@ describe('requireInvestor', () => {
 
     requireInvestor(req, mockRes(), next);
 
-    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
     expect((req as AuthenticatedRequest).user).toEqual({ id: 'investor-1', role: 'investor' });
   });
 
-  it('returns 401 when Authorization header is missing', () => {
-    const res = mockRes();
+  it('calls next with 401 AppError when Authorization header is missing', () => {
     const next: NextFunction = jest.fn();
 
-    requireInvestor(makeReq(), res, next);
+    requireInvestor(makeReq(), mockRes(), next);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(next).not.toHaveBeenCalled();
+    expectAppError(next, 401);
   });
 
-  it('returns 401 for Basic auth', () => {
-    const res = mockRes();
+  it('calls next with 401 AppError for Basic auth', () => {
     const next: NextFunction = jest.fn();
 
-    requireInvestor(makeReq('Basic some-credentials'), res, next);
+    requireInvestor(makeReq('Basic some-credentials'), mockRes(), next);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(next).not.toHaveBeenCalled();
+    expectAppError(next, 401);
   });
 
-  it('returns 401 for an invalid token', () => {
-    const res = mockRes();
+  it('calls next with 401 AppError for an invalid token', () => {
     const next: NextFunction = jest.fn();
 
-    requireInvestor(makeReq('Bearer invalid.token.here'), res, next);
+    requireInvestor(makeReq('Bearer invalid.token.here'), mockRes(), next);
 
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(next).not.toHaveBeenCalled();
+    expectAppError(next, 401);
   });
 
-  it('returns 403 for a non-investor role', () => {
+  it('calls next with 403 AppError for a non-investor role', () => {
     const token = makeJwtToken({ sub: 'admin-1', role: 'admin' });
-    const res = mockRes();
     const next: NextFunction = jest.fn();
 
-    requireInvestor(makeReq(`Bearer ${token}`), res, next);
+    requireInvestor(makeReq(`Bearer ${token}`), mockRes(), next);
 
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(next).not.toHaveBeenCalled();
+    expectAppError(next, 403);
   });
 
-  it('returns 500 when JWT_SECRET is not set', () => {
+  it('calls next with 500 AppError when JWT_SECRET is not set', () => {
     delete process.env.JWT_SECRET;
     const token = makeJwtToken({ sub: 'investor-1', role: 'investor' });
-    const res = mockRes();
     const next: NextFunction = jest.fn();
 
-    requireInvestor(makeReq(`Bearer ${token}`), res, next);
+    requireInvestor(makeReq(`Bearer ${token}`), mockRes(), next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(next).not.toHaveBeenCalled();
+    expectAppError(next, 500);
+  });
+
+  it('verifies investor token signed with previous secret when JWT_SECRET_PREVIOUS is set', () => {
+    const token = makeJwtToken({ sub: 'investor-1', role: 'investor' }, PREVIOUS_SECRET);
+    process.env.JWT_SECRET_PREVIOUS = PREVIOUS_SECRET;
+
+    const req = makeReq(`Bearer ${token}`);
+    const next: NextFunction = jest.fn();
+
+    requireInvestor(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect((req as AuthenticatedRequest).user).toEqual({ id: 'investor-1', role: 'investor' });
   });
 });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,9 +1,11 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
-import { verifyToken, JwtPayload } from '../lib/jwt';
+import { verifyToken, JwtPayload, getDefaultClaimValidationOptions, getJwtSecretsForVerification } from '../lib/jwt';
 import crypto from 'crypto';
 import { AuthContext, AuthenticatedRequest as LogoutAuthenticatedRequest } from '../auth/logout/types';
 import { SessionRepository as DbSessionRepository } from '../db/repositories/sessionRepository';
 import { hashSessionToken, isSessionExpired } from '../auth/session';
+import { Errors, AppError, ErrorCode } from '../lib/errors';
+import { globalLogger } from '../lib/logger';
 
 // ── AuthenticatedRequest (JWT / sub-based) ────────────────────────────────────
 export interface AuthenticatedRequest extends Request {
@@ -19,27 +21,25 @@ export interface AuthenticatedRequest extends Request {
 
 // ── authMiddleware (Bearer JWT via lib/jwt) ───────────────────────────────────
 export function authMiddleware(): RequestHandler {
-  return (req: Request, res: Response, next: NextFunction) => {
+  return (req: Request, _res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
 
     if (!authHeader) {
-      res.status(401).json({ error: 'Unauthorized', message: 'Authorization header missing' });
+      next(Errors.unauthorized('Authorization header missing'));
       return;
     }
 
     const parts = authHeader.split(' ');
     if (parts.length !== 2 || parts[0] !== 'Bearer') {
-      res.status(401).json({
-        error: 'Unauthorized',
-        message: 'Invalid authorization header format. Expected: Bearer <token>',
-      });
+      next(Errors.unauthorized('Invalid authorization header format. Expected: Bearer <token>'));
       return;
     }
 
     const token = parts[1];
 
     try {
-      const payload = verifyToken(token);
+      const claimOpts = getDefaultClaimValidationOptions();
+      const payload = verifyToken(token, claimOpts);
       (req as AuthenticatedRequest).user = {
         ...payload,
         sub: payload.sub,
@@ -47,12 +47,14 @@ export function authMiddleware(): RequestHandler {
       };
       next();
     } catch (error) {
-      let errorMessage = 'Invalid or expired token';
-      if (error instanceof Error) {
-        if (error.name === 'TokenExpiredError') errorMessage = 'Token has expired';
-        else if (error.name === 'JsonWebTokenError') errorMessage = 'Invalid token signature';
+      if (error instanceof Error && error.message.includes('JWT_SECRET')) {
+        next(Errors.internal('Server configuration error'));
+        return;
       }
-      res.status(401).json({ error: 'Unauthorized', message: errorMessage });
+      globalLogger.warn('JWT verification failed in authMiddleware', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      next(Errors.unauthorized('Invalid or expired token'));
     }
   };
 }
@@ -76,7 +78,8 @@ export function optionalAuthMiddleware(): RequestHandler {
     }
 
     try {
-      const payload = verifyToken(parts[1]);
+      const claimOpts = getDefaultClaimValidationOptions();
+      const payload = verifyToken(parts[1], claimOpts);
       (req as AuthenticatedRequest).user = {
         ...payload,
         sub: payload.sub,
@@ -99,22 +102,42 @@ interface JwtPayloadInternal {
   exp?: number;
 }
 
-export function verifyJwt(token: string, secret: string): JwtPayloadInternal {
+/**
+ * @notice Verify a JWT using raw HMAC-SHA256 with key rotation support.
+ * @dev Accepts a single secret or an array of secrets (current first, previous second).
+ *      The first secret that produces a valid signature wins.
+ * @param token JWT string to verify.
+ * @param secretOrSecrets One or more HMAC secrets to try, in priority order.
+ * @returns Decoded payload if signature and expiry are valid.
+ * @throws {Error} If the token format, signature, or expiry is invalid.
+ */
+export function verifyJwt(token: string, secretOrSecrets: string | string[]): JwtPayloadInternal {
+  const secrets = Array.isArray(secretOrSecrets) ? secretOrSecrets : [secretOrSecrets];
   const parts = token.split('.');
   if (parts.length !== 3) throw new Error('Invalid token format');
 
   const [headerB64, payloadB64, signatureB64] = parts;
 
-  const expectedSig = crypto
-    .createHmac('sha256', secret)
-    .update(`${headerB64}.${payloadB64}`)
-    .digest('base64url');
+  let payload: JwtPayloadInternal | null = null;
+  for (const secret of secrets) {
+    const expectedSig = crypto
+      .createHmac('sha256', secret)
+      .update(`${headerB64}.${payloadB64}`)
+      .digest('base64url');
 
-  if (expectedSig !== signatureB64) throw new Error('Invalid token signature');
+    if (expectedSig === signatureB64) {
+      try {
+        payload = JSON.parse(
+          Buffer.from(payloadB64, 'base64url').toString('utf8'),
+        ) as JwtPayloadInternal;
+        break;
+      } catch {
+        continue;
+      }
+    }
+  }
 
-  const payload: JwtPayloadInternal = JSON.parse(
-    Buffer.from(payloadB64, 'base64url').toString('utf8'),
-  );
+  if (!payload) throw new Error('Invalid token signature');
 
   if (payload.exp !== undefined && payload.exp < Math.floor(Date.now() / 1000)) {
     throw new Error('Token expired');
@@ -124,31 +147,30 @@ export function verifyJwt(token: string, secret: string): JwtPayloadInternal {
 }
 
 // ── requireInvestor ───────────────────────────────────────────────────────────
-export function requireInvestor(req: Request, res: Response, next: NextFunction): void {
+export function requireInvestor(req: Request, _res: Response, next: NextFunction): void {
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    next(Errors.unauthorized('Missing or invalid Authorization header'));
     return;
   }
 
   const token = authHeader.slice(7);
-  const secret = process.env.JWT_SECRET;
-
-  if (!secret) {
-    res.status(500).json({ error: 'Server configuration error' });
-    return;
-  }
 
   try {
-    const payload = verifyJwt(token, secret);
+    const secrets = getJwtSecretsForVerification();
+    const payload = verifyJwt(token, secrets);
     if (payload.role !== 'investor') {
-      res.status(403).json({ error: 'Forbidden: investor role required' });
+      next(Errors.forbidden('investor role required'));
       return;
     }
     (req as AuthenticatedRequest).user = { id: payload.sub, role: 'investor' };
     next();
-  } catch {
-    res.status(401).json({ error: 'Invalid or expired token' });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('JWT_SECRET')) {
+      next(Errors.internal('Server configuration error'));
+      return;
+    }
+    next(Errors.unauthorized('Invalid or expired token'));
   }
 }
 
@@ -157,12 +179,12 @@ export function requireInvestor(req: Request, res: Response, next: NextFunction)
 // this const shadows the factory fn for issuer-only routes.
 export const requireIssuerAuth = (
   req: AuthenticatedRequest,
-  res: Response,
+  _res: Response,
   next: NextFunction,
 ): void => {
   const issuerId = req.header('X-Issuer-Id');
   if (!issuerId) {
-    res.status(401).json({ error: 'Unauthorized: Missing Issuer ID' });
+    next(Errors.unauthorized('Missing Issuer ID'));
     return;
   }
   req.user = { id: issuerId, role: 'issuer' };
@@ -171,10 +193,10 @@ export const requireIssuerAuth = (
 
 // ── createRequireAuth (session-hardened)
 export function createRequireAuth(sessionRepository: DbSessionRepository): RequestHandler {
-  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  return async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      res.status(401).json({ error: 'Unauthorized: Missing or invalid Authorization header' });
+      next(Errors.unauthorized('Missing or invalid Authorization header'));
       return;
     }
 
@@ -182,31 +204,39 @@ export function createRequireAuth(sessionRepository: DbSessionRepository): Reque
     let payload: JwtPayload;
 
     try {
-      payload = verifyToken(token);
+      const claimOpts = getDefaultClaimValidationOptions();
+      payload = verifyToken(token, claimOpts);
     } catch (err) {
-      res.status(401).json({ error: 'Unauthorized: invalid or expired token' });
+      if (err instanceof Error && err.message.includes('JWT_SECRET')) {
+        next(Errors.internal('Server configuration error'));
+        return;
+      }
+      globalLogger.warn('JWT verification failed in createRequireAuth', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      next(Errors.unauthorized('Invalid or expired token'));
       return;
     }
 
     if (!payload.sub || !payload.sid) {
-      res.status(401).json({ error: 'Unauthorized: token missing subject or session' });
+      next(Errors.unauthorized('Token missing subject or session'));
       return;
     }
 
     const session = await sessionRepository.findById(payload.sid);
 
     if (!session || session.user_id !== payload.sub) {
-      res.status(401).json({ error: 'Unauthorized: session not found or user mismatch' });
+      next(Errors.unauthorized('Session not found or user mismatch'));
       return;
     }
 
     if (isSessionExpired(session.expires_at)) {
-      res.status(401).json({ error: 'Unauthorized: session expired' });
+      next(Errors.unauthorized('Session expired'));
       return;
     }
 
     if (hashSessionToken(token) !== session.token_hash) {
-      res.status(401).json({ error: 'Unauthorized: token mismatch' });
+      next(Errors.unauthorized('Token mismatch'));
       return;
     }
 


### PR DESCRIPTION
…dience invariants

- Add getJwtSecretsForVerification() for multi-secret verification (key rotation)
- Add validateClaims() with configurable clock skew tolerance (default 30s)
- Add getDefaultClaimValidationOptions() reading JWT_ISSUER, JWT_AUDIENCE, JWT_CLOCK_TOLERANCE_SECONDS from env
- Rewrite verifyToken() to verify against all configured secrets with explicit claim validation
- Add issuer/audience claims to issueToken() when provided
- Refactor middleware to use AppError/Errors via next() instead of res.status().json()
- Mount global errorHandler in app.ts
- Extend config/env.ts with JWT_SECRET_PREVIOUS, JWT_ISSUER, JWT_AUDIENCE, JWT_CLOCK_TOLERANCE_SECONDS
- Add comprehensive tests for key rotation, clock skew, issuer/audience validation
- Add docs/jwt-key-rotation.md documenting security assumptions and rotation procedure
closes #255 