### PR TITLE
Add guarded Google and Apple social login

### DIFF
--- a/docs/social-login.md
+++ b/docs/social-login.md
@@ -1,0 +1,44 @@
+# Social Login Security Model
+
+Revora supports Google and Apple login through explicit account linking. A verified provider email
+is never enough to claim an existing password account.
+
+## Provider Verification
+
+`JwksSocialTokenVerifier` validates compact JWT identity tokens before any account lookup:
+
+- Google issuers are pinned to `https://accounts.google.com` and `accounts.google.com`.
+- Apple issuer is pinned to `https://appleid.apple.com`.
+- Audience must match configured client IDs:
+  - `GOOGLE_OAUTH_CLIENT_ID` or `GOOGLE_CLIENT_ID`
+  - `APPLE_CLIENT_ID` or `APPLE_SERVICE_ID`
+- Signatures are verified against provider JWKS using RS256.
+- Expired, not-yet-valid, missing-subject, missing-email, and unverified-email tokens are rejected.
+
+## Account Linking
+
+Social login works only after the primary account links the provider:
+
+1. The user signs in through the existing password flow.
+2. The user calls `POST /api/auth/social/:provider/link`.
+3. The request must include `confirm: true`, `currentPassword`, and a provider `idToken`.
+4. The current password is verified as step-up authentication before linking.
+
+The database enforces:
+
+- `UNIQUE (provider, provider_subject)` so one provider account cannot control multiple users.
+- `UNIQUE (user_id, provider)` so a user has at most one Google and one Apple identity.
+
+## Login Behavior
+
+`POST /api/auth/social/:provider/login` requires a verified provider token and an existing linked
+identity. If a password account exists with the same verified email but no linked identity, the
+login is rejected with `EMAIL_ACCOUNT_REQUIRES_LINK` to prevent unverified account takeover.
+
+If a provider email changes after linking, login continues to use the stable provider subject and
+updates the stored provider email only after the new email is verified by the provider.
+
+## Unlink Behavior
+
+`DELETE /api/auth/social/:provider/link` requires the same `confirm: true` and `currentPassword`
+step-up check. Unlink is idempotent: repeating unlink returns `{ "unlinked": false }`.

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,11 @@ import { RefreshTokenRepository, TokenService } from './auth/refresh/types';
 import { RefreshTokenRepositoryAdapter } from './auth/refresh/repositoryAdapter';
 import { JwtTokenServiceAdapter } from './auth/refresh/tokenServiceAdapter';
 import { errorHandler } from './middleware/errorHandler';
