### PR TITLE
feat: KYC risk-tier-driven investment caps

### DIFF
--- a/docs/kyc-risk-tier-investment-caps.md
+++ b/docs/kyc-risk-tier-investment-caps.md
@@ -1,0 +1,131 @@
+# KYC Risk-Tier Investment Caps
+
+## Overview
+
+Investment concentration caps were previously static per offering
+(`offerings.max_investor_share_bps`). This feature adds a **per-investor**
+dynamic adjustment driven by `users.kyc_risk_tier`, so higher-risk investors
+face a lower effective cap on **new** investment intents.
+
+Cap changes (tier upgrades/downgrades) **never retroactively invalidate**
+existing investments. A previously blocked intent is re-evaluated only on the
+next `createInvestment` call after the tier change.
+
+---
+
+## Risk tiers and multipliers
+
+| Tier         | Multiplier on offering `max_investor_share_bps` | Notes |
+|--------------|--------------------------------------------------|-------|
+| `low`        | 1.0                                              | Full offering cap |
+| `standard`   | 1.0                                              | Default for new users |
+| `elevated`   | 0.5                                              | Half offering cap |
+| `high`       | 0.25                                             | Quarter offering cap |
+| `restricted` | 0                                                | Blocks all new capital (even if offering has no static cap) |
+
+`effective_cap_bps = floor(offering_cap_bps × multiplier)`, clamped to `[0, 10000]`.
+
+When the offering has **no** static cap (`NULL`):
+
+- Non-`restricted` tiers → unlimited (no concentration check)
+- `restricted` → effective cap `0` (new intents blocked)
+
+---
+
+## Implementation
+
+| Piece | Path |
+|-------|------|
+| Migration | `src/db/migrations/016_add_kyc_risk_tier_to_users.sql` |
+| Pure resolver | `src/lib/kycRiskTierCaps.ts` |
+| Tier update + audit | `src/services/kycRiskTierService.ts` |
+| Cap gate on invest | `src/services/investmentService.ts` (`assertKycTierCap`) |
+| Admin API | `PATCH /api/admin/investors/:id/kyc-risk-tier` |
+
+### `resolveEffectiveCap(offeringCapBps, tier)`
+
+Returns `{ tier, multiplier, offeringCapBps, effectiveCapBps }`.
+
+### `evaluateInvestmentAgainstCap({ existingTotal, newAmount, totalOfferingAmount, resolution })`
+
+Pure allow/deny for a single intent. Callers supply the existing commitment total;
+this module never mutates investment rows.
+
+### `KycRiskTierService.updateKycRiskTier`
+
+Persists the new tier and emits audit action **`investor.cap.recalculated`** with:
+
+- `previous_tier`, `new_tier`, `multiplier`, `effective_cap_bps`
+- `retroactive_invalidation: false`
+- `changed: boolean`
+
+---
+
+## Security assumptions
+
+1. Only **admin** callers may change `kyc_risk_tier` (`requireAdmin` on the admin route).
+2. Cap enforcement runs inside `InvestmentService.createInvestment` before insert.
+3. Existing investments are never deleted, reduced, or status-flipped by a tier change.
+4. Investors cannot self-elevate their tier via the public investment API.
+5. Invalid / missing tier values coerce to `standard` when read from the DB
+   (`parseKycRiskTier`), preventing accidental lockouts from corrupt rows.
+6. Audit emission uses `SecurityAuditRepository` (same pattern as AML).
+
+---
+
+## Abuse and failure paths
+
+| Scenario | Behaviour |
+|----------|-----------|
+| High-risk investor exceeds adjusted cap | `403` with KYC risk-tier adjusted cap message |
+| `restricted` investor, any positive amount | `403` (effective cap 0) |
+| Tier upgraded after a blocked intent | Next `createInvestment` re-checks; may succeed if under new cap |
+| Tier downgraded after large commitment | Existing rows kept; further amounts blocked if over new cap |
+| Offering has `NULL` cap, non-restricted tier | Allowed (unlimited) |
+| Non-investor user id on tier update | `400` validation error |
+| Unknown investor on tier update | `404` |
+| Unauthenticated admin tier patch | `401` |
+| Non-admin role on tier patch | `403` |
+
+---
+
+## Test coverage
+
+| File | Focus |
+|------|-------|
+| `src/lib/__tests__/kycRiskTierCaps.test.ts` | Multipliers, boundaries, upgrade-on-next-intent, no retroactive clawback semantics |
+| `src/services/__tests__/kycRiskTierService.test.ts` | Tier update + `investor.cap.recalculated` audit |
+| `src/services/investmentService.test.ts` | Service wiring: block / allow-after-upgrade / restricted / no DELETE |
+
+Target: ≥95% coverage on new modules (`kycRiskTierCaps.ts`, `kycRiskTierService.ts`).
+
+---
+
+## Example usage
+
+```http
+PATCH /api/admin/investors/investor-1/kyc-risk-tier
+Authorization: Bearer <admin-jwt>
+Content-Type: application/json
+
+{ "tier": "high", "offering_cap_bps": 1000 }
+```
+
+```json
+{
+  "investor_id": "investor-1",
+  "previous_tier": "standard",
+  "kyc_risk_tier": "high",
+  "effective_cap_bps": 250,
+  "multiplier": 0.25,
+  "retroactive_invalidation": false
+}
+```
+
+---
+
+## Related files
+
+- `src/lib/investmentConsistencyGuard.ts` — static concentration cap (FOR UPDATE path)
+- `docs/investment-consistency-checks.md` — offering-status consistency rules
+- `docs/aml-transaction-monitoring.md` — audit / compliance patterns

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.test.ts',

