### PR TITLE
feat: propagate request id across logs and error responses

### DIFF
--- a/src/middleware/__tests__/requestIdPropagation.test.ts
+++ b/src/middleware/__tests__/requestIdPropagation.test.ts
@@ -1,0 +1,134 @@
+import { Request, Response } from 'express';
+import { requestIdMiddleware } from '../requestId';
+import { errorHandler } from '../errorHandler';
+import { Logger } from '../../lib/logger';
+import { AppError, Errors } from '../../lib/errors';
+
+// Helper mock structures - casting directly to any avoids complex Express interface mismatches
+function createMockRequest(headers: Record<string, string | string[]> = {}): Partial<Request> {
+  return {
+    headers,
+    method: 'GET',
+    path: '/test-route',
+  } as unknown as Request;
+}
+
+function createMockResponse(): any {
+  const headers = new Map<string, string>();
+  const res: any = {
+    statusCode: 200,
+    setHeader: jest.fn((name: string, value: string) => {
+      headers.set(name.toLowerCase(), value);
+      return res;
+    }),
+    status: jest.fn((code: number) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res;
+}
+
+describe('Request ID Propagation Pipeline', () => {
+  let mockConsoleLog: jest.SpyInstance;
+  let mockConsoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockRestore();
+    mockConsoleError.mockRestore();
+  });
+
+  describe('requestIdMiddleware', () => {
+    it('should reuse an incoming X-Request-Id header value', () => {
+      const req = createMockRequest({ 'x-request-id': 'client-provided-id-123' }) as Request;
+      const res = createMockResponse() as Response;
+      const next = jest.fn();
+
+      requestIdMiddleware()(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(req.requestId).toBe('client-provided-id-123');
+      expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'client-provided-id-123');
+      expect(req.logger).toBeInstanceOf(Logger);
+    });
+
+    it('should automatically generate a unique random UUID string if the tracking header is absent', () => {
+      const req = createMockRequest() as Request;
+      const res = createMockResponse() as Response;
+      const next = jest.fn();
+
+      requestIdMiddleware()(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(req.requestId).toBeDefined();
+      // FIX: Standard Jest asymmetric object matcher equality verification syntax
+      expect(req.requestId).toEqual(uuidAsymmetricMatcher);
+    });
+
+    it('should attach a valid child logger that automatically passes down context details', () => {
+      const req = createMockRequest({ 'x-request-id': 'trace-id-999' }) as Request;
+      const res = createMockResponse() as Response;
+      const next = jest.fn();
+
+      requestIdMiddleware()(req, res, next);
+
+      req.logger?.info('Sample operational event string');
+
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const rawLogPayload = JSON.parse(mockConsoleLog.mock.calls[0][0]);
+      expect(rawLogPayload.requestId).toBe('trace-id-999');
+      expect(rawLogPayload.message).toBe('Sample operational event string');
+    });
+  });
+
+  describe('errorHandler Global Router Integration', () => {
+    it('should intercept thrown AppErrors, trace logging, and structure json responses properly', () => {
+      const req = createMockRequest({ 'x-request-id': 'err-trace-111' }) as Request;
+      const res = createMockResponse() as Response;
+      const next = jest.fn();
+
+      requestIdMiddleware()(req, res, next);
+
+      const standardError = Errors.badRequest('Client Payload Mismatch');
+      errorHandler(standardError, req, res, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', 'err-trace-111');
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: 'err-trace-111',
+          code: 'BAD_REQUEST',
+        })
+      );
+    });
+
+    it('should downgrade unmapped exceptions safely inside production parameters', () => {
+      const req = createMockRequest({ 'x-request-id': 'fatal-500-trace' }) as Request;
+      const res = createMockResponse() as Response;
+      const next = jest.fn();
+
+      requestIdMiddleware()(req, res, next);
+
+      const nativeFatalError = new Error('Database hardware timeout fault down');
+      errorHandler(nativeFatalError, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(mockConsoleError).toHaveBeenCalled();
+      
+      const loggedOutput = JSON.parse(mockConsoleError.mock.calls[0][0]);
+      expect(loggedOutput.requestId).toBe('fatal-500-trace');
+    });
+  });
+});
+
+// Structural UUID shape matching regex context bounds definition
+const uuidShapeRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uuidAsymmetricMatcher = {
+  asymmetricMatch: (actual: string) => uuidShapeRegex.test(actual),
+};

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -16,21 +16,13 @@ interface StructuredErrorLogEntry {
 const isProduction = (): boolean => process.env.NODE_ENV === 'production';
 
 function getRequestId(req: Request): string | undefined {
-  return (req as Request & { requestId?: string }).requestId;
+  return req.requestId;
 }
 
-/**
- * Maps arbitrary thrown values to a structured application error.
- *
- * Security boundary:
- * - AppError instances are trusted to carry client-visible messages/details.
- * - Unknown values are always downgraded to a generic INTERNAL_ERROR.
- */
 export function mapUnknownErrorToAppError(err: unknown): AppError {
   if (err instanceof AppError) {
     return err;
   }
-
   return Errors.internal();
 }
 
@@ -71,9 +63,11 @@ export const errorHandler: ErrorRequestHandler = (
   const requestId = getRequestId(req);
   const mapped = mapUnknownErrorToAppError(err);
   
-  // Use globalLogger for structured logging
+  // REQUIREMENT: Route through the contextual request-scoped logger if present
+  const activeLogger = req.logger ?? globalLogger;
+  
   if (mapped.statusCode >= 500) {
-    globalLogger.error(mapped.message, {
+    activeLogger.error(mapped.message, {
       requestId,
       code: mapped.code,
       statusCode: mapped.statusCode,
@@ -83,7 +77,7 @@ export const errorHandler: ErrorRequestHandler = (
       method: req.method,
     });
   } else {
-    globalLogger.warn(mapped.message, {
+    activeLogger.warn(mapped.message, {
       requestId,
       code: mapped.code,
       statusCode: mapped.statusCode,
@@ -91,6 +85,11 @@ export const errorHandler: ErrorRequestHandler = (
       path: req.path,
       method: req.method,
     });
+  }
+
+  // REQUIREMENT: Include validation tracking parameters inside headers and responses
+  if (requestId) {
+    res.setHeader('X-Request-Id', requestId);
   }
 
   const finalError = mapped.expose ? mapped : Errors.internal();

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -1,10 +1,13 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { randomUUID } from 'crypto';
+import { globalLogger, Logger } from '../lib/logger';
 
 declare global {
   namespace Express {
     interface Request {
       requestId?: string;
+      // New: Request-scoped logger containing requestId trace parameters
+      logger?: Logger;
     }
   }
 }
@@ -24,9 +27,13 @@ export function requestIdMiddleware(): RequestHandler {
     const fromHeader = pickHeaderId(req.headers['x-request-id']);
     const existing = req.requestId;
     const id = fromHeader ?? existing ?? randomUUID();
+    
     if (!req.requestId) req.requestId = id;
+    
+    // REQUIREMENT: Instantiate a request-scoped logger context payload
+    req.logger = globalLogger.child({ requestId: id });
+    
     res.setHeader('X-Request-Id', id);
     next();
   };
 }
-


### PR DESCRIPTION
### Description
Closes #335. Implements uniform request-id propagation across all runtime application logging systems and centralized Express framework error responses to support reliable distributed tracing.

### Changes Implemented
- Refactored `requestIdMiddleware` to instantiate context-aware child loggers via `globalLogger.child({ requestId })` attached as a request-scoped parameter (`req.logger`).
- Updated `errorHandler` to interface primarily with the contextual request-scoped logger, ensuring trace references are output automatically without signature breaking changes downstream.
- Wired `errorHandler` JSON payload payloads and response headers to emit verified tracking identifiers (`X-Request-Id`).
- Added full test specifications covering custom input parsing values, automated system generation steps, and exception handling downgrades.