+import { SocialIdentityRepository } from './db/repositories/socialIdentityRepository';
+import { SocialUserRepositoryAdapter } from './auth/social/socialUserRepositoryAdapter';
+import { SocialAuthService } from './auth/social/socialAuthService';
+import { createDefaultSocialTokenVerifierFromEnv } from './auth/social/providerVerifiers';
+import { createSocialAuthRouter } from './auth/social/socialAuthRoute';
 
 // Adapter to convert database User to login service UserRecord
 class UserRepositoryAdapter implements IUserRepository {
@@ -200,6 +205,13 @@ export function createApp() {
     new SessionRepositoryAdapter(sessionRepository),
     jwtIssuer,
   );
+  const socialAuthService = new SocialAuthService(
+    new SocialUserRepositoryAdapter(userRepository),
+    new SocialIdentityRepository(pool),
+    new SessionRepositoryAdapter(sessionRepository),
+    jwtIssuer,
+    createDefaultSocialTokenVerifierFromEnv(),
+  );
 
   // Refresh service
   const refreshTokenRepository = new RefreshTokenRepositoryAdapter(sessionRepository);
@@ -209,6 +221,7 @@ export function createApp() {
 
   // Auth and health routes
   app.use(createLoginRouter({ loginService }));
+  app.use(createSocialAuthRouter({ socialAuthService, requireAuth }));
   app.use(createRefreshRouter({ refreshService }));
   app.use(createLogoutRouter({ requireAuth, sessionRepository }));
   app.use(createChangePasswordRouter({ requireAuth, db: pool }));

--- a/src/auth/social/providerVerifiers.ts
+++ b/src/auth/social/providerVerifiers.ts
@@ -1,0 +1,188 @@
+import { createPublicKey, createVerify } from 'node:crypto';
+import {
+  SocialAuthError,
+  SocialAuthProvider,
+  SocialProviderClaims,
+  SocialTokenVerifier,
+} from './types';
+
+interface JwtHeader {
+  alg?: string;
+  kid?: string;
+  typ?: string;
+}
+
+interface JwtPayload {
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  email?: string;
+  email_verified?: boolean | string;
+  exp?: number;
+  nbf?: number;
+}
+
+interface ProviderConfig {
+  provider: SocialAuthProvider;
+  issuers: readonly string[];
+  audiences: readonly string[];
+  jwksUrl: string;
+}
+
+interface JwksResponse {
+  keys: ProviderJwk[];
+}
+
+type ProviderJwk = Record<string, unknown> & { kid?: string };
+
+const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'] as const;
+const APPLE_ISSUERS = ['https://appleid.apple.com'] as const;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+function splitEnvList(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function decodeBase64Url(input: string): Buffer {
+  return Buffer.from(input, 'base64url');
+}
+
+function decodeJwtPart<T>(part: string): T {
+  try {
+    return JSON.parse(decodeBase64Url(part).toString('utf8')) as T;
+  } catch {
+    throw new SocialAuthError('INVALID_TOKEN', 'Identity token is not valid JSON.');
+  }
+}
+
+function normalizeEmailVerified(value: boolean | string | undefined): boolean {
+  return value === true || value === 'true';
+}
+
+function nowEpochSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export class JwksSocialTokenVerifier implements SocialTokenVerifier {
+  private readonly configs: Map<SocialAuthProvider, ProviderConfig>;
+  private readonly jwksCache = new Map<string, { expiresAt: number; keys: ProviderJwk[] }>();
+
+  constructor(configs: ProviderConfig[]) {
+    this.configs = new Map(configs.map((config) => [config.provider, config]));
+  }
+
+  async verify(provider: SocialAuthProvider, idToken: string): Promise<SocialProviderClaims> {
+    const config = this.configs.get(provider);
+    if (!config || config.audiences.length === 0) {
+      throw new SocialAuthError('PROVIDER_NOT_CONFIGURED', `${provider} social login is not configured.`);
+    }
+
+    const parts = idToken.split('.');
+    if (parts.length !== 3) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token must be a compact JWT.');
+    }
+
+    const [encodedHeader, encodedPayload, encodedSignature] = parts;
+    const header = decodeJwtPart<JwtHeader>(encodedHeader);
+    const payload = decodeJwtPart<JwtPayload>(encodedPayload);
+
+    if (header.alg !== 'RS256') {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token must use RS256.');
+    }
+    if (!header.kid) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token is missing a key id.');
+    }
+    if (!payload.iss || !config.issuers.includes(payload.iss)) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token issuer is not trusted.');
+    }
+
+    const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud].filter(Boolean);
+    const audience = audiences.find((candidate): candidate is string =>
+      typeof candidate === 'string' && config.audiences.includes(candidate),
+    );
+    if (!audience) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token audience is not allowed.');
+    }
+
+    const now = nowEpochSeconds();
+    if (typeof payload.exp !== 'number' || payload.exp <= now) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token has expired.');
+    }
+    if (typeof payload.nbf === 'number' && payload.nbf > now) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token is not valid yet.');
+    }
+    if (!payload.sub || !payload.email) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token is missing subject or email.');
+    }
+
+    await this.verifySignature(config, header.kid, `${encodedHeader}.${encodedPayload}`, encodedSignature);
+
+    return {
+      provider,
+      subject: payload.sub,
+      email: payload.email.toLowerCase().trim(),
+      emailVerified: normalizeEmailVerified(payload.email_verified),
+      issuer: payload.iss,
+      audience,
+    };
+  }
+
+  private async verifySignature(
+    config: ProviderConfig,
+    kid: string,
+    signingInput: string,
+    encodedSignature: string,
+  ): Promise<void> {
+    const keys = await this.getJwks(config.jwksUrl);
+    const jwk = keys.find((key) => key.kid === kid);
+    if (!jwk) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token key id is not trusted.');
+    }
+
+    const publicKey = createPublicKey({ key: jwk as any, format: 'jwk' });
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(signingInput);
+    verifier.end();
+
+    if (!verifier.verify(publicKey, decodeBase64Url(encodedSignature))) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Identity token signature is invalid.');
+    }
+  }
+
+  private async getJwks(jwksUrl: string): Promise<ProviderJwk[]> {
+    const cached = this.jwksCache.get(jwksUrl);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.keys;
+    }
+
+    const response = await fetch(jwksUrl);
+    if (!response.ok) {
+      throw new SocialAuthError('INVALID_TOKEN', 'Unable to fetch provider signing keys.');
+    }
+
+    const body = (await response.json()) as JwksResponse;
+    const keys = Array.isArray(body.keys) ? body.keys : [];
+    this.jwksCache.set(jwksUrl, { keys, expiresAt: Date.now() + CACHE_TTL_MS });
+    return keys;
+  }
+}
+
+export function createDefaultSocialTokenVerifierFromEnv(): SocialTokenVerifier {
+  return new JwksSocialTokenVerifier([
+    {
+      provider: 'google',
+      issuers: GOOGLE_ISSUERS,
+      audiences: splitEnvList(process.env.GOOGLE_OAUTH_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID),
+      jwksUrl: 'https://www.googleapis.com/oauth2/v3/certs',
+    },
+    {
+      provider: 'apple',
+      issuers: APPLE_ISSUERS,
+      audiences: splitEnvList(process.env.APPLE_CLIENT_ID ?? process.env.APPLE_SERVICE_ID),
+      jwksUrl: 'https://appleid.apple.com/auth/keys',
+    },
+  ]);
+}

