### PR TITLE
feat: schedule periodic reconciliation with discrepancy alarms (#390)

### DIFF
--- a/src/db/migrations/013_create_reconciliation_run_summaries.sql
+++ b/src/db/migrations/013_create_reconciliation_run_summaries.sql
@@ -1,0 +1,36 @@
+-- Migration 013: reconciliation_run_summaries
+--
+-- Persists every scheduler-triggered reconciliation run.
+-- Primary key: (offering_id, period_id, started_at) gives a natural composite
+-- identity that matches the ReconciliationRunSummary shape in the scheduler.
+--
+-- Indexes
+-- -------
+-- idx_rrs_offering_started  — fast lookup of the most-recent run per offering
+--   (used by ReconciliationRunStore.getLastRun via ORDER BY started_at DESC LIMIT 1).
+-- idx_rrs_balanced          — supports dashboard queries filtering imbalanced runs.
+
+CREATE TABLE IF NOT EXISTS reconciliation_run_summaries (
+  offering_id        TEXT        NOT NULL,
+  period_id          TEXT        NOT NULL,   -- e.g. "2026-05" (ISO-month)
+  started_at         TIMESTAMPTZ NOT NULL,
+  completed_at       TIMESTAMPTZ NOT NULL,
+  is_balanced        BOOLEAN     NOT NULL,
+  discrepancy_count  INTEGER     NOT NULL DEFAULT 0,
+  discrepancy_amount NUMERIC(20, 8) NOT NULL DEFAULT 0,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (offering_id, period_id, started_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rrs_offering_started
+  ON reconciliation_run_summaries (offering_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rrs_balanced
+  ON reconciliation_run_summaries (is_balanced)
+  WHERE is_balanced = FALSE;
+
+COMMENT ON TABLE reconciliation_run_summaries IS
+  'One row per ReconciliationScheduler-triggered run. '
+  'Keyed by (offering_id, period_id, started_at) so concurrent multi-instance '
+  'writes are naturally de-duplicated by the primary key constraint.';

--- a/src/services/reconciliationScheduler.test.ts
+++ b/src/services/reconciliationScheduler.test.ts
@@ -1,0 +1,685 @@
+/**
+ * ReconciliationScheduler unit tests
+ *
+ * Coverage targets (aligned with ≥ 95 % requirement):
+ * ┌─────────────────────────────────────────────────────────────┬────────┐
+ * │ Scenario                                                    │ tested │
+ * ├─────────────────────────────────────────────────────────────┼────────┤
+ * │ Per-offering cadence: every active offering reconciled      │   ✓    │
+ * │ Inactive offerings skipped                                  │   ✓    │
+ * │ Missed-run resume: period starts from last run completedAt  │   ✓    │
+ * │ No prior run: period starts from lookbackMs ago             │   ✓    │
+ * │ Alarm raised when run is imbalanced                         │   ✓    │
+ * │ Alarm clears on subsequent balanced run                     │   ✓    │
+ * │ Cardinality cap: overflow label for offerings > cap         │   ✓    │
+ * │ Failed reconciliation raises alarm, recorded as error       │   ✓    │
+ * │ Run summary persisted with correct fields                   │   ✓    │
+ * │ Counter incremented only when discrepancies exist           │   ✓    │
+ * │ Balanced run does NOT increment discrepancy counter         │   ✓    │
+ * │ Multiple offerings: independent alarm/counter per label     │   ✓    │
+ * └─────────────────────────────────────────────────────────────┴────────┘
+ */
+
+import {
+  ReconciliationScheduler,
+  InMemoryReconciliationRunStore,
+  ReconciliationRunSummary,
+  SchedulerOffering,
+} from './reconciliationScheduler';
+import { MetricsCollector } from '../lib/metrics';
+import { ReconciliationResult } from './revenueReconciliationService';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal balanced ReconciliationResult. */
+function balancedResult(offeringId: string): ReconciliationResult {
+  return {
+    offeringId,
+    periodStart: new Date('2026-04-01'),
+    periodEnd: new Date('2026-04-30'),
+    isBalanced: true,
+    discrepancies: [],
+    summary: {
+      totalRevenueReported: '1000.00',
+      totalPayouts: '1000.00',
+      discrepancyAmount: '0.00',
+      investorCount: 5,
+      payoutsProcessed: 5,
+      payoutsFailed: 0,
+    },
+    checkedAt: new Date(),
+  };
+}
+
+/** Build an imbalanced ReconciliationResult with one discrepancy. */
+function imbalancedResult(offeringId: string): ReconciliationResult {
+  return {
+    offeringId,
+    periodStart: new Date('2026-04-01'),
+    periodEnd: new Date('2026-04-30'),
+    isBalanced: false,
+    discrepancies: [
+      {
+        type: 'REVENUE_MISMATCH',
+        severity: 'error',
+        message: 'Revenue mismatch',
+        details: {},
+        offeringId,
+      },
+    ],
+    summary: {
+      totalRevenueReported: '1000.00',
+      totalPayouts: '950.00',
+      discrepancyAmount: '50.00',
+      investorCount: 5,
+      payoutsProcessed: 4,
+      payoutsFailed: 1,
+    },
+    checkedAt: new Date(),
+  };
+}
+
+/** Minimal mock RevenueReconciliationService. */
+function makeService(
+  impl: (
+    offeringId: string,
+    periodStart: Date,
+    periodEnd: Date
+  ) => Promise<ReconciliationResult> = async (id) => balancedResult(id)
+) {
+  return { reconcile: jest.fn(impl) } as any;
+}
+
+/** Minimal mock OfferingRepository. */
+function makeOfferingRepo(offerings: SchedulerOffering[]) {
+  return { listAll: jest.fn().mockResolvedValue(offerings) };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ReconciliationScheduler', () => {
+  let metrics: MetricsCollector;
+  let store: InMemoryReconciliationRunStore;
+
+  beforeEach(() => {
+    // Disable PII detection so offering-id short labels pass through unredacted.
+    metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    store = new InMemoryReconciliationRunStore();
+  });
+
+  // ── Per-offering cadence ────────────────────────────────────────────────────
+
+  describe('per-offering cadence', () => {
+    it('reconciles every active offering in a single tick', async () => {
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001', status: 'active' },
+        { id: 'bbbb0000-0000-0000-0000-000000000002', status: 'open' },
+        { id: 'cccc0000-0000-0000-0000-000000000003', status: 'closed' },
+      ];
+      const service = makeService();
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo(offerings),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.attempted).toBe(3);
+      expect(result.successful).toBe(3);
+      expect(result.failed).toBe(0);
+      expect(service.reconcile).toHaveBeenCalledTimes(3);
+    });
+
+    it('skips offerings whose status is not active-like', async () => {
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001', status: 'active' },
+        { id: 'dddd0000-0000-0000-0000-000000000004', status: 'draft' },
+        { id: 'eeee0000-0000-0000-0000-000000000005', status: 'cancelled' },
+      ];
+      const service = makeService();
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo(offerings),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.attempted).toBe(1);
+      expect(service.reconcile).toHaveBeenCalledTimes(1);
+      expect(service.reconcile).toHaveBeenCalledWith(
+        'aaaa0000-0000-0000-0000-000000000001',
+        expect.any(Date),
+        expect.any(Date),
+        expect.any(Object)
+      );
+    });
+
+    it('treats offerings with no status field as active', async () => {
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001' }, // no status
+      ];
+      const service = makeService();
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo(offerings),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+      expect(result.attempted).toBe(1);
+      expect(service.reconcile).toHaveBeenCalledTimes(1);
+    });
+
+    it('persists a run summary for each reconciled offering', async () => {
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001', status: 'active' },
+        { id: 'bbbb0000-0000-0000-0000-000000000002', status: 'active' },
+      ];
+      const scheduler = new ReconciliationScheduler(
+        makeService(),
+        makeOfferingRepo(offerings),
+        store,
+        metrics
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      const runs = store.getAllRuns();
+      expect(runs).toHaveLength(2);
+      const ids = runs.map((r) => r.offeringId).sort();
+      expect(ids).toEqual([
+        'aaaa0000-0000-0000-0000-000000000001',
+        'bbbb0000-0000-0000-0000-000000000002',
+      ]);
+    });
+  });
+
+  // ── Missed-run resume ───────────────────────────────────────────────────────
+
+  describe('missed-run resume', () => {
+    it('uses last run completedAt as the new period start (no gap)', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const pastCompletedAt = new Date('2026-03-01T12:00:00Z');
+
+      // Seed a previous run
+      await store.saveRun({
+        offeringId,
+        periodId: '2026-02',
+        startedAt: new Date('2026-03-01T11:59:00Z'),
+        completedAt: pastCompletedAt,
+        isBalanced: true,
+        discrepancyCount: 0,
+        discrepancyAmount: '0.00',
+      });
+
+      const service = makeService();
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      // The period start forwarded to reconcile() must be the previous completedAt
+      const [, periodStartArg] = service.reconcile.mock.calls[0];
+      expect((periodStartArg as Date).getTime()).toBe(pastCompletedAt.getTime());
+    });
+
+    it('uses lookbackMs when no previous run exists', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const lookbackMs = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+      const service = makeService();
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics,
+        { lookbackMs }
+      );
+
+      const before = Date.now();
+      await scheduler.runScheduledReconciliation();
+      const after = Date.now();
+
+      const [, periodStartArg, periodEndArg] = service.reconcile.mock.calls[0];
+      const start = (periodStartArg as Date).getTime();
+      const end = (periodEndArg as Date).getTime();
+
+      // period end ≈ now
+      expect(end).toBeGreaterThanOrEqual(before);
+      expect(end).toBeLessThanOrEqual(after);
+      // period start ≈ now - lookbackMs
+      expect(start).toBeGreaterThanOrEqual(before - lookbackMs - 100);
+      expect(start).toBeLessThanOrEqual(after - lookbackMs + 100);
+    });
+
+    it('correctly advances the window on a second tick (no overlapping period)', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const service = makeService();
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics,
+        { lookbackMs: 30 * 24 * 60 * 60 * 1000 }
+      );
+
+      // First tick
+      await scheduler.runScheduledReconciliation();
+      const [, , firstEnd] = service.reconcile.mock.calls[0];
+
+      // Second tick
+      await scheduler.runScheduledReconciliation();
+      const [, secondStart] = service.reconcile.mock.calls[1];
+
+      // Second window must start no earlier than the first window's end
+      expect((secondStart as Date).getTime()).toBeGreaterThanOrEqual(
+        (firstEnd as Date).getTime() - 100 // small clock skew tolerance
+      );
+    });
+  });
+
+  // ── Alarm semantics ─────────────────────────────────────────────────────────
+
+  describe('alarm semantics', () => {
+    it('sets reconciliation_alarm_open=1 when a run is imbalanced', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const scheduler = new ReconciliationScheduler(
+        makeService(async (id) => imbalancedResult(id)),
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.alarmRaised).toBe(1);
+      expect(result.alarmCleared).toBe(0);
+
+      const snapshot = await metrics.getSnapshot();
+      const alarmPoint = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_alarm_open'
+      );
+      expect(alarmPoint?.value).toBe(1);
+    });
+
+    it('sets reconciliation_alarm_open=0 on a subsequent balanced run (alarm clears)', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const offering = [{ id: offeringId, status: 'active' }];
+
+      // Tick 1: imbalanced → alarm opens
+      const scheduler1 = new ReconciliationScheduler(
+        makeService(async (id) => imbalancedResult(id)),
+        makeOfferingRepo(offering),
+        store,
+        metrics
+      );
+      await scheduler1.runScheduledReconciliation();
+
+      // Tick 2: balanced → alarm clears
+      const scheduler2 = new ReconciliationScheduler(
+        makeService(async (id) => balancedResult(id)),
+        makeOfferingRepo(offering),
+        store,
+        metrics
+      );
+      const result2 = await scheduler2.runScheduledReconciliation();
+
+      expect(result2.alarmRaised).toBe(0);
+      expect(result2.alarmCleared).toBe(1);
+
+      const snapshot = await metrics.getSnapshot();
+      const alarmPoint = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_alarm_open'
+      );
+      expect(alarmPoint?.value).toBe(0);
+    });
+
+    it('does not raise alarm when run is balanced from the start', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const scheduler = new ReconciliationScheduler(
+        makeService(async (id) => balancedResult(id)),
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.alarmRaised).toBe(0);
+      expect(result.alarmCleared).toBe(1);
+    });
+
+    it('raises alarm when reconcile() throws', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const service = {
+        reconcile: jest.fn().mockRejectedValue(new Error('DB timeout')),
+      } as any;
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.failed).toBe(1);
+      expect(result.alarmRaised).toBe(1);
+      expect(result.errors[0].error).toContain('DB timeout');
+
+      const snapshot = await metrics.getSnapshot();
+      const alarmPoint = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_alarm_open'
+      );
+      expect(alarmPoint?.value).toBe(1);
+    });
+
+    it('maintains separate alarm state per offering', async () => {
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001', status: 'active' },
+        { id: 'bbbb0000-0000-0000-0000-000000000002', status: 'active' },
+      ];
+
+      // aaaa → imbalanced, bbbb → balanced
+      const service = makeService(async (id) =>
+        id.startsWith('aaaa') ? imbalancedResult(id) : balancedResult(id)
+      );
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo(offerings),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.alarmRaised).toBe(1);
+      expect(result.alarmCleared).toBe(1);
+    });
+  });
+
+  // ── Metrics counters ────────────────────────────────────────────────────────
+
+  describe('reconciliation_discrepancy_total counter', () => {
+    it('increments by discrepancy count when discrepancies found', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const scheduler = new ReconciliationScheduler(
+        makeService(async (id) => imbalancedResult(id)),
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      const snapshot = await metrics.getSnapshot();
+      const counter = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_discrepancy_total'
+      );
+      // imbalancedResult() produces 1 discrepancy
+      expect(counter?.value).toBe(1);
+    });
+
+    it('does NOT increment the counter when run is balanced', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const scheduler = new ReconciliationScheduler(
+        makeService(async (id) => balancedResult(id)),
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      const snapshot = await metrics.getSnapshot();
+      const counter = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_discrepancy_total'
+      );
+      expect(counter).toBeUndefined();
+    });
+
+    it('accumulates across multiple imbalanced ticks', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const offering = [{ id: offeringId, status: 'active' }];
+
+      for (let i = 0; i < 3; i++) {
+        const scheduler = new ReconciliationScheduler(
+          makeService(async (id) => imbalancedResult(id)),
+          makeOfferingRepo(offering),
+          store,
+          metrics
+        );
+        await scheduler.runScheduledReconciliation();
+      }
+
+      const snapshot = await metrics.getSnapshot();
+      const counter = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_discrepancy_total'
+      );
+      // 1 discrepancy × 3 ticks = 3
+      expect(counter?.value).toBe(3);
+    });
+  });
+
+  // ── Cardinality cap ─────────────────────────────────────────────────────────
+
+  describe('cardinality cap', () => {
+    it('labels offerings beyond the cap as "overflow"', async () => {
+      const cardinalityLimit = 2;
+      // 4 offerings — first 2 get individual labels, last 2 go to "overflow"
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001', status: 'active' },
+        { id: 'bbbb0000-0000-0000-0000-000000000002', status: 'active' },
+        { id: 'cccc0000-0000-0000-0000-000000000003', status: 'active' },
+        { id: 'dddd0000-0000-0000-0000-000000000004', status: 'active' },
+      ];
+
+      // Make all runs imbalanced so we can detect which labels were emitted
+      const scheduler = new ReconciliationScheduler(
+        makeService(async (id) => imbalancedResult(id)),
+        makeOfferingRepo(offerings),
+        store,
+        metrics,
+        { cardinalityLimit }
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      const snapshot = await metrics.getSnapshot();
+      const alarmPoints = snapshot.custom.filter(
+        (p) => p.name === 'reconciliation_alarm_open'
+      );
+
+      const labels = alarmPoints.map((p) => p.labels?.offering_id).sort();
+      // "aaaa" and "bbbb" are within cap; cccc and dddd → "overflow"
+      // Note: two offerings share "overflow" so only one gauge entry for "overflow"
+      expect(labels).toContain('aaaa0000');
+      expect(labels).toContain('bbbb0000');
+      expect(labels).toContain('overflow');
+      expect(labels).not.toContain('cccc0000');
+      expect(labels).not.toContain('dddd0000');
+    });
+
+    it('correctly uses the first UUID segment as the short label', async () => {
+      const offeringId = 'abcd1234-5678-0000-0000-000000000001';
+      const scheduler = new ReconciliationScheduler(
+        makeService(async (id) => imbalancedResult(id)),
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics,
+        { cardinalityLimit: 10 }
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      const snapshot = await metrics.getSnapshot();
+      const alarmPoint = snapshot.custom.find(
+        (p) => p.name === 'reconciliation_alarm_open'
+      );
+      // Short label = first segment of UUID = "abcd1234"
+      expect(alarmPoint?.labels?.offering_id).toBe('abcd1234');
+    });
+  });
+
+  // ── Run summary persistence ──────────────────────────────────────────────────
+
+  describe('InMemoryReconciliationRunStore', () => {
+    it('saves and retrieves the most recent run for an offering', async () => {
+      const summary1: ReconciliationRunSummary = {
+        offeringId: 'off-1',
+        periodId: '2026-03',
+        startedAt: new Date('2026-03-31T23:00:00Z'),
+        completedAt: new Date('2026-03-31T23:01:00Z'),
+        isBalanced: true,
+        discrepancyCount: 0,
+        discrepancyAmount: '0.00',
+      };
+      const summary2: ReconciliationRunSummary = {
+        ...summary1,
+        periodId: '2026-04',
+        startedAt: new Date('2026-04-30T23:00:00Z'),
+        completedAt: new Date('2026-04-30T23:01:00Z'),
+        isBalanced: false,
+        discrepancyCount: 2,
+        discrepancyAmount: '50.00',
+      };
+
+      await store.saveRun(summary1);
+      await store.saveRun(summary2);
+
+      const last = await store.getLastRun('off-1');
+      expect(last?.periodId).toBe('2026-04');
+      expect(last?.isBalanced).toBe(false);
+    });
+
+    it('returns null when no run exists for the offering', async () => {
+      const last = await store.getLastRun('nonexistent-offering');
+      expect(last).toBeNull();
+    });
+
+    it('does not overwrite a newer run with an older one', async () => {
+      const newerRun: ReconciliationRunSummary = {
+        offeringId: 'off-1',
+        periodId: '2026-05',
+        startedAt: new Date('2026-05-31T00:00:00Z'),
+        completedAt: new Date('2026-05-31T00:01:00Z'),
+        isBalanced: true,
+        discrepancyCount: 0,
+        discrepancyAmount: '0.00',
+      };
+      const olderRun: ReconciliationRunSummary = {
+        ...newerRun,
+        periodId: '2026-04',
+        startedAt: new Date('2026-04-30T00:00:00Z'),
+        completedAt: new Date('2026-04-30T00:01:00Z'),
+      };
+
+      await store.saveRun(newerRun);
+      await store.saveRun(olderRun); // should not overwrite
+
+      const last = await store.getLastRun('off-1');
+      expect(last?.periodId).toBe('2026-05');
+    });
+
+    it('handles independent runs for different offerings', async () => {
+      const runA: ReconciliationRunSummary = {
+        offeringId: 'off-A',
+        periodId: '2026-05',
+        startedAt: new Date('2026-05-31T00:00:00Z'),
+        completedAt: new Date('2026-05-31T00:01:00Z'),
+        isBalanced: false,
+        discrepancyCount: 1,
+        discrepancyAmount: '10.00',
+      };
+      const runB: ReconciliationRunSummary = {
+        ...runA,
+        offeringId: 'off-B',
+        isBalanced: true,
+        discrepancyCount: 0,
+        discrepancyAmount: '0.00',
+      };
+
+      await store.saveRun(runA);
+      await store.saveRun(runB);
+
+      const lastA = await store.getLastRun('off-A');
+      const lastB = await store.getLastRun('off-B');
+
+      expect(lastA?.isBalanced).toBe(false);
+      expect(lastB?.isBalanced).toBe(true);
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles an empty offering list gracefully', async () => {
+      const scheduler = new ReconciliationScheduler(
+        makeService(),
+        makeOfferingRepo([]),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+      expect(result.attempted).toBe(0);
+      expect(result.successful).toBe(0);
+      expect(result.failed).toBe(0);
+    });
+
+    it('continues processing other offerings when one fails', async () => {
+      const offerings: SchedulerOffering[] = [
+        { id: 'aaaa0000-0000-0000-0000-000000000001', status: 'active' },
+        { id: 'bbbb0000-0000-0000-0000-000000000002', status: 'active' },
+      ];
+
+      const service = makeService(async (id) => {
+        if (id.startsWith('aaaa')) throw new Error('RPC timeout');
+        return balancedResult(id);
+      });
+
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo(offerings),
+        store,
+        metrics
+      );
+
+      const result = await scheduler.runScheduledReconciliation();
+
+      expect(result.attempted).toBe(2);
+      expect(result.successful).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].offeringId).toBe('aaaa0000-0000-0000-0000-000000000001');
+    });
+
+    it('forwards the configured tolerance to reconciliationService.reconcile()', async () => {
+      const offeringId = 'aaaa0000-0000-0000-0000-000000000001';
+      const service = makeService();
+      const customTolerance = 0.001;
+
+      const scheduler = new ReconciliationScheduler(
+        service,
+        makeOfferingRepo([{ id: offeringId, status: 'active' }]),
+        store,
+        metrics,
+        { tolerance: customTolerance }
+      );
+
+      await scheduler.runScheduledReconciliation();
+
+      const [, , , opts] = service.reconcile.mock.calls[0];
+      expect((opts as any).tolerance).toBe(customTolerance);
+    });
+  });
+});

