### PR TITLE
Add dead-letter alarm and route

### DIFF
--- a/docs/webhook-dead-letters.md
+++ b/docs/webhook-dead-letters.md
@@ -1,0 +1,41 @@
+# Webhook Dead-Letter Inspection and Replay
+
+This document describes the new observability and admin routes for inspecting and replaying webhook dead-letter deliveries.
+
+## Metrics
+
+- Metric: `webhook_dead_letter_total{endpoint="<endpoint-id>"}`
+  - Type: gauge
+  - Description: Number of deliveries marked `dead_letter` for the endpoint.
+  - Cardinality: capped by `MetricsCollector.maxCardinality` (default 1000).
+  - Emitted whenever a delivery is moved to `dead_letter`.
+
+## Admin Endpoints (requires admin session auth)
+
+Base path: `/api/v1/admin/webhooks`
+
+- `GET /:endpointId/dead-letters`
+  - Returns recent dead-letter deliveries for the given endpoint.
+  - Query params: `page` (default 0), `limit` (default 50, max 100).
+  - Response: `{ total, limit, page, items: [WebhookDelivery] }`
+
+- `POST /dead-letters/:id/replay`
+  - Idempotently re-enqueues the given dead-lettered delivery.
+  - Implementation: updates the existing delivery record back to `pending`, resets `attempts`, clears `last_error` and `next_retry_at`.
+  - Triggers an immediate background re-processing attempt when the in-process `WebhookQueue` is available; otherwise it will be picked up by the normal retry/resume mechanism.
+
+## Security and correctness notes
+
+- Endpoints are protected by the existing session-based `requireAuth` middleware and additionally require the `admin` role.
+- Replay is idempotent: it reuses the existing delivery record (no new delivery rows are created).
+- Pagination guard prevents large responses (`limit` capped to 100).
+- Metric labels are sanitized and subject to `MetricsCollector` cardinality limits to avoid explosion of unique label values.
+
+## Testing
+
+- Unit tests added: `src/routes/adminWebhooks.test.ts` covering listing, replay success, non-admin access, and invalid-replay cases.
+
+## Usage
+
+- To view metrics (Prometheus format): `GET /metrics` (requires internal `METRICS_TOKEN` in production).
+- To inspect dead letters: call the admin endpoints described above with an admin session.

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,8 @@ import { pool } from './db/pool';
 import { createRequireAuth } from './middleware/auth';
 import { createCorsMiddleware } from './middleware/cors';
 import { SessionRepository } from './db/repositories/sessionRepository';
+import { WebhookEndpointRepository } from './db/repositories/webhookEndpointRepository';
+import { createAdminWebhooksRouter } from './routes/adminWebhooks';
 import { createLogoutRouter } from './auth/logout/logoutRoute';
 import { createChangePasswordRouter } from './auth/changePassword/changePasswordRoute';
 import { createLoginRouter } from './auth/login/loginRoute';