--- a/src/auth/social/socialAuthHandler.ts
+++ b/src/auth/social/socialAuthHandler.ts
@@ -1,0 +1,122 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { SocialAuthService } from './socialAuthService';
+import { SocialAuthError, SocialAuthProvider } from './types';
+
+const PROVIDERS = new Set<SocialAuthProvider>(['google', 'apple']);
+
+function getProvider(req: Request): SocialAuthProvider {
+  const provider = req.params.provider;
+  if (!PROVIDERS.has(provider as SocialAuthProvider)) {
+    throw new SocialAuthError('INVALID_PROVIDER', 'Unsupported social auth provider.');
+  }
+  return provider as SocialAuthProvider;
+}
+
+function getUserId(req: Request): string | undefined {
+  return (req as any).user?.sub ?? (req as any).user?.id ?? (req as any).auth?.userId;
+}
+
+function mapError(error: SocialAuthError): { status: number; code: string; message: string } {
+  switch (error.code) {
+    case 'INVALID_PROVIDER':
+    case 'PROVIDER_NOT_CONFIGURED':
+    case 'INVALID_TOKEN':
+    case 'UNVERIFIED_EMAIL':
+      return { status: 400, code: error.code, message: error.message };
+    case 'STEP_UP_REQUIRED':
+    case 'SOCIAL_IDENTITY_NOT_LINKED':
+    case 'EMAIL_ACCOUNT_REQUIRES_LINK':
+      return { status: 401, code: error.code, message: error.message };
+    case 'IDENTITY_LINKED_TO_ANOTHER_USER':
+      return { status: 409, code: error.code, message: error.message };
+    case 'USER_NOT_FOUND':
+      return { status: 404, code: error.code, message: error.message };
+    default:
+      return { status: 400, code: error.code, message: error.message };
+  }
+}
+
+function requireString(body: unknown, field: string): string {
+  const value = (body as Record<string, unknown> | undefined)?.[field];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new SocialAuthError('INVALID_TOKEN', `${field} is required.`);
+  }
+  return value;
+}
+
+function requireConfirmation(body: unknown): void {
+  if ((body as Record<string, unknown> | undefined)?.confirm !== true) {
+    throw new SocialAuthError('STEP_UP_REQUIRED', 'Link changes require confirm: true.');
+  }
+}
+
+export function createSocialLoginHandler(service: SocialAuthService): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const result = await service.loginWithProvider(getProvider(req), requireString(req.body, 'idToken'));
+      res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof SocialAuthError) {
+        const mapped = mapError(error);
+        res.status(mapped.status).json({ error: mapped.code, message: mapped.message });
+        return;
+      }
+      next(error);
+    }
+  };
+}
+
+export function createSocialLinkHandler(service: SocialAuthService): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      requireConfirmation(req.body);
+      const userId = getUserId(req);
+      if (!userId) throw new SocialAuthError('STEP_UP_REQUIRED', 'Authenticated user is required.');
+
+      const result = await service.linkProvider({
+        userId,
+        provider: getProvider(req),
+        idToken: requireString(req.body, 'idToken'),
+        currentPassword: requireString(req.body, 'currentPassword'),
+      });
+
+      res.status(200).json({
+        linked: result.linked,
+        provider: result.identity.provider,
+        providerEmail: result.identity.providerEmail,
+      });
+    } catch (error) {
+      if (error instanceof SocialAuthError) {
+        const mapped = mapError(error);
+        res.status(mapped.status).json({ error: mapped.code, message: mapped.message });
+        return;
+      }
+      next(error);
+    }
+  };
+}
+
+export function createSocialUnlinkHandler(service: SocialAuthService): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      requireConfirmation(req.body);
+      const userId = getUserId(req);
+      if (!userId) throw new SocialAuthError('STEP_UP_REQUIRED', 'Authenticated user is required.');
+
+      const result = await service.unlinkProvider({
+        userId,
+        provider: getProvider(req),
+        currentPassword: requireString(req.body, 'currentPassword'),
+      });
+
+      res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof SocialAuthError) {
+        const mapped = mapError(error);
+        res.status(mapped.status).json({ error: mapped.code, message: mapped.message });
+        return;
+      }
+      next(error);
+    }
+  };
+}