--- a/src/services/reconciliationScheduler.ts
+++ b/src/services/reconciliationScheduler.ts
@@ -1,0 +1,314 @@
+/**
+ * ReconciliationScheduler
+ *
+ * Runs RevenueReconciliationService.reconcile() on a scheduled cadence for every
+ * active offering. Persists each run summary, emits Prometheus-compatible metrics,
+ * and raises/clears a dead-letter alarm gauge when discrepancies breach the
+ * configured tolerance.
+ *
+ * Metric naming
+ * ─────────────
+ * reconciliation_discrepancy_total  counter  {offering_id}  Running sum of
+ *   discrepancies detected across all scheduler-triggered runs for an offering.
+ *
+ * reconciliation_alarm_open         gauge    {offering_id}  1 while the latest
+ *   run found imbalanced results, 0 once a subsequent balanced run clears it.
+ *
+ * Cardinality cap
+ * ───────────────
+ * Only the first `cardinalityLimit` (default 50) offerings receive individual
+ * labels. Overflow offerings are bucketed under offering_id="overflow" to keep
+ * total time-series count bounded and respect MetricsCollector's maxCardinality.
+ *
+ * Alarm semantics
+ * ───────────────
+ * An alarm opens (gauge → 1) when a run's reconciliation result is NOT balanced.
+ * It clears automatically (gauge → 0) the first time a subsequent run for that
+ * same offering IS balanced. No manual intervention required.
+ */
+
+import { Logger, globalLogger } from '../lib/logger';
+import { MetricsCollector } from '../lib/metrics';
+import {
+  RevenueReconciliationService,
+  ReconciliationResult,
+} from './revenueReconciliationService';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Minimal offering shape the scheduler needs. */
+export interface SchedulerOffering {
+  id: string;
+  status?: string;
+}
+
+/** Repository interface for active-offering discovery. */
+export interface ActiveOfferingRepository {
+  listAll(): Promise<SchedulerOffering[]>;
+}
+
+/** Persisted record of a single scheduler-triggered reconciliation run. */
+export interface ReconciliationRunSummary {
+  offeringId: string;
+  /** Opaque period identifier, e.g. ISO-month "2026-05" or UUID of revenue report. */
+  periodId: string;
+  startedAt: Date;
+  completedAt: Date;
+  isBalanced: boolean;
+  discrepancyCount: number;
+  discrepancyAmount: string;
+}
+
+/** Storage interface for run summaries (keyed by offeringId + periodId + startedAt). */
+export interface ReconciliationRunStore {
+  saveRun(summary: ReconciliationRunSummary): Promise<void>;
+  getLastRun(offeringId: string): Promise<ReconciliationRunSummary | null>;
+}
+
+export interface ReconciliationSchedulerOptions {
+  /**
+   * How far back from "now" to open the reconciliation window on each scheduled
+   * tick when no previous run exists. Default: 30 days.
+   */
+  lookbackMs?: number;
+  /** Discrepancy tolerance forwarded to RevenueReconciliationService. Default: 0.01. */
+  tolerance?: number;
+  /**
+   * Maximum number of offerings that receive individually-labelled metrics.
+   * Offerings beyond this cap are counted under offering_id="overflow".
+   * Default: 50.
+   */
+  cardinalityLimit?: number;
+  logger?: Logger;
+}
+
+export interface SchedulerRunResult {
+  attempted: number;
+  successful: number;
+  failed: number;
+  alarmRaised: number;
+  alarmCleared: number;
+  errors: Array<{ offeringId: string; error: string }>;
+}
+
+// ─── Statuses considered "active" for scheduling purposes ─────────────────────
+const ACTIVE_STATUSES = new Set(['open', 'active', 'processing', 'closed']);
+
+// ─── Metric names ─────────────────────────────────────────────────────────────
+const METRIC_DISCREPANCY_TOTAL = 'reconciliation_discrepancy_total';
+const METRIC_ALARM_OPEN = 'reconciliation_alarm_open';
+
+// ─── ReconciliationScheduler ──────────────────────────────────────────────────
+
+export class ReconciliationScheduler {
+  private readonly lookbackMs: number;
+  private readonly tolerance: number;
+  private readonly cardinalityLimit: number;
+  private readonly logger: Logger;
+
+  constructor(
+    private readonly reconciliationService: RevenueReconciliationService,
+    private readonly offeringRepo: ActiveOfferingRepository,
+    private readonly runStore: ReconciliationRunStore,
+    private readonly metrics: MetricsCollector,
+    options: ReconciliationSchedulerOptions = {}
+  ) {
+    this.lookbackMs = options.lookbackMs ?? 30 * 24 * 60 * 60 * 1000;
+    this.tolerance = options.tolerance ?? 0.01;
+    this.cardinalityLimit = options.cardinalityLimit ?? 50;
+    this.logger = options.logger ?? globalLogger;
+  }
+
+  /**
+   * Run one reconciliation tick across all active offerings.
+   *
+   * Called by a cron or interval mechanism (e.g. node-cron, setInterval).
+   * Safe to call concurrently — each offering is processed sequentially within
+   * a single tick, so there are no inter-call races for the same offering.
+   */
+  async runScheduledReconciliation(): Promise<SchedulerRunResult> {
+    this.logger.info('ReconciliationScheduler: starting scheduled tick');
+
+    const allOfferings = await this.offeringRepo.listAll();
+    const active = allOfferings.filter(
+      (o) => !o.status || ACTIVE_STATUSES.has(o.status)
+    );
+
+    this.logger.info(
+      `ReconciliationScheduler: ${active.length} active offering(s) to reconcile`
+    );
+
+    const result: SchedulerRunResult = {
+      attempted: active.length,
+      successful: 0,
+      failed: 0,
+      alarmRaised: 0,
+      alarmCleared: 0,
+      errors: [],
+    };
+
+    for (let idx = 0; idx < active.length; idx++) {
+      const offering = active[idx];
+      // Label for metrics — use first segment of UUID to stay below PII threshold
+      // while still being identifiable in dashboards; overflow if above cap.
+      const metricLabel =
+        idx < this.cardinalityLimit
+          ? this.shortLabel(offering.id)
+          : 'overflow';
+
+      try {
+        const { periodStart, periodEnd } = await this.determinePeriod(offering.id);
+        const startedAt = new Date();
+
+        this.logger.info('ReconciliationScheduler: reconciling offering', {
+          offeringId: offering.id,
+          periodStart,
+          periodEnd,
+        });
+
+        const reconcileResult = await this.reconciliationService.reconcile(
+          offering.id,
+          periodStart,
+          periodEnd,
+          { tolerance: this.tolerance }
+        );
+
+        const completedAt = new Date();
+
+        // Persist run summary
+        const summary: ReconciliationRunSummary = {
+          offeringId: offering.id,
+          periodId: this.periodId(periodStart),
+          startedAt,
+          completedAt,
+          isBalanced: reconcileResult.isBalanced,
+          discrepancyCount: reconcileResult.discrepancies.length,
+          discrepancyAmount: reconcileResult.summary.discrepancyAmount,
+        };
+        await this.runStore.saveRun(summary);
+
+        // Emit metrics
+        this.emitMetrics(metricLabel, reconcileResult, result);
+
+        result.successful++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error('ReconciliationScheduler: offering run failed', {
+          offeringId: offering.id,
+          error: message,
+        });
+        result.failed++;
+        result.errors.push({ offeringId: offering.id, error: message });
+
+        // Keep alarm open (or raise it) if this run errored — treat an error as
+        // an unresolved discrepancy so the dead-letter alarm fires.
+        this.metrics.setGauge(
+          METRIC_ALARM_OPEN,
+          1,
+          { offering_id: metricLabel },
+          'Dead-letter alarm: 1 when reconciliation found discrepancies or errored'
+        );
+        result.alarmRaised++;
+      }
+    }
+
+    this.logger.info('ReconciliationScheduler: tick complete', result);
+    return result;
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  /**
+   * Determine the reconciliation window for an offering.
+   *
+   * If a previous run exists the window starts from that run's completedAt
+   * timestamp (so no gaps between runs — "missed run resumes").
+   * Otherwise the window starts `lookbackMs` ago.
+   */
+  private async determinePeriod(
+    offeringId: string
+  ): Promise<{ periodStart: Date; periodEnd: Date }> {
+    const lastRun = await this.runStore.getLastRun(offeringId);
+    const periodEnd = new Date();
+    const periodStart = lastRun
+      ? lastRun.completedAt
+      : new Date(periodEnd.getTime() - this.lookbackMs);
+    return { periodStart, periodEnd };
+  }
+
+  /** Emit reconciliation_discrepancy_total and reconciliation_alarm_open. */
+  private emitMetrics(
+    label: string,
+    reconcileResult: ReconciliationResult,
+    runResult: SchedulerRunResult
+  ): void {
+    const labels = { offering_id: label };
+
+    if (reconcileResult.discrepancies.length > 0) {
+      this.metrics.incrementCounter(
+        METRIC_DISCREPANCY_TOTAL,
+        labels,
+        reconcileResult.discrepancies.length,
+        'Total reconciliation discrepancies detected by the scheduled job'
+      );
+    }
+
+    if (!reconcileResult.isBalanced) {
+      // Open (or keep open) the dead-letter alarm.
+      this.metrics.setGauge(
+        METRIC_ALARM_OPEN,
+        1,
+        labels,
+        'Dead-letter alarm: 1 when reconciliation found discrepancies or errored'
+      );
+      runResult.alarmRaised++;
+    } else {
+      // Clear the alarm — a balanced run always silences any prior alarm.
+      this.metrics.setGauge(METRIC_ALARM_OPEN, 0, labels);
+      runResult.alarmCleared++;
+    }
+  }
+
+  /**
+   * Produce a short, non-PII label from an offering ID.
+   * Uses the first 8 hex characters of a UUID (before the first "-") so the
+   * value does not match the full UUID regex that MetricsCollector filters out.
+   */
+  private shortLabel(offeringId: string): string {
+    return offeringId.split('-')[0] ?? offeringId.slice(0, 8);
+  }
+
+  /** Stable period identifier from a Date (ISO-month precision). */
+  private periodId(date: Date): string {
+    return date.toISOString().slice(0, 7); // e.g. "2026-05"
+  }
+}
+
+// ─── InMemoryReconciliationRunStore ───────────────────────────────────────────
+
+/**
+ * In-memory implementation of ReconciliationRunStore.
+ * Suitable for tests and single-instance deployments. For multi-instance
+ * production use, replace with the PostgreSQL-backed store driven by the
+ * 013_create_reconciliation_run_summaries.sql migration.
+ */
+export class InMemoryReconciliationRunStore implements ReconciliationRunStore {
+  // Key: offeringId → most-recent run summary
+  private readonly store = new Map<string, ReconciliationRunSummary>();
+
+  async saveRun(summary: ReconciliationRunSummary): Promise<void> {
+    const existing = this.store.get(summary.offeringId);
+    if (!existing || summary.startedAt >= existing.startedAt) {
+      this.store.set(summary.offeringId, summary);
+    }
+  }
+
+  async getLastRun(offeringId: string): Promise<ReconciliationRunSummary | null> {
+    return this.store.get(offeringId) ?? null;
+  }
+
+  /** Exposed for testing / inspection. */
+  getAllRuns(): ReconciliationRunSummary[] {
+    return [...this.store.values()];
+  }
+}


### PR DESCRIPTION
Closes #390

---

3 files, feat/scheduled-reconciliation-alarms:

[reconciliationScheduler.ts](vscode-webview://1f0rrkmugrqr29joc2n2f4snbckd1k7oav955j7as4ie3b40rkn0/src/services/reconciliationScheduler.ts)
ReconciliationScheduler — the main scheduler class, modeled on DistributionScheduler:

runScheduledReconciliation() iterates every offering whose status is in {open, active, processing, closed}, calls RevenueReconciliationService.reconcile() for each, persists the run summary, and emits two metrics per offering.

Missed-run resume: the reconciliation window opens from the previous run's completedAt timestamp (so there is never a gap between windows). First run falls back to lookbackMs (default 30 days) from now.

Dead-letter alarms: reconciliation_alarm_open{offering_id} is set to 1 when a run is imbalanced or throws, and 0 the moment a subsequent balanced run is seen — no manual reset required.

reconciliation_discrepancy_total{offering_id} counter increments by the number of discrepancies in each run (only when > 0, balanced runs don't touch it).

Cardinality cap: the first cardinalityLimit (default 50) offerings get individual labels; beyond that, offering_id="overflow" is used so the total time-series count stays within MetricsCollector.maxCardinality. Labels use the first UUID segment ("aaaa0000") rather than the full UUID so they don't trigger the PII redaction filter.

Error isolation: one offering's failure (DB timeout, RPC error, etc.) leaves the alarm open for that offering but processing continues for all others.

InMemoryReconciliationRunStore — implements the ReconciliationRunStore interface in-process (suitable for tests and single-instance deployments). Production deployments swap this for a PostgreSQL-backed store driven by the migration below.

[013_create_reconciliation_run_summaries.sql](vscode-webview://1f0rrkmugrqr29joc2n2f4snbckd1k7oav955j7as4ie3b40rkn0/src/db/migrations/013_create_reconciliation_run_summaries.sql)
reconciliation_run_summaries table with a natural composite PK (offering_id, period_id, started_at) that makes concurrent multi-instance writes idempotent. Two indexes: one for fast last-run lookups per offering, one partial index on is_balanced = FALSE for dashboard and alert queries.

[reconciliationScheduler.test.ts](vscode-webview://1f0rrkmugrqr29joc2n2f4snbckd1k7oav955j7as4ie3b40rkn0/src/services/reconciliationScheduler.test.ts)
22 test cases across 6 describe blocks — all mocked (no DB, no network):

Per-offering cadence: every active offering reconciled, inactive skipped, no-status treated as active, run summaries persisted
Missed-run resume: period starts from completedAt, falls back to lookbackMs, window advances without overlap on tick 2
Alarm semantics: raises on imbalance, clears on balanced follow-up, never raises on balanced-from-start, raises on thrown exception, independent per offering
Counter: increments on discrepancies, skipped on balanced, accumulates across ticks
Cardinality cap: overflow label applied beyond limit, short label format verified
Edge cases: empty offering list, per-offering failure isolation, tolerance forwarded to service