@@ -186,6 +188,10 @@ export function createApp() {
 
   const sessionRepository = new SessionRepository(pool);
   const requireAuth = createRequireAuth(sessionRepository);
+
+  // Admin webhooks management
+  const webhookRepo = new WebhookEndpointRepository(pool);
+  app.use('/api/v1/admin/webhooks', createAdminWebhooksRouter({ repo: webhookRepo, requireAuth }));
 
   const userRepository = new UserRepository(pool);
   const jwtIssuer = new JwtIssuerImpl();

--- a/src/db/repositories/webhookEndpointRepository.ts
+++ b/src/db/repositories/webhookEndpointRepository.ts
@@ -138,6 +138,25 @@ export class WebhookEndpointRepository {
     return result.rows[0] ? this.mapDelivery(result.rows[0]) : null;
   }
 
+  async listDeadLettersByEndpoint(endpointId: string, limit = 50, offset = 0): Promise<WebhookDelivery[]> {
+    const result: QueryResult<WebhookDelivery> = await this.db.query(
+      `SELECT * FROM webhook_deliveries
+       WHERE endpoint_id = $1 AND status = 'dead_letter'
+       ORDER BY updated_at DESC
+       LIMIT $2 OFFSET $3`,
+      [endpointId, limit, offset]
+    );
+    return result.rows.map((row) => this.mapDelivery(row));
+  }
+
+  async countDeadLettersByEndpoint(endpointId: string): Promise<number> {
+    const result = await this.db.query(
+      `SELECT COUNT(*)::int AS cnt FROM webhook_deliveries WHERE endpoint_id = $1 AND status = 'dead_letter'`,
+      [endpointId]
+    );
+    return result.rows[0] ? result.rows[0].cnt : 0;
+  }
+
   private map(row: WebhookEndpoint): WebhookEndpoint {
     return {
       id: row.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   WebhookEventType,
 } from "./services/webhookService";
 import { pool } from "./db/pool";
+import { globalMetrics } from "./lib/metrics";
 import { createPasswordResetRouter } from "./routes/passwordReset";
 import { emailService } from "./services/emailService";
 
@@ -795,6 +796,15 @@ export class WebhookQueue {
       last_error: result.error,
       next_retry_at: null,
     });
+    // If the delivery was dead-lettered, update per-endpoint gauge
+    if (nextDelay === -1) {
+      try {
+        const count = await this.repo.countDeadLettersByEndpoint(delivery.endpoint_id);
+        globalMetrics.setGauge('webhook_dead_letter_total', count, { endpoint: endpoint.id }, 'Number of dead-lettered webhook deliveries per endpoint');
+      } catch (err) {
+        console.error('[WebhookQueue] Failed to update dead-letter metric:', err);
+      }
+    }
     return false;
   }
 