--- a/src/db/migrations/016_add_kyc_risk_tier_to_users.sql
+++ b/src/db/migrations/016_add_kyc_risk_tier_to_users.sql
@@ -1,0 +1,25 @@
+-- Migration: Add kyc_risk_tier to users (investor profile)
+-- Description: Per-investor KYC risk tier used to scale offering investment caps.
+--              Cap changes affect only future investment intents — existing
+--              investments are never retroactively invalidated.
+--
+-- Tiers (strictest → loosest for new capital):
+--   restricted | high | elevated | standard | low
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS kyc_risk_tier VARCHAR(20) NOT NULL DEFAULT 'standard';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'users_kyc_risk_tier_check'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_kyc_risk_tier_check
+      CHECK (kyc_risk_tier IN ('low', 'standard', 'elevated', 'high', 'restricted'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_users_kyc_risk_tier ON users (kyc_risk_tier);

--- a/src/db/repositories/investmentRepository.ts
+++ b/src/db/repositories/investmentRepository.ts
@@ -195,6 +195,22 @@ export class InvestmentRepository {
   }
 
   /**
+   * Sum non-failed investments for an investor in an offering (pool-backed).
+   * Used by the investment service for KYC-tier cap checks on new intents.
+   */
+  async sumInvestorCommitment(investorId: string, offeringId: string): Promise<string> {
+    const result = await this.db.query<{ total: string }>(
+      `SELECT COALESCE(SUM(amount), 0)::text AS total
+         FROM investments
+        WHERE investor_id = $1
+          AND offering_id = $2
+          AND status != 'failed'`,
+      [investorId, offeringId],
+    );
+    return result.rows[0]?.total ?? '0';
+  }
+
+  /**
    * Map database row to Investment entity
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/db/repositories/userRepository.test.ts
+++ b/src/db/repositories/userRepository.test.ts
@@ -18,7 +18,7 @@
  *  - Raw pg errors that are NOT `23505` are re-thrown unchanged.
  */
 
-import { Pool, QueryResult } from 'pg';
+import { Pool, QueryResult, QueryResultRow } from 'pg';
 import { UserRepository, User, CreateUserInput, UpdateUserInput } from './userRepository';
 import { UniqueConstraintError } from '../../lib/errors';
 
@@ -30,11 +30,12 @@ const BASE_USER: User = {
   password_hash: 'salt:hash',
   name: 'Alice',
   role: 'investor',
+  kyc_risk_tier: 'standard',
   created_at: new Date('2024-01-01'),
   updated_at: new Date('2024-01-01'),
 };
 
-function makeQueryResult<T>(rows: T[]): QueryResult<T> {
+function makeQueryResult<T extends QueryResultRow>(rows: T[]): QueryResult<T> {
   return { rows, rowCount: rows.length, command: 'SELECT', oid: 0, fields: [] };
 }
 
@@ -170,7 +171,7 @@ describe('UserRepository', () => {
       expect(result.email).toBe('bob@example.com');
       expect(mockPool.query).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO users'),
-        expect.arrayContaining(['bob@example.com', 's:h', 'Bob', 'startup']),
+        expect.arrayContaining(['bob@example.com', 's:h', 'Bob', 'startup', 'standard']),
       );
     });
 
@@ -181,6 +182,7 @@ describe('UserRepository', () => {
 
       const params = mockPool.query.mock.calls[0][1] as any[];
       expect(params[3]).toBe('startup'); // 4th positional param is role
+      expect(params[4]).toBe('standard'); // 5th is kyc_risk_tier default
     });
 
     it('passes null for name when not provided', async () => {

--- a/src/db/repositories/userRepository.ts
+++ b/src/db/repositories/userRepository.ts
@@ -1,5 +1,10 @@
 import { Pool, QueryResult } from 'pg';
 import { UniqueConstraintError } from '../../lib/errors';
+import {
+  DEFAULT_KYC_RISK_TIER,
+  KycRiskTier,
+  parseKycRiskTier,
+} from '../../lib/kycRiskTierCaps';
 
 /**
  * Full user row — password_hash included for internal auth use only.
@@ -11,6 +16,8 @@ export interface User {
   password_hash: string;
   name?: string;
   role: 'startup' | 'investor';
+  /** KYC risk tier used to scale per-offering investment caps. */
+  kyc_risk_tier: KycRiskTier;
   created_at: Date;
   updated_at: Date;
 }
@@ -23,6 +30,7 @@ export interface CreateUserInput {
   password_hash: string;
   name?: string;
   role?: 'startup' | 'investor';
+  kyc_risk_tier?: KycRiskTier;
 }
 
 export interface UpdateUserInput {
@@ -30,6 +38,7 @@ export interface UpdateUserInput {
   email?: string;
   password_hash?: string;
   role?: 'startup' | 'investor';
+  kyc_risk_tier?: KycRiskTier;
 }
 
 /**
@@ -54,7 +63,7 @@ export class UserRepository {
    */
   async findById(id: string): Promise<User | null> {
     const query = `
-      SELECT id, email, password_hash, name, role, created_at, updated_at
+      SELECT id, email, password_hash, name, role, kyc_risk_tier, created_at, updated_at
       FROM users
       WHERE id = $1
       LIMIT 1
@@ -73,7 +82,7 @@ export class UserRepository {
    */
   async findByEmail(email: string): Promise<User | null> {
     const query = `
-      SELECT id, email, password_hash, name, role, created_at, updated_at
+      SELECT id, email, password_hash, name, role, kyc_risk_tier, created_at, updated_at
       FROM users
       WHERE email = $1
       LIMIT 1
@@ -97,8 +106,8 @@ export class UserRepository {
    */
   async createUser(input: CreateUserInput): Promise<User> {
     const query = `
-      INSERT INTO users (email, password_hash, name, role, created_at, updated_at)
-      VALUES ($1, $2, $3, $4, NOW(), NOW())
+      INSERT INTO users (email, password_hash, name, role, kyc_risk_tier, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
       RETURNING *
     `;
     const values = [
@@ -106,6 +115,7 @@ export class UserRepository {
       input.password_hash,
       input.name ?? null,
       input.role ?? 'startup',
+      input.kyc_risk_tier ?? DEFAULT_KYC_RISK_TIER,
     ];
     let result: QueryResult<User>;
     try {
@@ -151,6 +161,10 @@ export class UserRepository {
       sets.push(`role = $${idx++}`);
       values.push(input.role);
     }
+    if (input.kyc_risk_tier !== undefined) {
+      sets.push(`kyc_risk_tier = $${idx++}`);
+      values.push(input.kyc_risk_tier);
+    }
 
     if (sets.length === 0) {
       const existing = await this.findById(input.id);
@@ -178,6 +192,14 @@ export class UserRepository {
   }
 
   /**
+   * Persist a new KYC risk tier for an investor.
+   * Does not emit audit events — callers (KycRiskTierService) own that.
+   */
+  async updateKycRiskTier(userId: string, tier: KycRiskTier): Promise<User> {
+    return this.updateUser({ id: userId, kyc_risk_tier: tier });
+  }
+
+  /**
    * Update a user's password hash directly.
    */
   async updatePasswordHash(userId: string, newPasswordHash: string): Promise<void> {
@@ -196,6 +218,7 @@ export class UserRepository {
       password_hash: row.password_hash,
       name: row.name ?? undefined,
       role: row.role as 'startup' | 'investor',
+      kyc_risk_tier: parseKycRiskTier(row.kyc_risk_tier),
       created_at: row.created_at,
       updated_at: row.updated_at,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { globalMetrics } from "./lib/metrics";
 import { createPasswordResetRouter } from "./routes/passwordReset";
 import { emailService } from "./services/emailService";
 import { createAdminRouter } from "./routes/admin";
+import { createAdminKycRiskTierRouter } from "./routes/adminKycRiskTier";
 import { AuditLogRepository } from "./db/repositories/auditLogRepository";
 import { AuditPurgeService } from "./services/auditPurgeService";
 import { PayoutDriftRepository } from "./db/repositories/payoutDriftRepository";
@@ -620,12 +621,13 @@ export function createApp(dependencies: AppDependencies = {}): express.Express {
 
   // Initialize repositories for admin and audit routes
   const auditLogRepo = new AuditLogRepository(pool);
+  const amlAuditRepo = new InMemorySecurityAuditRepository();
 
   // Mount admin router
   apiRouter.use("/admin", createAdminRouter(auditLogRepo));
+  apiRouter.use("/admin", createAdminKycRiskTierRouter(pool, amlAuditRepo));
 
   // Initialize AML service and routes
-  const amlAuditRepo = new InMemorySecurityAuditRepository();
   const amlService = createAMLService(pool, amlAuditRepo, 'system');
   apiRouter.use("/aml", createAMLRoutes(amlService));
 

--- a/src/lib/__tests__/kycRiskTierCaps.test.ts
+++ b/src/lib/__tests__/kycRiskTierCaps.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for KYC risk-tier investment cap resolution.
+ *
+ * Covers multipliers, restricted/null offering baselines, boundary checks,
+ * and the "tier upgrade unblocks only on next intent" evaluation semantics.
+ */
+
+import {
+  CapResolution,
+  DEFAULT_KYC_RISK_TIER,
+  INVESTOR_CAP_RECALCULATED_ACTION,
+  TIER_CAP_MULTIPLIERS,
+  effectiveCapAmount,
+  evaluateInvestmentAgainstCap,
+  isKycRiskTier,
+  parseKycRiskTier,
+  resolveEffectiveCap,
+} from '../kycRiskTierCaps';
+
+describe('kycRiskTierCaps', () => {
+  describe('isKycRiskTier / parseKycRiskTier', () => {
+    it('accepts known tiers', () => {
+      expect(isKycRiskTier('high')).toBe(true);
+      expect(isKycRiskTier('restricted')).toBe(true);
+      expect(isKycRiskTier('nope')).toBe(false);
+      expect(isKycRiskTier(1)).toBe(false);
+    });
+
+    it('falls back to standard for invalid values', () => {
+      expect(parseKycRiskTier(undefined)).toBe(DEFAULT_KYC_RISK_TIER);
+      expect(parseKycRiskTier('bogus')).toBe('standard');
+      expect(parseKycRiskTier('elevated')).toBe('elevated');
+    });
+  });
+
+  describe('resolveEffectiveCap', () => {
+    it('scales offering cap by tier multiplier (high-risk → lower cap)', () => {
+      const base = 1_000; // 10%
+      expect(resolveEffectiveCap(base, 'low').effectiveCapBps).toBe(1_000);
+      expect(resolveEffectiveCap(base, 'standard').effectiveCapBps).toBe(1_000);
+      expect(resolveEffectiveCap(base, 'elevated').effectiveCapBps).toBe(500);
+      expect(resolveEffectiveCap(base, 'high').effectiveCapBps).toBe(250);
+      expect(resolveEffectiveCap(base, 'restricted').effectiveCapBps).toBe(0);
+    });
+
+    it('floors fractional scaled bps', () => {
+      // 333 * 0.25 = 83.25 → 83
+      expect(resolveEffectiveCap(333, 'high').effectiveCapBps).toBe(83);
+    });
+
+    it('returns null (unlimited) when offering has no cap and tier is not restricted', () => {
+      expect(resolveEffectiveCap(null, 'standard').effectiveCapBps).toBeNull();
+      expect(resolveEffectiveCap(undefined, 'elevated').effectiveCapBps).toBeNull();
+    });
+
+    it('restricted always resolves to 0 even without an offering cap', () => {
+      expect(resolveEffectiveCap(null, 'restricted').effectiveCapBps).toBe(0);
+      expect(resolveEffectiveCap(5_000, 'restricted').effectiveCapBps).toBe(0);
+    });
+
+    it('exposes multiplier metadata for audits', () => {
+      const r = resolveEffectiveCap(2_000, 'high');
+      expect(r.multiplier).toBe(TIER_CAP_MULTIPLIERS.high);
+      expect(r.offeringCapBps).toBe(2_000);
+      expect(r.tier).toBe('high');
+    });
+  });
+
+  describe('effectiveCapAmount', () => {
+    it('converts bps to absolute units', () => {
+      const resolution: CapResolution = {
+        tier: 'elevated',
+        multiplier: 0.5,
+        offeringCapBps: 1_000,
+        effectiveCapBps: 500,
+      };
+      expect(effectiveCapAmount(resolution, 1_000_000)).toBe(50_000);
+    });
+
+    it('returns null when unlimited', () => {
+      const resolution = resolveEffectiveCap(null, 'standard');
+      expect(effectiveCapAmount(resolution, 1_000_000)).toBeNull();
+    });
+
+    it('rejects non-finite offering size', () => {
+      const resolution = resolveEffectiveCap(1_000, 'standard');
+      expect(() => effectiveCapAmount(resolution, Number.NaN)).toThrow(/non-negative finite/);
+    });
+  });
+
+  describe('evaluateInvestmentAgainstCap', () => {
+    const offeringSize = 1_000_000;
+
+    it('allows any amount when offering has no static cap (unlimited)', () => {
+      const resolution = resolveEffectiveCap(null, 'standard');
+      const result = evaluateInvestmentAgainstCap({
+        existingTotal: 999_999,
+        newAmount: 999_999,
+        totalOfferingAmount: offeringSize,
+        resolution,
+      });
+      expect(result.allowed).toBe(true);
+      if (result.allowed) {
+        expect(result.capAmount).toBeNull();
+      }
+    });
+
+    it('allows investment under the tier-adjusted cap', () => {
+      const resolution = resolveEffectiveCap(1_000, 'high'); // 250 bps → 25_000
+      const result = evaluateInvestmentAgainstCap({
+        existingTotal: 10_000,
+        newAmount: 15_000,
+        totalOfferingAmount: offeringSize,
+        resolution,
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('rejects when existing + new would exceed the adjusted cap', () => {
+      const resolution = resolveEffectiveCap(1_000, 'high'); // 25_000
+      const result = evaluateInvestmentAgainstCap({
+        existingTotal: 20_000,
+        newAmount: 6_000,
+        totalOfferingAmount: offeringSize,
+        resolution,
+      });
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/KYC risk-tier adjusted cap/);
+        expect(result.capAmount).toBe(25_000);
+      }
+    });
+
+    it('allows exact boundary', () => {
+      const resolution = resolveEffectiveCap(1_000, 'elevated'); // 50_000
+      const result = evaluateInvestmentAgainstCap({
+        existingTotal: 40_000,
+        newAmount: 10_000,
+        totalOfferingAmount: offeringSize,
+        resolution,
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('restricted blocks any positive new amount', () => {
+      const resolution = resolveEffectiveCap(1_000, 'restricted');
+      const result = evaluateInvestmentAgainstCap({
+        existingTotal: 0,
+        newAmount: 1,
+        totalOfferingAmount: offeringSize,
+        resolution,
+      });
+      expect(result.allowed).toBe(false);
+    });
+
+    it('tier upgrade unblocks prior above-cap attempt only on next evaluation', () => {
+      const offeringCapBps = 1_000; // 100_000 absolute at standard
+      const totalOfferingAmount = offeringSize;
+      const existingTotal = 0;
+      const attempted = 60_000;
+
+      const blocked = evaluateInvestmentAgainstCap({
+        existingTotal,
+        newAmount: attempted,
+        totalOfferingAmount,
+        resolution: resolveEffectiveCap(offeringCapBps, 'high'), // 25_000
+      });
+      expect(blocked.allowed).toBe(false);
+
+      // Existing commitment unchanged (still 0) — upgrade alone does nothing
+      // until the next intent is evaluated:
+      const afterUpgrade = evaluateInvestmentAgainstCap({
+        existingTotal,
+        newAmount: attempted,
+        totalOfferingAmount,
+        resolution: resolveEffectiveCap(offeringCapBps, 'standard'), // 100_000
+      });
+      expect(afterUpgrade.allowed).toBe(true);
+    });
+
+    it('never treats prior over-cap commitments as invalidating — only gates new amount', () => {
+      // Investor somehow already holds 80k (legacy / grandfathered). Cap is now 50k.
+      // A zero-size "intent" is not used; a tiny new amount still fails, but we do not
+      // claw back the 80k — evaluate only cares about existing+new vs cap.
+      const resolution = resolveEffectiveCap(1_000, 'elevated'); // 50_000
+      const addMore = evaluateInvestmentAgainstCap({
+        existingTotal: 80_000,
+        newAmount: 1,
+        totalOfferingAmount: offeringSize,
+        resolution,
+      });
+      expect(addMore.allowed).toBe(false);
+      // No mutation API exists — existingTotal is an input, not rewritten.
+      expect(addMore.allowed === false && addMore.existingTotal).toBe(80_000);
+    });
+  });
+
+  describe('audit action constant', () => {
+    it('uses the investor.cap.recalculated action string', () => {
+      expect(INVESTOR_CAP_RECALCULATED_ACTION).toBe('investor.cap.recalculated');
+    });
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -147,3 +147,15 @@ export class BadRequestError extends AppError {
     this.name = 'BadRequestError';
   }
 }
+
+export class UniqueConstraintError extends Error {
+  public readonly field: string;
+
+  constructor(field: string) {
+    super(`Unique constraint violation on ${field}`);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = 'UniqueConstraintError';
+    this.field = field;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/src/lib/kycRiskTierCaps.ts
+++ b/src/lib/kycRiskTierCaps.ts
@@ -1,0 +1,164 @@
+/**
+ * KYC risk-tier investment cap resolution.
+ *
+ * Offering concentration caps (`max_investor_share_bps`) remain the static
+ * baseline. Each investor's `kyc_risk_tier` scales that baseline so higher-risk
+ * investors face a lower effective cap on **new** investment intents.
+ *
+ * Invariants:
+ * - Existing investments are never retroactively invalidated when a tier (or
+ *   the offering cap) changes.
+ * - A prior intent that was blocked by a tight tier is re-evaluated only on
+ *   the **next** createInvestment call after a tier upgrade.
+ * - `restricted` always resolves to 0 bps (blocks new capital) even when the
+ *   offering has no static cap configured.
+ */
+
+export const KYC_RISK_TIERS = [
+  'low',
+  'standard',
+  'elevated',
+  'high',
+  'restricted',
+] as const;
+
+export type KycRiskTier = (typeof KYC_RISK_TIERS)[number];
+
+export const DEFAULT_KYC_RISK_TIER: KycRiskTier = 'standard';
+
+/**
+ * Multiplier applied to the offering's `max_investor_share_bps`.
+ * High-risk tiers receive strictly lower multipliers.
+ */
+export const TIER_CAP_MULTIPLIERS: Readonly<Record<KycRiskTier, number>> = {
+  low: 1.0,
+  standard: 1.0,
+  elevated: 0.5,
+  high: 0.25,
+  restricted: 0,
+};
+
+export function isKycRiskTier(value: unknown): value is KycRiskTier {
+  return typeof value === 'string' && (KYC_RISK_TIERS as readonly string[]).includes(value);
+}
+
+export function parseKycRiskTier(value: unknown, fallback: KycRiskTier = DEFAULT_KYC_RISK_TIER): KycRiskTier {
+  return isKycRiskTier(value) ? value : fallback;
+}
+
+export interface CapResolution {
+  tier: KycRiskTier;
+  multiplier: number;
+  /** Offering baseline in bps, or null when the offering has no static cap. */
+  offeringCapBps: number | null;
+  /**
+   * Effective per-investor cap in bps after applying the tier multiplier.
+   * `null` means unlimited (no offering cap and tier is not `restricted`).
+   * `0` means new investments are blocked.
+   */
+  effectiveCapBps: number | null;
+}
+
+/**
+ * Resolve the effective concentration cap for an investor on an offering.
+ *
+ * @param offeringCapBps  Offering `max_investor_share_bps` (null = none).
+ * @param tier            Investor KYC risk tier.
+ */
+export function resolveEffectiveCap(offeringCapBps: number | null | undefined, tier: KycRiskTier): CapResolution {
+  const multiplier = TIER_CAP_MULTIPLIERS[tier];
+  const base = offeringCapBps == null ? null : offeringCapBps;
+
+  if (tier === 'restricted') {
+    return {
+      tier,
+      multiplier,
+      offeringCapBps: base,
+      effectiveCapBps: 0,
+    };
+  }
+
+  if (base == null) {
+    return {
+      tier,
+      multiplier,
+      offeringCapBps: null,
+      effectiveCapBps: null,
+    };
+  }
+
+  const scaled = Math.floor(base * multiplier);
+  const effectiveCapBps = Math.min(10_000, Math.max(0, scaled));
+
+  return {
+    tier,
+    multiplier,
+    offeringCapBps: base,
+    effectiveCapBps,
+  };
+}
+
+/**
+ * Convert an effective bps cap into an absolute amount against the offering size.
+ * Returns `null` when unlimited; `0` when blocked.
+ */
+export function effectiveCapAmount(
+  resolution: CapResolution,
+  totalOfferingAmount: number,
+): number | null {
+  if (resolution.effectiveCapBps == null) return null;
+  if (!Number.isFinite(totalOfferingAmount) || totalOfferingAmount < 0) {
+    throw new Error('totalOfferingAmount must be a non-negative finite number');
+  }
+  return (resolution.effectiveCapBps / 10_000) * totalOfferingAmount;
+}
+
+export interface CapCheckInput {
+  existingTotal: number;
+  newAmount: number;
+  totalOfferingAmount: number;
+  resolution: CapResolution;
+}
+
+export type CapCheckResult =
+  | { allowed: true; resolution: CapResolution; capAmount: number | null }
+  | {
+      allowed: false;
+      resolution: CapResolution;
+      capAmount: number;
+      existingTotal: number;
+      newAmount: number;
+      reason: string;
+    };
+
+/**
+ * Pure check used by the investment service on each new intent.
+ * Does not mutate or inspect persisted investments beyond the totals supplied.
+ */
+export function evaluateInvestmentAgainstCap(input: CapCheckInput): CapCheckResult {
+  const { existingTotal, newAmount, totalOfferingAmount, resolution } = input;
+  const capAmount = effectiveCapAmount(resolution, totalOfferingAmount);
+
+  if (capAmount == null) {
+    return { allowed: true, resolution, capAmount: null };
+  }
+
+  if (existingTotal + newAmount > capAmount) {
+    return {
+      allowed: false,
+      resolution,
+      capAmount,
+      existingTotal,
+      newAmount,
+      reason:
+        `Investment would exceed the KYC risk-tier adjusted cap of ${resolution.effectiveCapBps} bps` +
+        ` (${capAmount} units) for tier "${resolution.tier}".` +
+        ` Investor has already committed ${existingTotal} units.`,
+    };
+  }
+
+  return { allowed: true, resolution, capAmount };
+}
+
+/** Audit action emitted whenever an investor's tier (and thus cap) changes. */
+export const INVESTOR_CAP_RECALCULATED_ACTION = 'investor.cap.recalculated';

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -57,7 +57,7 @@ export function authMiddleware(): RequestHandler {
         error: error instanceof Error ? error.message : 'Unknown error',
         path: req.path,
       });
-      next(Errors.unauthorized(errorMessage));
+      next(Errors.unauthorized('Invalid or expired token'));
     }
   };
 }

--- a/src/routes/__tests__/adminKycRiskTier.test.ts
+++ b/src/routes/__tests__/adminKycRiskTier.test.ts
@@ -1,0 +1,120 @@
+import request from 'supertest';
+import express from 'express';
+import { Pool } from 'pg';
+import { createAdminKycRiskTierRouter } from '../adminKycRiskTier';
+import { InMemorySecurityAuditRepository } from '../../security/audit';
+import { INVESTOR_CAP_RECALCULATED_ACTION } from '../../lib/kycRiskTierCaps';
+import { errorHandler } from '../../middleware/errorHandler';
+
+let setAdminUser = true;
+
+jest.mock('../../middleware/auth', () => {
+  const actual = jest.requireActual('../../middleware/auth');
+  return {
+    ...actual,
+    requireAdmin: (req: any, _res: any, next: any) => {
+      if (setAdminUser) {
+        req.user = { id: 'admin-1', role: 'admin' };
+      }
+      next();
+    },
+  };
+});
+
+describe('PATCH /admin/investors/:id/kyc-risk-tier', () => {
+  let app: express.Express;
+  let mockPool: { query: jest.Mock };
+  let auditRepo: InMemorySecurityAuditRepository;
+
+  beforeEach(() => {
+    setAdminUser = true;
+    mockPool = { query: jest.fn() };
+    auditRepo = new InMemorySecurityAuditRepository();
+    app = express();
+    app.use(express.json());
+    app.use('/admin', createAdminKycRiskTierRouter(mockPool as unknown as Pool, auditRepo));
+    app.use(errorHandler);
+  });
+
+  it('updates tier and returns non-retroactive response', async () => {
+    const investor = {
+      id: 'investor-1',
+      email: 'a@b.com',
+      password_hash: 'x',
+      role: 'investor',
+      kyc_risk_tier: 'high',
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    mockPool.query
+      // findById
+      .mockResolvedValueOnce({ rows: [investor], rowCount: 1, command: 'SELECT', oid: 0, fields: [] })
+      // updateUser RETURNING
+      .mockResolvedValueOnce({
+        rows: [{ ...investor, kyc_risk_tier: 'standard' }],
+        rowCount: 1,
+        command: 'UPDATE',
+        oid: 0,
+        fields: [],
+      });
+
+    const res = await request(app)
+      .patch('/admin/investors/investor-1/kyc-risk-tier')
+      .send({ tier: 'standard', offering_cap_bps: 1000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      investor_id: 'investor-1',
+      previous_tier: 'high',
+      kyc_risk_tier: 'standard',
+      effective_cap_bps: 1000,
+      retroactive_invalidation: false,
+    });
+
+    const events = await auditRepo.findByUserId('admin-1');
+    expect(events.some((e) => e.action === INVESTOR_CAP_RECALCULATED_ACTION)).toBe(true);
+  });
+
+
+  it('returns 401 when authenticated user is absent', async () => {
+    setAdminUser = false;
+    const res = await request(app)
+      .patch('/admin/investors/investor-1/kyc-risk-tier')
+      .send({ tier: 'standard' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when investor is not found', async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: 'SELECT',
+      oid: 0,
+      fields: [],
+    });
+
+    const res = await request(app)
+      .patch('/admin/investors/missing/kyc-risk-tier')
+      .send({ tier: 'standard' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('delegates unexpected errors to the error handler', async () => {
+    mockPool.query.mockRejectedValueOnce(new Error('db down'));
+
+    const res = await request(app)
+      .patch('/admin/investors/investor-1/kyc-risk-tier')
+      .send({ tier: 'standard' });
+
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+
+  it('rejects invalid tier', async () => {
+    const res = await request(app)
+      .patch('/admin/investors/investor-1/kyc-risk-tier')
+      .send({ tier: 'nope' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/routes/adminKycRiskTier.ts
+++ b/src/routes/adminKycRiskTier.ts
@@ -1,0 +1,80 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { Pool } from 'pg';
+import { requireAdmin, AuthenticatedRequest } from '../middleware/auth';
+import { UserRepository } from '../db/repositories/userRepository';
+import { SecurityAuditRepository } from '../security/types';
+import { createKycRiskTierService } from '../services/kycRiskTierService';
+import { isKycRiskTier } from '../lib/kycRiskTierCaps';
+import { AppError } from '../lib/errors';
+
+/**
+ * Admin routes for KYC risk-tier management.
+ * Mount under `/admin` (requireAdmin applied here as well for safety).
+ */
+export function createAdminKycRiskTierRouter(
+  db: Pool,
+  auditRepo: SecurityAuditRepository,
+): Router {
+  const router = Router();
+  const service = createKycRiskTierService(new UserRepository(db), auditRepo);
+
+  router.use(requireAdmin);
+
+  /**
+   * PATCH /investors/:id/kyc-risk-tier
+   * Body: { tier: 'low'|'standard'|'elevated'|'high'|'restricted', offering_cap_bps?: number|null }
+   *
+   * Updates the investor's KYC risk tier and emits `investor.cap.recalculated`.
+   * Does not modify existing investments.
+   */
+  router.patch(
+    '/investors/:id/kyc-risk-tier',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        if (!authReq.user) {
+          res.status(401).json({ error: 'Unauthorized' });
+          return;
+        }
+
+        const tier = (req.body as { tier?: unknown })?.tier;
+        if (!isKycRiskTier(tier)) {
+          res.status(400).json({
+            error: 'tier must be one of: low, standard, elevated, high, restricted',
+          });
+          return;
+        }
+
+        const body = req.body as { offering_cap_bps?: number | null };
+        const referenceOfferingCapBps =
+          body.offering_cap_bps === undefined
+            ? null
+            : body.offering_cap_bps;
+
+        const result = await service.updateKycRiskTier({
+          investorId: String(req.params.id),
+          tier,
+          actorId: String(authReq.user.id),
+          referenceOfferingCapBps,
+        });
+
+        res.status(200).json({
+          investor_id: result.user.id,
+          previous_tier: result.previousTier,
+          kyc_risk_tier: result.user.kyc_risk_tier,
+          effective_cap_bps: result.resolution.effectiveCapBps,
+          multiplier: result.resolution.multiplier,
+          retroactive_invalidation: false,
+        });
+      } catch (error) {
+        if (error instanceof AppError) {
+          res.status(error.statusCode).json(error.toResponse());
+          return;
+        }
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/src/services/__tests__/kycRiskTierService.test.ts
+++ b/src/services/__tests__/kycRiskTierService.test.ts
@@ -1,0 +1,116 @@
+import { UserRepository, User } from '../../db/repositories/userRepository';
+import { SecurityAuditRepository, AuditEvent } from '../../security/types';
+import { KycRiskTierService } from '../kycRiskTierService';
+import { INVESTOR_CAP_RECALCULATED_ACTION } from '../../lib/kycRiskTierCaps';
+
+function makeInvestor(override: Partial<User> = {}): User {
+  return {
+    id: 'investor-1',
+    email: 'inv@example.com',
+    password_hash: 'hash',
+    role: 'investor',
+    kyc_risk_tier: 'standard',
+    created_at: new Date('2024-01-01'),
+    updated_at: new Date('2024-01-01'),
+    ...override,
+  };
+}
+
+describe('KycRiskTierService', () => {
+  let userRepo: jest.Mocked<Pick<UserRepository, 'findById' | 'updateKycRiskTier'>>;
+  let auditRepo: jest.Mocked<Pick<SecurityAuditRepository, 'record'>>;
+  let service: KycRiskTierService;
+
+  beforeEach(() => {
+    userRepo = {
+      findById: jest.fn(),
+      updateKycRiskTier: jest.fn(),
+    };
+    auditRepo = {
+      record: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new KycRiskTierService(
+      userRepo as unknown as UserRepository,
+      auditRepo as unknown as SecurityAuditRepository,
+    );
+  });
+
+  it('updates tier and emits investor.cap.recalculated', async () => {
+    const before = makeInvestor({ kyc_risk_tier: 'high' });
+    const after = makeInvestor({ kyc_risk_tier: 'standard' });
+    userRepo.findById.mockResolvedValue(before);
+    userRepo.updateKycRiskTier.mockResolvedValue(after);
+
+    const result = await service.updateKycRiskTier({
+      investorId: 'investor-1',
+      tier: 'standard',
+      actorId: 'admin-1',
+      referenceOfferingCapBps: 1_000,
+    });
+
+    expect(result.previousTier).toBe('high');
+    expect(result.user.kyc_risk_tier).toBe('standard');
+    expect(result.resolution.effectiveCapBps).toBe(1_000);
+    expect(userRepo.updateKycRiskTier).toHaveBeenCalledWith('investor-1', 'standard');
+
+    expect(auditRepo.record).toHaveBeenCalledTimes(1);
+    const event = auditRepo.record.mock.calls[0][0] as AuditEvent;
+    expect(event.action).toBe(INVESTOR_CAP_RECALCULATED_ACTION);
+    expect(event.details).toMatchObject({
+      investor_id: 'investor-1',
+      previous_tier: 'high',
+      new_tier: 'standard',
+      effective_cap_bps: 1_000,
+      retroactive_invalidation: false,
+      changed: true,
+    });
+  });
+
+  it('skips DB update when tier is unchanged but still audits', async () => {
+    const user = makeInvestor({ kyc_risk_tier: 'elevated' });
+    userRepo.findById.mockResolvedValue(user);
+
+    await service.updateKycRiskTier({
+      investorId: 'investor-1',
+      tier: 'elevated',
+      actorId: 'admin-1',
+    });
+
+    expect(userRepo.updateKycRiskTier).not.toHaveBeenCalled();
+    expect(auditRepo.record).toHaveBeenCalledTimes(1);
+    const event = auditRepo.record.mock.calls[0][0] as AuditEvent;
+    expect(event.details.changed).toBe(false);
+  });
+
+  it('rejects unknown investors', async () => {
+    userRepo.findById.mockResolvedValue(null);
+    await expect(
+      service.updateKycRiskTier({
+        investorId: 'missing',
+        tier: 'high',
+        actorId: 'admin-1',
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('rejects non-investor accounts', async () => {
+    userRepo.findById.mockResolvedValue(makeInvestor({ role: 'startup' }));
+    await expect(
+      service.updateKycRiskTier({
+        investorId: 'investor-1',
+        tier: 'high',
+        actorId: 'admin-1',
+      }),
+    ).rejects.toThrow(/investor accounts/);
+  });
+
+  it('rejects invalid tier values', async () => {
+    await expect(
+      service.updateKycRiskTier({
+        investorId: 'investor-1',
+        tier: 'nope' as any,
+        actorId: 'admin-1',
+      }),
+    ).rejects.toThrow(/Invalid kyc_risk_tier/);
+  });
+});

--- a/src/services/investmentService.test.ts
+++ b/src/services/investmentService.test.ts
@@ -1,7 +1,9 @@
 import { Pool, QueryResult } from 'pg';
 import { InvestmentRepository, Investment } from '../db/repositories/investmentRepository';
 import { OfferingRepository, Offering } from '../db/repositories/offeringRepository';
+import { UserRepository, User } from '../db/repositories/userRepository';
 import { InvestmentService, CreateInvestmentRequest, createInvestmentService } from './investmentService';
+import { AMLService } from '../aml/amlService';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -31,6 +33,20 @@ function makeOfferingRow(override: Partial<Offering> = {}): Offering {
     contract_address: 'CA123...',
     status: 'active',
     total_raised: '10000.00',
+    target_amount: '1000000.00',
+    created_at: new Date('2024-01-01'),
+    updated_at: new Date('2024-01-01'),
+    ...override,
+  };
+}
+
+function makeUser(override: Partial<User> = {}): User {
+  return {
+    id: 'investor-123',
+    email: 'inv@example.com',
+    password_hash: 'hash',
+    role: 'investor',
+    kyc_risk_tier: 'standard',
     created_at: new Date('2024-01-01'),
     updated_at: new Date('2024-01-01'),
     ...override,
@@ -67,63 +83,49 @@ describe('InvestmentService', () => {
     };
 
     it('creates an investment when offering exists and is active', async () => {
-      // Arrange
       const offeringRow = makeOfferingRow({ status: 'active' });
       const investmentRow = makeInvestmentRow();
-      
-      // First query: findById (offering)
+
       mockPool.query
         .mockResolvedValueOnce(mockQueryResult([offeringRow]))
-        // Second query: create (investment)
         .mockResolvedValueOnce({ rows: [investmentRow], rowCount: 1, command: 'INSERT', oid: 0, fields: [] } as QueryResult<Investment>);
 
-      // Act
       const result = await service.createInvestment(baseInput);
 
-      // Assert
       expect(result).toEqual(investmentRow);
       expect(mockPool.query).toHaveBeenCalledTimes(2);
     });
 
     it('creates an investment when offering status is "open"', async () => {
-      // Arrange
       const offeringRow = makeOfferingRow({ status: 'open' });
       const investmentRow = makeInvestmentRow();
-      
+
       mockPool.query
         .mockResolvedValueOnce(mockQueryResult([offeringRow]))
         .mockResolvedValueOnce({ rows: [investmentRow], rowCount: 1, command: 'INSERT', oid: 0, fields: [] } as QueryResult<Investment>);
 
-      // Act
       const result = await service.createInvestment(baseInput);
 
-      // Assert
       expect(result).toEqual(investmentRow);
     });
 
     it('throws NOT_FOUND error when offering does not exist', async () => {
-      // Arrange
       mockPool.query.mockResolvedValueOnce(mockQueryResult([]));
 
-      // Act & Assert
       await expect(service.createInvestment(baseInput)).rejects.toThrow('Offering offering-abc not found');
     });
 
     it('throws VALIDATION_ERROR when offering is not active', async () => {
-      // Arrange
       const offeringRow = makeOfferingRow({ status: 'closed' });
       mockPool.query.mockResolvedValueOnce(mockQueryResult([offeringRow]));
 
-      // Act & Assert
       await expect(service.createInvestment(baseInput)).rejects.toThrow('Offering is not active');
     });
 
     it('throws VALIDATION_ERROR when amount is invalid', async () => {
-      // Arrange
       const offeringRow = makeOfferingRow({ status: 'active' });
       mockPool.query.mockResolvedValueOnce(mockQueryResult([offeringRow]));
 
-      // Act & Assert
       await expect(service.createInvestment({ ...baseInput, amount: '-100' })).rejects.toThrow(
         'Invalid amount: must be a positive number',
       );
@@ -138,41 +140,229 @@ describe('InvestmentService', () => {
     });
 
     it('throws VALIDATION_ERROR when asset is empty', async () => {
-      // Arrange
       const offeringRow = makeOfferingRow({ status: 'active' });
       mockPool.query.mockResolvedValueOnce(mockQueryResult([offeringRow]));
 
-      // Act & Assert
       await expect(service.createInvestment({ ...baseInput, asset: '' })).rejects.toThrow('Asset is required');
     });
 
     it('creates investment with pending status by default', async () => {
-      // Arrange
       const offeringRow = makeOfferingRow({ status: 'active' });
       const investmentRow = makeInvestmentRow({ status: 'pending' });
-      
+
       mockPool.query
         .mockResolvedValueOnce(mockQueryResult([offeringRow]))
         .mockResolvedValueOnce({ rows: [investmentRow], rowCount: 1, command: 'INSERT', oid: 0, fields: [] } as QueryResult<Investment>);
 
-      // Act
       const result = await service.createInvestment(baseInput);
 
-      // Assert
       expect(result.status).toBe('pending');
+    });
+  });
+
+  describe('KYC risk-tier cap gating', () => {
+    const baseInput: CreateInvestmentRequest = {
+      investor_id: 'investor-123',
+      offering_id: 'offering-abc',
+      amount: '60000.00',
+      asset: 'USDC',
+    };
+
+    function serviceWithUserRepo(user: User | null): {
+      service: InvestmentService;
+      mockPool: { query: jest.Mock };
+    } {
+      const pool = makeMockPool();
+      const invRepo = new InvestmentRepository(pool as unknown as Pool);
+      const offRepo = new OfferingRepository(pool as unknown as Pool);
+      const userRepo = {
+        findById: jest.fn().mockResolvedValue(user),
+      } as unknown as UserRepository;
+      return {
+        service: new InvestmentService(invRepo, offRepo, undefined, userRepo),
+        mockPool: pool,
+      };
+    }
+
+    it('blocks high-risk investor when intent exceeds tier-adjusted cap', async () => {
+      const { service: svc, mockPool: pool } = serviceWithUserRepo(
+        makeUser({ kyc_risk_tier: 'high' }),
+      );
+      pool.query
+        .mockResolvedValueOnce(
+          mockQueryResult([
+            makeOfferingRow({
+              max_investor_share_bps: 1_000,
+              target_amount: '1000000',
+            }),
+          ]),
+        )
+        .mockResolvedValueOnce(mockQueryResult([{ total: '0' }]));
+
+      await expect(svc.createInvestment(baseInput)).rejects.toThrow(/KYC risk-tier adjusted cap/);
+    });
+
+    it('allows the same intent after tier upgrade on the next createInvestment call', async () => {
+      const userRepo = {
+        findById: jest
+          .fn()
+          .mockResolvedValueOnce(makeUser({ kyc_risk_tier: 'high' }))
+          .mockResolvedValueOnce(makeUser({ kyc_risk_tier: 'standard' })),
+      } as unknown as UserRepository;
+
+      const pool = makeMockPool();
+      const invRepo = new InvestmentRepository(pool as unknown as Pool);
+      const offRepo = new OfferingRepository(pool as unknown as Pool);
+      const svc = new InvestmentService(invRepo, offRepo, undefined, userRepo);
+      const offering = makeOfferingRow({
+        max_investor_share_bps: 1_000,
+        target_amount: '1000000',
+      });
+      const investmentRow = makeInvestmentRow({ amount: '60000.00' });
+
+      pool.query
+        .mockResolvedValueOnce(mockQueryResult([offering]))
+        .mockResolvedValueOnce(mockQueryResult([{ total: '0' }]));
+      await expect(svc.createInvestment(baseInput)).rejects.toThrow(/KYC risk-tier adjusted cap/);
+
+      pool.query
+        .mockResolvedValueOnce(mockQueryResult([offering]))
+        .mockResolvedValueOnce(mockQueryResult([{ total: '0' }]))
+        .mockResolvedValueOnce({
+          rows: [investmentRow],
+          rowCount: 1,
+          command: 'INSERT',
+          oid: 0,
+          fields: [],
+        } as QueryResult<Investment>);
+
+      const created = await svc.createInvestment(baseInput);
+      expect(created.amount).toBe('60000.00');
+    });
+
+    it('does not invalidate existing over-cap commitments — only rejects additional amount', async () => {
+      const { service: svc, mockPool: pool } = serviceWithUserRepo(
+        makeUser({ kyc_risk_tier: 'elevated' }),
+      );
+      pool.query
+        .mockResolvedValueOnce(
+          mockQueryResult([
+            makeOfferingRow({
+              max_investor_share_bps: 1_000,
+              target_amount: '1000000',
+            }),
+          ]),
+        )
+        .mockResolvedValueOnce(mockQueryResult([{ total: '80000' }]));
+
+      await expect(
+        svc.createInvestment({ ...baseInput, amount: '1' }),
+      ).rejects.toThrow(/KYC risk-tier adjusted cap/);
+      const sql = pool.query.mock.calls.map((c) => String(c[0]));
+      expect(sql.some((s) => /DELETE\s+FROM\s+investments/i.test(s))).toBe(false);
+      expect(sql.some((s) => /INSERT\s+INTO\s+investments/i.test(s))).toBe(false);
+    });
+
+
+    it('invokes AML evaluation when amlService is configured', async () => {
+      const amlService = {
+        evaluateTransaction: jest.fn().mockResolvedValue([]),
+      } as unknown as AMLService;
+      const svc = new InvestmentService(investmentRepo, offeringRepo, amlService);
+      const offeringRow = makeOfferingRow({ status: 'active' });
+      const investmentRow = makeInvestmentRow();
+
+      mockPool.query
+        .mockResolvedValueOnce(mockQueryResult([offeringRow]))
+        .mockResolvedValueOnce({
+          rows: [investmentRow],
+          rowCount: 1,
+          command: 'INSERT',
+          oid: 0,
+          fields: [],
+        } as QueryResult<Investment>);
+
+      const result = await svc.createInvestment(baseInput);
+      expect(result).toEqual(investmentRow);
+      expect(amlService.evaluateTransaction).toHaveBeenCalledTimes(1);
+      await new Promise((r) => setImmediate(r));
+    });
+
+    it('does not fail investment creation when AML evaluation rejects asynchronously', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const amlService = {
+        evaluateTransaction: jest.fn().mockRejectedValue(new Error('aml failed')),
+      } as unknown as AMLService;
+      const svc = new InvestmentService(investmentRepo, offeringRepo, amlService);
+      const offeringRow = makeOfferingRow({ status: 'active' });
+      const investmentRow = makeInvestmentRow();
+
+      mockPool.query
+        .mockResolvedValueOnce(mockQueryResult([offeringRow]))
+        .mockResolvedValueOnce({
+          rows: [investmentRow],
+          rowCount: 1,
+          command: 'INSERT',
+          oid: 0,
+          fields: [],
+        } as QueryResult<Investment>);
+
+      await expect(svc.createInvestment(baseInput)).resolves.toEqual(investmentRow);
+      await new Promise((r) => setImmediate(r));
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('does not fail investment creation when AML setup throws synchronously', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const amlService = {
+        evaluateTransaction: jest.fn(() => {
+          throw new Error('sync aml');
+        }),
+      } as unknown as AMLService;
+      const svc = new InvestmentService(investmentRepo, offeringRepo, amlService);
+      const offeringRow = makeOfferingRow({ status: 'active' });
+      const investmentRow = makeInvestmentRow();
+
+      mockPool.query
+        .mockResolvedValueOnce(mockQueryResult([offeringRow]))
+        .mockResolvedValueOnce({
+          rows: [investmentRow],
+          rowCount: 1,
+          command: 'INSERT',
+          oid: 0,
+          fields: [],
+        } as QueryResult<Investment>);
+
+      await expect(svc.createInvestment(baseInput)).resolves.toEqual(investmentRow);
+      expect(consoleSpy).toHaveBeenCalledWith('AML evaluation setup failed:', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+
+    it('blocks restricted tier even when offering has no static cap', async () => {
+      const { service: svc, mockPool: pool } = serviceWithUserRepo(
+        makeUser({ kyc_risk_tier: 'restricted' }),
+      );
+      pool.query
+        .mockResolvedValueOnce(
+          mockQueryResult([
+            makeOfferingRow({
+              max_investor_share_bps: null,
+              target_amount: '1000000',
+            }),
+          ]),
+        )
+        .mockResolvedValueOnce(mockQueryResult([{ total: '0' }]));
+
+      await expect(svc.createInvestment(baseInput)).rejects.toThrow(/KYC risk-tier adjusted cap/);
     });
   });
 });
 
 describe('createInvestmentService', () => {
   it('creates an InvestmentService instance', () => {
-    // Arrange
     const mockPool = makeMockPool();
-    
-    // Act
     const service = createInvestmentService(mockPool as unknown as Pool);
-    
-    // Assert
     expect(service).toBeInstanceOf(InvestmentService);
   });
 });

--- a/src/services/investmentService.ts
+++ b/src/services/investmentService.ts
@@ -1,9 +1,16 @@
 import { Pool } from 'pg';
 import { InvestmentRepository, CreateInvestmentInput, Investment } from '../db/repositories/investmentRepository';
 import { OfferingRepository } from '../db/repositories/offeringRepository';
-import { Errors } from '../lib/errors';
+import { UserRepository } from '../db/repositories/userRepository';
+import { Errors, AppError, ErrorCode } from '../lib/errors';
 import { AMLService } from '../aml/amlService';
 import { TransactionContext } from '../aml/types';
+import {
+  DEFAULT_KYC_RISK_TIER,
+  evaluateInvestmentAgainstCap,
+  parseKycRiskTier,
+  resolveEffectiveCap,
+} from '../lib/kycRiskTierCaps';
 
 /**
  * Input for creating an investment
@@ -17,20 +24,21 @@ export interface CreateInvestmentRequest {
 
 /**
  * Investment Service
- * Handles business logic for investments
+ * Handles business logic for investments, including KYC risk-tier cap gating.
  */
 export class InvestmentService {
   constructor(
     private investmentRepo: InvestmentRepository,
     private offeringRepo: OfferingRepository,
-    private amlService?: AMLService
+    private amlService?: AMLService,
+    private userRepo?: UserRepository,
   ) {}
 
   /**
    * Create a new investment
    * @param input Investment data
    * @returns Created investment
-   * @throws Error if offering not found or invalid
+   * @throws Error if offering not found, invalid, or KYC-tier cap exceeded
    */
   async createInvestment(input: CreateInvestmentRequest): Promise<Investment> {
     // 1. Validate offering exists
@@ -56,7 +64,23 @@ export class InvestmentService {
       throw Errors.validationError('Asset is required');
     }
 
-    // 5. Create investment record
+    // 5. KYC risk-tier dynamic cap (new intents only — never touches existing rows)
+    await this.assertKycTierCap({
+      investorId: input.investor_id,
+      offeringId: input.offering_id,
+      newAmount: amountNum,
+      offeringCapBps:
+        typeof offering.max_investor_share_bps === 'number'
+          ? offering.max_investor_share_bps
+          : offering.max_investor_share_bps == null
+            ? null
+            : Number(offering.max_investor_share_bps),
+      totalOfferingAmount: parseFloat(
+        String(offering.target_amount ?? offering.total_raised ?? '0'),
+      ),
+    });
+
+    // 6. Create investment record
     const investmentInput: CreateInvestmentInput = {
       investor_id: input.investor_id,
       offering_id: input.offering_id,
@@ -67,7 +91,7 @@ export class InvestmentService {
 
     const investment = await this.investmentRepo.create(investmentInput);
 
-    // 6. Run AML transaction monitoring if service is available
+    // 7. Run AML transaction monitoring if service is available
     if (this.amlService) {
       try {
         const context: TransactionContext = {
@@ -78,7 +102,7 @@ export class InvestmentService {
           asset: investment.asset,
           timestamp: investment.created_at,
         };
-        
+
         // Run AML evaluation asynchronously (non-blocking)
         this.amlService.evaluateTransaction(context).catch(error => {
           // Log error but don't fail the investment creation
@@ -92,6 +116,64 @@ export class InvestmentService {
 
     return investment;
   }
+
+  /**
+   * Resolve the investor's KYC tier and reject the intent when it would exceed
+   * the tier-adjusted concentration cap. Existing commitments are never modified.
+   */
+  private async assertKycTierCap(args: {
+    investorId: string;
+    offeringId: string;
+    newAmount: number;
+    offeringCapBps: number | null;
+    totalOfferingAmount: number;
+  }): Promise<void> {
+    let tier = DEFAULT_KYC_RISK_TIER;
+    if (this.userRepo) {
+      const user = await this.userRepo.findById(args.investorId);
+      if (user) {
+        tier = parseKycRiskTier(user.kyc_risk_tier);
+      }
+    }
+
+    const offeringCapBps =
+      args.offeringCapBps != null && Number.isFinite(args.offeringCapBps)
+        ? args.offeringCapBps
+        : null;
+
+    const resolution = resolveEffectiveCap(offeringCapBps, tier);
+
+    // Unlimited after tier resolution — nothing to enforce.
+    if (resolution.effectiveCapBps == null) {
+      return;
+    }
+
+    const totalOfferingAmount = Number.isFinite(args.totalOfferingAmount)
+      ? Math.max(0, args.totalOfferingAmount)
+      : 0;
+
+    const existingTotal = parseFloat(
+      await this.investmentRepo.sumInvestorCommitment(args.investorId, args.offeringId),
+    );
+
+    const check = evaluateInvestmentAgainstCap({
+      existingTotal: Number.isFinite(existingTotal) ? existingTotal : 0,
+      newAmount: args.newAmount,
+      totalOfferingAmount,
+      resolution,
+    });
+
+    if (!check.allowed) {
+      throw new AppError(ErrorCode.FORBIDDEN, 403, check.reason, {
+        kyc_risk_tier: resolution.tier,
+        effective_cap_bps: resolution.effectiveCapBps,
+        offering_cap_bps: resolution.offeringCapBps,
+        existing_total: check.existingTotal,
+        attempted_amount: check.newAmount,
+        cap_amount: check.capAmount,
+      });
+    }
+  }
 }
 
 /**
@@ -101,6 +183,7 @@ export function createInvestmentService(db: Pool, amlService?: AMLService): Inve
   return new InvestmentService(
     new InvestmentRepository(db),
     new OfferingRepository(db),
-    amlService
+    amlService,
+    new UserRepository(db),
   );
 }

--- a/src/services/kycRiskTierService.ts
+++ b/src/services/kycRiskTierService.ts
@@ -1,0 +1,124 @@
+/**
+ * KYC risk-tier service — updates investor tiers and emits cap-recalculation audits.
+ *
+ * Cap changes never invalidate existing investments; they only affect subsequent
+ * `createInvestment` intents via {@link resolveEffectiveCap}.
+ */
+
+import { UserRepository, User } from '../db/repositories/userRepository';
+import { SecurityAuditRepository, AuditEvent } from '../security/types';
+import { Errors } from '../lib/errors';
+import {
+  CapResolution,
+  INVESTOR_CAP_RECALCULATED_ACTION,
+  KycRiskTier,
+  isKycRiskTier,
+  resolveEffectiveCap,
+} from '../lib/kycRiskTierCaps';
+
+export interface UpdateKycRiskTierInput {
+  investorId: string;
+  tier: KycRiskTier;
+  /** Actor performing the change (admin user id). */
+  actorId: string;
+  /**
+   * Optional offering baseline used only for audit context (illustrative
+   * effective cap after the change). Does not mutate offerings.
+   */
+  referenceOfferingCapBps?: number | null;
+}
+
+export interface UpdateKycRiskTierResult {
+  user: User;
+  previousTier: KycRiskTier;
+  resolution: CapResolution;
+}
+
+export class KycRiskTierService {
+  constructor(
+    private userRepo: UserRepository,
+    private auditRepo: SecurityAuditRepository,
+  ) {}
+
+  /**
+   * Persist a new KYC risk tier and emit `investor.cap.recalculated`.
+   */
+  async updateKycRiskTier(input: UpdateKycRiskTierInput): Promise<UpdateKycRiskTierResult> {
+    if (!isKycRiskTier(input.tier)) {
+      throw Errors.validationError(`Invalid kyc_risk_tier: ${String(input.tier)}`);
+    }
+
+    const existing = await this.userRepo.findById(input.investorId);
+    if (!existing) {
+      throw Errors.notFound(`Investor ${input.investorId} not found`);
+    }
+    if (existing.role !== 'investor') {
+      throw Errors.validationError('KYC risk tier can only be set on investor accounts');
+    }
+
+    const previousTier = existing.kyc_risk_tier;
+    const user =
+      previousTier === input.tier
+        ? existing
+        : await this.userRepo.updateKycRiskTier(input.investorId, input.tier);
+
+    const resolution = resolveEffectiveCap(
+      input.referenceOfferingCapBps ?? null,
+      user.kyc_risk_tier,
+    );
+
+    await this.emitCapRecalculated({
+      investorId: user.id,
+      actorId: input.actorId,
+      previousTier,
+      resolution,
+      changed: previousTier !== input.tier,
+    });
+
+    return { user, previousTier, resolution };
+  }
+
+  private async emitCapRecalculated(args: {
+    investorId: string;
+    actorId: string;
+    previousTier: KycRiskTier;
+    resolution: CapResolution;
+    changed: boolean;
+  }): Promise<void> {
+    const event: AuditEvent = {
+      id: `audit_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+      type: 'AUTHORIZATION',
+      userId: args.actorId,
+      action: INVESTOR_CAP_RECALCULATED_ACTION,
+      resource: `investor/${args.investorId}`,
+      outcome: 'SUCCESS',
+      details: {
+        investor_id: args.investorId,
+        previous_tier: args.previousTier,
+        new_tier: args.resolution.tier,
+        multiplier: args.resolution.multiplier,
+        offering_cap_bps: args.resolution.offeringCapBps,
+        effective_cap_bps: args.resolution.effectiveCapBps,
+        changed: args.changed,
+        // Explicit: existing investments are untouched.
+        retroactive_invalidation: false,
+      },
+      securityContext: {
+        requestId: `req_${Date.now()}`,
+        ipAddress: 'system',
+        userAgent: 'kyc-risk-tier-service',
+        timestamp: new Date(),
+      },
+      timestamp: new Date(),
+    };
+
+    await this.auditRepo.record(event);
+  }
+}
+
+export function createKycRiskTierService(
+  userRepo: UserRepository,
+  auditRepo: SecurityAuditRepository,
+): KycRiskTierService {
+  return new KycRiskTierService(userRepo, auditRepo);
+}


### PR DESCRIPTION
Scale offering concentration caps by investor kyc_risk_tier, gate new intents only (no retroactive invalidation), and emit investor.cap.recalculated on tier change. Closes #541 