--- a/src/auth/social/socialAuthRoute.ts
+++ b/src/auth/social/socialAuthRoute.ts
@@ -1,0 +1,30 @@
+import { Router, RequestHandler } from 'express';
+import {
+  createSocialLinkHandler,
+  createSocialLoginHandler,
+  createSocialUnlinkHandler,
+} from './socialAuthHandler';
+import { SocialAuthService } from './socialAuthService';
+
+export interface SocialAuthRouterDependencies {
+  socialAuthService: SocialAuthService;
+  requireAuth: RequestHandler;
+}
+
+export function createSocialAuthRouter(deps: SocialAuthRouterDependencies): Router {
+  const router = Router();
+
+  router.post('/api/auth/social/:provider/login', createSocialLoginHandler(deps.socialAuthService));
+  router.post(
+    '/api/auth/social/:provider/link',
+    deps.requireAuth,
+    createSocialLinkHandler(deps.socialAuthService),
+  );
+  router.delete(
+    '/api/auth/social/:provider/link',
+    deps.requireAuth,
+    createSocialUnlinkHandler(deps.socialAuthService),
+  );
+
+  return router;
+}

--- a/src/auth/social/socialAuthService.test.ts
+++ b/src/auth/social/socialAuthService.test.ts
@@ -1,0 +1,279 @@
+import { createHash } from 'node:crypto';
+import { JwtIssuer, SessionRepository, UserRole } from '../login/types';
+import { SocialAuthService } from './socialAuthService';
+import {
+  SocialIdentityRecord,
+  SocialIdentityRepository,
+  SocialProviderClaims,
+  SocialTokenVerifier,
+  SocialUserRecord,
+  SocialUserRepository,
+} from './types';
+
+const hashPassword = (plain: string): string =>
+  createHash('sha256').update(plain).digest('hex');
+
+class FakeUsers implements SocialUserRepository {
+  private users = new Map<string, SocialUserRecord>();
+
+  add(user: SocialUserRecord): void {
+    this.users.set(user.id, user);
+  }
+
+  async findById(id: string): Promise<SocialUserRecord | null> {
+    return this.users.get(id) ?? null;
+  }
+
+  async findByEmail(email: string): Promise<SocialUserRecord | null> {
+    return [...this.users.values()].find((user) => user.email === email) ?? null;
+  }
+}
+
+class FakeIdentities implements SocialIdentityRepository {
+  identities = new Map<string, SocialIdentityRecord>();
+
+  async findByProviderSubject(
+    provider: 'google' | 'apple',
+    providerSubject: string,
+  ): Promise<SocialIdentityRecord | null> {
+    return (
+      [...this.identities.values()].find(
+        (identity) =>
+          identity.provider === provider && identity.providerSubject === providerSubject,
+      ) ?? null
+    );
+  }
+
+  async findByUserAndProvider(
+    userId: string,
+    provider: 'google' | 'apple',
+  ): Promise<SocialIdentityRecord | null> {
+    return (
+      [...this.identities.values()].find(
+        (identity) => identity.userId === userId && identity.provider === provider,
+      ) ?? null
+    );
+  }
+
+  async createIdentity(input: {
+    userId: string;
+    provider: 'google' | 'apple';
+    providerSubject: string;
+    providerEmail: string;
+    emailVerified: boolean;
+  }): Promise<SocialIdentityRecord> {
+    const identity: SocialIdentityRecord = {
+      id: `identity-${this.identities.size + 1}`,
+      userId: input.userId,
+      provider: input.provider,
+      providerSubject: input.providerSubject,
+      providerEmail: input.providerEmail,
+      emailVerified: input.emailVerified,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.identities.set(identity.id, identity);
+    return identity;
+  }
+
+  async updateIdentityEmail(id: string, providerEmail: string): Promise<void> {
+    const identity = this.identities.get(id);
+    if (identity) {
+      identity.providerEmail = providerEmail;
+      identity.emailVerified = true;
+      identity.updatedAt = new Date();
+    }
+  }
+
+  async deleteByUserAndProvider(userId: string, provider: 'google' | 'apple'): Promise<boolean> {
+    const identity = await this.findByUserAndProvider(userId, provider);
+    if (!identity) return false;
+    this.identities.delete(identity.id);
+    return true;
+  }
+}
+
+class FakeVerifier implements SocialTokenVerifier {
+  claims: SocialProviderClaims = {
+    provider: 'google',
+    subject: 'google-subject-1',
+    email: 'verified@example.com',
+    emailVerified: true,
+    issuer: 'https://accounts.google.com',
+    audience: 'client-id',
+  };
+
+  async verify(): Promise<SocialProviderClaims> {
+    return this.claims;
+  }
+}
+
+class FakeSessions implements SessionRepository {
+  sessions: Array<{ id: string; userId: string; tokenHash: string; expiresAt: Date }> = [];
+
+  async createSession(input: {
+    id: string;
+    userId: string;
+    tokenHash: string;
+    expiresAt: Date;
+  }): Promise<void> {
+    this.sessions.push(input);
+  }
+}
+
+class FakeJwtIssuer implements JwtIssuer {
+  sign(payload: { userId: string; sessionId: string; role: UserRole }) {
+    return {
+      accessToken: `access-${payload.userId}-${payload.sessionId}`,
+      refreshToken: `refresh-${payload.userId}-${payload.sessionId}`,
+    };
+  }
+}
+
+function fixture() {
+  const users = new FakeUsers();
+  const identities = new FakeIdentities();
+  const sessions = new FakeSessions();
+  const verifier = new FakeVerifier();
+  const service = new SocialAuthService(
+    users,
+    identities,
+    sessions,
+    new FakeJwtIssuer(),
+    verifier,
+  );
+  return { users, identities, sessions, verifier, service };
+}
+
+describe('SocialAuthService', () => {
+  it('rejects unverified provider email before lookup or linking', async () => {
+    const { users, verifier, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'verified@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+    verifier.claims = { ...verifier.claims, emailVerified: false };
+
+    await expect(
+      service.linkProvider({
+        userId: 'user-1',
+        provider: 'google',
+        idToken: 'token',
+        currentPassword: 'Password123!',
+      }),
+    ).rejects.toMatchObject({ code: 'UNVERIFIED_EMAIL' });
+  });
+
+  it('does not social-login an existing password account by email without explicit link', async () => {
+    const { users, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'verified@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+
+    await expect(service.loginWithProvider('google', 'token')).rejects.toMatchObject({
+      code: 'EMAIL_ACCOUNT_REQUIRES_LINK',
+    });
+  });
+
+  it('links with password step-up and then logs in through the provider', async () => {
+    const { users, sessions, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'verified@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+
+    await service.linkProvider({
+      userId: 'user-1',
+      provider: 'google',
+      idToken: 'token',
+      currentPassword: 'Password123!',
+    });
+    const result = await service.loginWithProvider('google', 'token');
+
+    expect(result.user.id).toBe('user-1');
+    expect(result.accessToken).toContain('access-user-1-');
+    expect(sessions.sessions).toHaveLength(1);
+  });
+
+  it('rejects link attempts without correct current password', async () => {
+    const { users, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'verified@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+
+    await expect(
+      service.linkProvider({
+        userId: 'user-1',
+        provider: 'google',
+        idToken: 'token',
+        currentPassword: 'wrong',
+      }),
+    ).rejects.toMatchObject({ code: 'STEP_UP_REQUIRED' });
+  });
+
+  it('keeps login bound to provider subject when provider email changes', async () => {
+    const { users, identities, verifier, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'old@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+    await identities.createIdentity({
+      userId: 'user-1',
+      provider: 'google',
+      providerSubject: 'google-subject-1',
+      providerEmail: 'old@example.com',
+      emailVerified: true,
+    });
+    verifier.claims = { ...verifier.claims, email: 'new@example.com', emailVerified: true };
+
+    const result = await service.loginWithProvider('google', 'token');
+
+    expect(result.user.id).toBe('user-1');
+    expect((await identities.findByUserAndProvider('user-1', 'google'))?.providerEmail).toBe(
+      'new@example.com',
+    );
+  });
+
+  it('unlink is idempotent after the first successful unlink', async () => {
+    const { users, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'verified@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+    await service.linkProvider({
+      userId: 'user-1',
+      provider: 'google',
+      idToken: 'token',
+      currentPassword: 'Password123!',
+    });
+
+    await expect(
+      service.unlinkProvider({
+        userId: 'user-1',
+        provider: 'google',
+        currentPassword: 'Password123!',
+      }),
+    ).resolves.toEqual({ unlinked: true });
+    await expect(
+      service.unlinkProvider({
+        userId: 'user-1',
+        provider: 'google',
+        currentPassword: 'Password123!',
+      }),
+    ).resolves.toEqual({ unlinked: false });
+  });
+});

--- a/src/auth/social/socialAuthService.ts
+++ b/src/auth/social/socialAuthService.ts
@@ -1,0 +1,183 @@
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import { JwtIssuer, SessionRepository } from '../login/types';
+import {
+  SocialAuthError,
+  SocialAuthProvider,
+  SocialIdentityRepository,
+  SocialLinkResult,
+  SocialLoginResult,
+  SocialTokenVerifier,
+  SocialUnlinkResult,
+  SocialUserRecord,
+  SocialUserRepository,
+} from './types';
+
+export class SocialAuthService {
+  constructor(
+    private readonly userRepository: SocialUserRepository,
+    private readonly identityRepository: SocialIdentityRepository,
+    private readonly sessionRepository: SessionRepository,
+    private readonly jwtIssuer: JwtIssuer,
+    private readonly tokenVerifier: SocialTokenVerifier,
+  ) {}
+
+  async loginWithProvider(
+    provider: SocialAuthProvider,
+    idToken: string,
+  ): Promise<SocialLoginResult> {
+    const claims = await this.verifyVerifiedEmail(provider, idToken);
+    const identity = await this.identityRepository.findByProviderSubject(provider, claims.subject);
+
+    if (!identity) {
+      const emailUser = await this.userRepository.findByEmail(claims.email);
+      if (emailUser) {
+        throw new SocialAuthError(
+          'EMAIL_ACCOUNT_REQUIRES_LINK',
+          'A password account with this email exists. Sign in and link the provider first.',
+        );
+      }
+      throw new SocialAuthError('SOCIAL_IDENTITY_NOT_LINKED', 'Social identity is not linked.');
+    }
+
+    const user = await this.userRepository.findById(identity.userId);
+    if (!user) {
+      throw new SocialAuthError('USER_NOT_FOUND', 'Linked user was not found.');
+    }
+
+    if (identity.providerEmail !== claims.email) {
+      await this.identityRepository.updateIdentityEmail(identity.id, claims.email);
+    }
+
+    return this.issueSession(user);
+  }
+
+  async linkProvider(input: {
+    userId: string;
+    provider: SocialAuthProvider;
+    idToken: string;
+    currentPassword: string;
+  }): Promise<SocialLinkResult> {
+    const user = await this.requireUserWithPassword(input.userId, input.currentPassword);
+    const claims = await this.verifyVerifiedEmail(input.provider, input.idToken);
+
+    const existingProviderSubject = await this.identityRepository.findByProviderSubject(
+      input.provider,
+      claims.subject,
+    );
+    if (existingProviderSubject && existingProviderSubject.userId !== input.userId) {
+      throw new SocialAuthError(
+        'IDENTITY_LINKED_TO_ANOTHER_USER',
+        'Social identity is already linked to another account.',
+      );
+    }
+
+    const existingUserProvider = await this.identityRepository.findByUserAndProvider(
+      input.userId,
+      input.provider,
+    );
+
+    if (existingUserProvider) {
+      if (existingUserProvider.providerSubject !== claims.subject) {
+        throw new SocialAuthError(
+          'IDENTITY_LINKED_TO_ANOTHER_USER',
+          'This account already has a different identity for the provider.',
+        );
+      }
+      if (existingUserProvider.providerEmail !== claims.email) {
+        await this.identityRepository.updateIdentityEmail(existingUserProvider.id, claims.email);
+      }
+      return { linked: true, identity: existingUserProvider };
+    }
+
+    if (user.email !== claims.email) {
+      const emailUser = await this.userRepository.findByEmail(claims.email);
+      if (emailUser && emailUser.id !== input.userId) {
+        throw new SocialAuthError(
+          'EMAIL_ACCOUNT_REQUIRES_LINK',
+          'Provider email belongs to another password account.',
+        );
+      }
+    }
+
+    const identity = await this.identityRepository.createIdentity({
+      userId: input.userId,
+      provider: input.provider,
+      providerSubject: claims.subject,
+      providerEmail: claims.email,
+      emailVerified: claims.emailVerified,
+    });
+
+    return { linked: true, identity };
+  }
+
+  async unlinkProvider(input: {
+    userId: string;
+    provider: SocialAuthProvider;
+    currentPassword: string;
+  }): Promise<SocialUnlinkResult> {
+    await this.requireUserWithPassword(input.userId, input.currentPassword);
+    const unlinked = await this.identityRepository.deleteByUserAndProvider(
+      input.userId,
+      input.provider,
+    );
+    return { unlinked };
+  }
+
+  private async verifyVerifiedEmail(provider: SocialAuthProvider, idToken: string) {
+    const claims = await this.tokenVerifier.verify(provider, idToken);
+    if (!claims.emailVerified) {
+      throw new SocialAuthError(
+        'UNVERIFIED_EMAIL',
+        'Provider email must be verified before it can be used.',
+      );
+    }
+    return claims;
+  }
+
+  private async requireUserWithPassword(
+    userId: string,
+    currentPassword: string,
+  ): Promise<SocialUserRecord> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new SocialAuthError('USER_NOT_FOUND', 'User was not found.');
+    }
+    if (!currentPassword || !this.verifyPassword(currentPassword, user.passwordHash)) {
+      throw new SocialAuthError('STEP_UP_REQUIRED', 'Current password confirmation is required.');
+    }
+    return user;
+  }
+
+  private async issueSession(user: SocialUserRecord): Promise<SocialLoginResult> {
+    const sessionId = randomUUID();
+    const tokens = this.jwtIssuer.sign({
+      userId: user.id,
+      sessionId,
+      role: user.role,
+    });
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    await this.sessionRepository.createSession({
+      id: sessionId,
+      userId: user.id,
+      tokenHash: createHash('sha256').update(tokens.refreshToken).digest('hex'),
+      expiresAt,
+    });
+
+    return {
+      ...tokens,
+      user: {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+      },
+    };
+  }
+
+  private verifyPassword(plaintext: string, storedHash: string): boolean {
+    const candidateHash = createHash('sha256').update(plaintext).digest('hex');
+    const candidate = Buffer.from(candidateHash, 'utf-8');
+    const stored = Buffer.from(storedHash, 'utf-8');
+    return candidate.length === stored.length && timingSafeEqual(candidate, stored);
+  }
+}

--- a/src/auth/social/socialUserRepositoryAdapter.ts
+++ b/src/auth/social/socialUserRepositoryAdapter.ts
@@ -1,0 +1,30 @@
+import { UserRepository as DbUserRepository } from '../../db/repositories/userRepository';
+import { SocialUserRecord, SocialUserRepository } from './types';
+
+export class SocialUserRepositoryAdapter implements SocialUserRepository {
+  constructor(private readonly dbUserRepository: DbUserRepository) {}
+
+  async findById(id: string): Promise<SocialUserRecord | null> {
+    const user = await this.dbUserRepository.findById(id);
+    return user ? this.mapUser(user) : null;
+  }
+
+  async findByEmail(email: string): Promise<SocialUserRecord | null> {
+    const user = await this.dbUserRepository.findByEmail(email);
+    return user ? this.mapUser(user) : null;
+  }
+
+  private mapUser(user: {
+    id: string;
+    email: string;
+    role: 'startup' | 'investor';
+    password_hash: string;
+  }): SocialUserRecord {
+    return {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+      passwordHash: user.password_hash,
+    };
+  }
+}

--- a/src/auth/social/types.ts
+++ b/src/auth/social/types.ts
@@ -1,0 +1,92 @@
+import { LoginSuccessResponse, UserRole } from '../login/types';
+
+export type SocialAuthProvider = 'google' | 'apple';
+
+export interface SocialProviderClaims {
+  provider: SocialAuthProvider;
+  subject: string;
+  email: string;
+  emailVerified: boolean;
+  issuer: string;
+  audience: string;
+}
+
+export interface SocialTokenVerifier {
+  verify(provider: SocialAuthProvider, idToken: string): Promise<SocialProviderClaims>;
+}
+
+export interface SocialIdentityRecord {
+  id: string;
+  userId: string;
+  provider: SocialAuthProvider;
+  providerSubject: string;
+  providerEmail: string;
+  emailVerified: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SocialIdentityRepository {
+  findByProviderSubject(
+    provider: SocialAuthProvider,
+    providerSubject: string,
+  ): Promise<SocialIdentityRecord | null>;
+  findByUserAndProvider(
+    userId: string,
+    provider: SocialAuthProvider,
+  ): Promise<SocialIdentityRecord | null>;
+  createIdentity(input: {
+    userId: string;
+    provider: SocialAuthProvider;
+    providerSubject: string;
+    providerEmail: string;
+    emailVerified: boolean;
+  }): Promise<SocialIdentityRecord>;
+  updateIdentityEmail(id: string, providerEmail: string): Promise<void>;
+  deleteByUserAndProvider(userId: string, provider: SocialAuthProvider): Promise<boolean>;
+}
+
+export interface SocialUserRecord {
+  id: string;
+  email: string;
+  role: UserRole;
+  passwordHash: string;
+}
+
+export interface SocialUserRepository {
+  findById(id: string): Promise<SocialUserRecord | null>;
+  findByEmail(email: string): Promise<SocialUserRecord | null>;
+}
+
+export type SocialAuthErrorCode =
+  | 'INVALID_PROVIDER'
+  | 'PROVIDER_NOT_CONFIGURED'
+  | 'INVALID_TOKEN'
+  | 'UNVERIFIED_EMAIL'
+  | 'SOCIAL_IDENTITY_NOT_LINKED'
+  | 'EMAIL_ACCOUNT_REQUIRES_LINK'
+  | 'USER_NOT_FOUND'
+  | 'STEP_UP_REQUIRED'
+  | 'IDENTITY_LINKED_TO_ANOTHER_USER';
+
+export class SocialAuthError extends Error {
+  constructor(
+    public readonly code: SocialAuthErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SocialAuthError';
+    Object.setPrototypeOf(this, SocialAuthError.prototype);
+  }
+}
+
+export interface SocialLinkResult {
+  linked: true;
+  identity: SocialIdentityRecord;
+}
+
+export interface SocialUnlinkResult {
+  unlinked: boolean;
+}
+
+export type SocialLoginResult = LoginSuccessResponse;

--- a/src/db/migrations/015_create_social_identities.sql
+++ b/src/db/migrations/015_create_social_identities.sql
@@ -1,0 +1,23 @@
+-- Migration: Create social identities table
+-- Description: Links verified Google/Apple provider subjects to existing users.
+
+CREATE TABLE IF NOT EXISTS social_identities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL CHECK (provider IN ('google', 'apple')),
+  provider_subject TEXT NOT NULL,
+  provider_email TEXT NOT NULL,
+  email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT social_identities_provider_subject_unique
+    UNIQUE (provider, provider_subject),
+  CONSTRAINT social_identities_user_provider_unique
+    UNIQUE (user_id, provider)
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_identities_user_id
+  ON social_identities(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_social_identities_provider_email
+  ON social_identities(provider, provider_email);

--- a/src/db/repositories/socialIdentityRepository.ts
+++ b/src/db/repositories/socialIdentityRepository.ts
@@ -1,0 +1,120 @@
+import { Pool, QueryResult } from 'pg';
+import {
+  SocialAuthProvider,
+  SocialIdentityRecord,
+  SocialIdentityRepository as ISocialIdentityRepository,
+} from '../../auth/social/types';
+
+interface SocialIdentityRow {
+  id: string;
+  user_id: string;
+  provider: SocialAuthProvider;
+  provider_subject: string;
+  provider_email: string;
+  email_verified: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export class SocialIdentityRepository implements ISocialIdentityRepository {
+  constructor(private readonly db: Pool) {}
+
+  async findByProviderSubject(
+    provider: SocialAuthProvider,
+    providerSubject: string,
+  ): Promise<SocialIdentityRecord | null> {
+    const result: QueryResult<SocialIdentityRow> = await this.db.query(
+      `
+        SELECT *
+        FROM social_identities
+        WHERE provider = $1 AND provider_subject = $2
+        LIMIT 1
+      `,
+      [provider, providerSubject],
+    );
+    return result.rows[0] ? this.mapRow(result.rows[0]) : null;
+  }
+
+  async findByUserAndProvider(
+    userId: string,
+    provider: SocialAuthProvider,
+  ): Promise<SocialIdentityRecord | null> {
+    const result: QueryResult<SocialIdentityRow> = await this.db.query(
+      `
+        SELECT *
+        FROM social_identities
+        WHERE user_id = $1 AND provider = $2
+        LIMIT 1
+      `,
+      [userId, provider],
+    );
+    return result.rows[0] ? this.mapRow(result.rows[0]) : null;
+  }
+
+  async createIdentity(input: {
+    userId: string;
+    provider: SocialAuthProvider;
+    providerSubject: string;
+    providerEmail: string;
+    emailVerified: boolean;
+  }): Promise<SocialIdentityRecord> {
+    const result: QueryResult<SocialIdentityRow> = await this.db.query(
+      `
+        INSERT INTO social_identities (
+          user_id,
+          provider,
+          provider_subject,
+          provider_email,
+          email_verified,
+          created_at,
+          updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+        RETURNING *
+      `,
+      [
+        input.userId,
+        input.provider,
+        input.providerSubject,
+        input.providerEmail,
+        input.emailVerified,
+      ],
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async updateIdentityEmail(id: string, providerEmail: string): Promise<void> {
+    await this.db.query(
+      `
+        UPDATE social_identities
+        SET provider_email = $1, email_verified = TRUE, updated_at = NOW()
+        WHERE id = $2
+      `,
+      [providerEmail, id],
+    );
+  }
+
+  async deleteByUserAndProvider(userId: string, provider: SocialAuthProvider): Promise<boolean> {
+    const result = await this.db.query(
+      `
+        DELETE FROM social_identities
+        WHERE user_id = $1 AND provider = $2
+      `,
+      [userId, provider],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  private mapRow(row: SocialIdentityRow): SocialIdentityRecord {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      provider: row.provider,
+      providerSubject: row.provider_subject,
+      providerEmail: row.provider_email,
+      emailVerified: row.email_verified,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add Google/Apple social token verification with issuer/audience pinning and JWKS signature validation
- add guarded social login, link, and unlink routes with verified-email enforcement and password step-up for link changes
- add social_identities migration with unique provider-subject and user-provider constraints
- document the social login security model and cover takeover/edge cases in tests

Closes #428

## Tests
- npx jest src/auth/social/socialAuthService.test.ts --runInBand
- npx jest src/auth/login/loginRoute.test.ts src/auth/social/socialAuthService.test.ts --runInBand
- npx tsc --noEmit --pretty false --skipLibCheck --target ES2022 --module CommonJS --strict --esModuleInterop --types node,jest src/auth/social/types.ts src/auth/social/providerVerifiers.ts src/auth/social/socialAuthService.ts src/auth/social/socialAuthHandler.ts src/auth/social/socialAuthRoute.ts src/auth/social/socialAuthService.test.ts src/db/repositories/socialIdentityRepository.ts
- git diff --check

## Repo notes
- Full npx tsc --noEmit is blocked by pre-existing syntax errors in src/lib/stellarRpcClient.ts, src/routes/offerings.ts, and src/services/revenueService.test.ts.
- ESLint cannot run with the current repo config because ESLint 9 expects eslint.config.* while the repo has .eslintrc.cjs.