--- a/src/routes/adminWebhooks.test.ts
+++ b/src/routes/adminWebhooks.test.ts
@@ -1,0 +1,77 @@
+import express from 'express';
+import request from 'supertest';
+import { createAdminWebhooksRouter } from './adminWebhooks';
+
+function makeRequireAuth(role = 'admin') {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as any).user = { id: 'user-1', role };
+    next();
+  };
+}
+
+describe('Admin Webhooks Router', () => {
+  test('GET dead-letters returns list for admin', async () => {
+    const mockRepo: any = {
+      listDeadLettersByEndpoint: jest.fn().mockResolvedValue([{ id: 'd1' }, { id: 'd2' }]),
+      countDeadLettersByEndpoint: jest.fn().mockResolvedValue(2),
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use('/admin/webhooks', createAdminWebhooksRouter({ repo: mockRepo, requireAuth: makeRequireAuth('admin') }));
+
+    const res = await request(app).get('/admin/webhooks/endpoint-1/dead-letters');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(2);
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(mockRepo.listDeadLettersByEndpoint).toHaveBeenCalledWith('endpoint-1', 50, 0);
+  });
+
+  test('non-admin cannot access listing', async () => {
+    const mockRepo: any = { listDeadLettersByEndpoint: jest.fn(), countDeadLettersByEndpoint: jest.fn() };
+    const app = express();
+    app.use(express.json());
+    app.use('/admin/webhooks', createAdminWebhooksRouter({ repo: mockRepo, requireAuth: makeRequireAuth('investor') }));
+
+    const res = await request(app).get('/admin/webhooks/endpoint-1/dead-letters');
+    expect(res.status).toBe(403);
+  });
+
+  test('POST replay idempotently resets delivery to pending and does not create duplicates', async () => {
+    const delivery = { id: 'd1', endpoint_id: 'endpoint-1', payload: { event: { id: 'ev1' } }, status: 'dead_letter' } as any;
+    const mockRepo: any = {
+      findDeliveryById: jest.fn().mockResolvedValue(delivery),
+      updateDelivery: jest.fn().mockImplementation(async (id, updates) => ({ ...delivery, ...updates })),
+      findById: jest.fn().mockResolvedValue({ id: 'endpoint-1', url: 'https://example.com' }),
+      createDelivery: jest.fn(),
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use('/admin/webhooks', createAdminWebhooksRouter({ repo: mockRepo, requireAuth: makeRequireAuth('admin') }));
+
+    const res1 = await request(app).post('/admin/webhooks/dead-letters/d1/replay');
+    expect(res1.status).toBe(200);
+    expect(mockRepo.updateDelivery).toHaveBeenCalled();
+    expect(mockRepo.createDelivery).not.toHaveBeenCalled();
+
+    const res2 = await request(app).post('/admin/webhooks/dead-letters/d1/replay');
+    expect(res2.status).toBe(200);
+    // still no new create
+    expect(mockRepo.createDelivery).not.toHaveBeenCalled();
+  });
+
+  test('replay returns 400 if delivery not dead_letter', async () => {
+    const delivery = { id: 'd2', endpoint_id: 'endpoint-1', status: 'failed' } as any;
+    const mockRepo: any = {
+      findDeliveryById: jest.fn().mockResolvedValue(delivery),
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use('/admin/webhooks', createAdminWebhooksRouter({ repo: mockRepo, requireAuth: makeRequireAuth('admin') }));
+
+    const res = await request(app).post('/admin/webhooks/dead-letters/d2/replay');
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/routes/adminWebhooks.ts
+++ b/src/routes/adminWebhooks.ts
@@ -1,0 +1,93 @@
+import { Router, Request, Response, RequestHandler } from 'express';
+import { WebhookEndpointRepository } from '../db/repositories/webhookEndpointRepository';
+
+export function createAdminWebhooksRouter(opts: {
+  repo: WebhookEndpointRepository;
+  requireAuth: RequestHandler;
+}) {
+  const { repo, requireAuth } = opts;
+  const router = Router();
+
+  // Ensure admin role
+  const requireAdmin: RequestHandler = (req, _res, next) => {
+    const user = (req as any).user;
+    if (!user || user.role !== 'admin') {
+      next({ status: 403, message: 'Forbidden: admin role required' });
+      return;
+    }
+    next();
+  };
+
+  // List recent dead-letter deliveries for an endpoint
+  router.get('/:endpointId/dead-letters', requireAuth, requireAdmin, async (req: Request, res: Response, next) => {
+    try {
+      const endpointId = req.params.endpointId;
+      const limitRaw = parseInt(String(req.query.limit || '50'), 10) || 50;
+      const pageRaw = parseInt(String(req.query.page || '0'), 10) || 0;
+
+      const limit = Math.min(Math.max(1, limitRaw), 100); // guard: 1..100
+      const offset = Math.max(0, pageRaw) * limit;
+
+      const [items, total] = await Promise.all([
+        repo.listDeadLettersByEndpoint(endpointId, limit, offset),
+        repo.countDeadLettersByEndpoint(endpointId),
+      ]);
+
+      res.json({ total, limit, page: pageRaw, items });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Replay a dead-letter delivery idempotently by resetting its status to pending
+  router.post('/dead-letters/:id/replay', requireAuth, requireAdmin, async (req: Request, res: Response, next) => {
+    try {
+      const id = req.params.id;
+      const delivery = await repo.findDeliveryById(id);
+      if (!delivery) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+      }
+
+      if (delivery.status !== 'dead_letter') {
+        res.status(400).json({ error: 'Delivery is not dead-lettered' });
+        return;
+      }
+
+      // Idempotent replay: update existing delivery back to pending and clear errors
+      const updated = await repo.updateDelivery(id, {
+        status: 'pending',
+        attempts: 0,
+        last_error: null,
+        next_retry_at: null,
+      });
+
+      // Trigger immediate re-processing if runtime queue is available
+      (async () => {
+        try {
+          // dynamic import to avoid top-level circular deps
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const idx = require('../index');
+          if (idx && idx.WebhookQueue && typeof idx.WebhookQueue.processDelivery === 'function') {
+            const endpoint = await repo.findById(delivery.endpoint_id);
+            if (endpoint) {
+              void idx.WebhookQueue.processDelivery(endpoint.url, delivery.payload, delivery.id);
+            }
+          }
+        } catch (err) {
+          // non-fatal: queue may live in a different process
+          // eslint-disable-next-line no-console
+          console.warn('[adminWebhooks] Could not trigger immediate replay:', err);
+        }
+      })();
+
+      res.json({ success: true, id: updated.id });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+export default createAdminWebhooksRouter;


### PR DESCRIPTION
Added dead-letter observability and admin controls for webhook deliveries. A new `webhook_dead_letter_total{endpoint}` gauge tracks failed deliveries in real time, and two new repository methods let you query and count dead letters by endpoint. An admin router exposes a list endpoint and a replay endpoint, both protected by session auth and admin role check. Replaying idempotently resets the delivery to `pending`, clears previous errors and attempts, and triggers immediate reprocessing if the queue is available. Tests and documentation included 
Closed #396 