### PR TITLE
feat: resumable batch renderer for investor PDFs

### DIFF
--- a/docs/investor-statement-batch-pipeline.md
+++ b/docs/investor-statement-batch-pipeline.md
@@ -1,0 +1,132 @@
+# Investor Statement PDF Batch Pipeline
+
+## Problem
+
+Closing a period requires rendering thousands of investor statement PDFs.
+Doing that **serially** exceeds the maintenance window. A process crash mid-run
+must not lose progress or leave **duplicate** PDF objects in storage.
+
+## Solution
+
+A Postgres-backed, resumable job queue:
+
+```
+enqueuePeriod(period, investors)
+        │
+        ▼
+┌─────────────────────┐
+│ pdf_render_batches  │  run summary / counters
+└─────────┬───────────┘
+          │ 1:N
+          ▼
+┌─────────────────────┐     claim (SKIP LOCKED + stale reclaim)
+│  pdf_render_jobs    │◄──────────────────────────────────────┐
+│  status checkpoint  │                                       │
+└─────────┬───────────┘                                       │
+          │                                                   │
+          ▼                                                   │
+   worker pool (N)  ──render──► storage.put(deterministic key)│
+          │                                                   │
+          ├── success → markCompleted (storage_key, checksum)─┘
+          └── failure → pending+backoff OR failed dead-letter
+```
+
+Checkpoints live **only in Postgres** (job `status`, `storage_key`, `checksum`,
+`claimed_at`). Workers are memory-stateless and safe to kill.
+
+## Components
+
+| Piece | Path |
+|-------|------|
+| Migration | `src/db/migrations/017_create_pdf_render_jobs.sql` |
+| Repository | `src/db/repositories/pdfRenderJobRepository.ts` |
+| Renderer | `src/services/statementPdfService.ts` |
+| Worker | `src/services/statementPdfBatchWorker.ts` |
+
+### Claim semantics
+
+`claimJobs(limit, staleAfterMs)` selects:
+
+- `status = pending AND available_at <= NOW()`, or
+- `status = processing AND claimed_at` older than the stale window (crash reclaim)
+
+…with `FOR UPDATE SKIP LOCKED`, then flips rows to `processing` and commits
+**before** rendering so locks are not held across PDF generation.
+
+### No duplicate outputs
+
+Storage keys are deterministic:
+
+`statements/{period_id}/{investor_id}.pdf`
+
+A resumed job overwrites the same object. Completion is recorded only after a
+successful `putObject`, so receivers never see two keys for one investor/period.
+
+### Throughput metric
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `statement_pdf_jobs_enqueued_total` | counter | Jobs inserted |
+| `statement_pdf_jobs_completed_total` | counter | Successful renders |
+| `statement_pdf_jobs_failed_total` | counter | Dead-lettered jobs |
+| `statement_pdf_render_duration_ms` | histogram | Per-job latency |
+| `statement_pdf_throughput_jobs_per_sec` | gauge | Sliding 60s completion rate |
+| `statement_pdf_batch_backlog` | gauge | Pending+processing count |
+
+## Failure modes
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Worker crash mid-render | Row stays `processing` until stale window, then reclaimable |
+| Transient render error | Back to `pending` with exponential `available_at` backoff |
+| Exhausted attempts | `failed` dead-letter; batch failed_jobs++ |
+| Re-enqueue same investors in batch | `ON CONFLICT DO NOTHING` |
+| Two workers race | `SKIP LOCKED` — each job claimed once |
+| Resume after partial success | Only pending/stale processing rows claimed; completed skipped |
+
+## Security assumptions
+
+1. Worker endpoints / admin enqueue APIs must be authenticated (admin-only).
+2. Metric labels use short non-PII fragments (`period` truncated, `batch` hex prefix).
+3. Storage keys must not embed secrets; investor IDs are already authz-scoped upstream.
+4. Overwrite-on-resume prevents orphan objects from multiplying attack surface in buckets.
+
+## Running the tests
+
+```bash
+npx jest --runInBand \
+  src/services/statementPdfBatchWorker.test.ts \
+  src/db/repositories/pdfRenderJobRepository.test.ts \
+  --coverage \
+  --collectCoverageFrom='src/services/statementPdfBatchWorker.ts' \
+  --collectCoverageFrom='src/services/statementPdfService.ts' \
+  --collectCoverageFrom='src/db/repositories/pdfRenderJobRepository.ts' \
+  --coverageThreshold='{"global":{"statements":95,"branches":90,"functions":95,"lines":95}}'
+```
+
+## Example usage
+
+```ts
+const storage = new InMemoryStatementPdfStorage(); // or S3 adapter
+const repo = new PdfRenderJobRepository(pool);
+const worker = new StatementPdfBatchWorker(
+  repo,
+  makeStatementRenderFn(storage),
+  metrics,
+  { concurrency: 8, batchSize: 50, staleAfterMs: 15 * 60_000 },
+);
+
+await worker.enqueuePeriod('2026-06', investorIds);
+worker.start(); // or cron: await worker.drainOnce();
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `017_create_pdf_render_jobs.sql` | Batches + jobs tables |
+| `pdfRenderJobRepository.ts` | Enqueue / claim / checkpoint |
+| `statementPdfService.ts` | Deterministic render + storage |
+| `statementPdfBatchWorker.ts` | Pool + metrics + resume |
+| `*.test.ts` | Edge cases incl. crash resume |
+| `docs/investor-statement-batch-pipeline.md` | This document |

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.test.ts',

--- a/src/db/migrations/017_create_pdf_render_jobs.sql
+++ b/src/db/migrations/017_create_pdf_render_jobs.sql
@@ -1,0 +1,75 @@
+-- Migration: pdf_render_jobs + pdf_render_batches
+-- Description: Resumable investor-statement PDF batch pipeline (Issue #540).
+--   Jobs are checkpointed in Postgres (status/storage_key/checksum), claimed with
+--   FOR UPDATE SKIP LOCKED, and reclaimable after a stale processing window so
+--   a crash mid-batch resumes without duplicating durable outputs (deterministic
+--   storage_key per investor+period).
+
+CREATE TABLE IF NOT EXISTS pdf_render_batches (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_id       TEXT NOT NULL,
+  total_jobs      INTEGER NOT NULL DEFAULT 0,
+  completed_jobs  INTEGER NOT NULL DEFAULT 0,
+  failed_jobs     INTEGER NOT NULL DEFAULT 0,
+  status          TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+  started_at      TIMESTAMPTZ,
+  completed_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pdf_render_batches_period
+  ON pdf_render_batches (period_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS pdf_render_jobs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  batch_id        UUID NOT NULL REFERENCES pdf_render_batches(id) ON DELETE CASCADE,
+  investor_id     TEXT NOT NULL,
+  period_id       TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+  attempts        INTEGER NOT NULL DEFAULT 0,
+  available_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  claimed_at      TIMESTAMPTZ,
+  -- Deterministic artifact identity: statements/{period_id}/{investor_id}.pdf
+  storage_key     TEXT,
+  checksum        TEXT,
+  error           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (batch_id, investor_id, period_id)
+);
+
+-- Dispatcher / worker poll: ready pending rows (and reclaim handled in SQL claim)
+CREATE INDEX IF NOT EXISTS idx_pdf_render_jobs_pending
+  ON pdf_render_jobs (available_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_pdf_render_jobs_processing_claimed
+  ON pdf_render_jobs (claimed_at)
+  WHERE status = 'processing';
+
+CREATE INDEX IF NOT EXISTS idx_pdf_render_jobs_batch_status
+  ON pdf_render_jobs (batch_id, status);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'update_updated_at_column') THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_trigger WHERE tgname = 'update_pdf_render_batches_updated_at'
+    ) THEN
+      CREATE TRIGGER update_pdf_render_batches_updated_at
+        BEFORE UPDATE ON pdf_render_batches
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_trigger WHERE tgname = 'update_pdf_render_jobs_updated_at'
+    ) THEN
+      CREATE TRIGGER update_pdf_render_jobs_updated_at
+        BEFORE UPDATE ON pdf_render_jobs
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+  END IF;
+END $$;

--- a/src/db/repositories/pdfRenderJobRepository.test.ts
+++ b/src/db/repositories/pdfRenderJobRepository.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Repository unit tests for pdf_render_jobs checkpointing (#540).
+ */
+
+import { Pool } from 'pg';
+import {
+  PdfRenderJobRepository,
+  buildStatementStorageKey,
+  checksumPayload,
+} from './pdfRenderJobRepository';
+
+function makePool(handlers: {
+  query?: jest.Mock;
+  connect?: jest.Mock;
+}): Pool {
+  return {
+    query: handlers.query ?? jest.fn(),
+    connect: handlers.connect ?? jest.fn(),
+  } as unknown as Pool;
+}
+
+describe('PdfRenderJobRepository', () => {
+  it('enqueueBatch inserts batch + unique investors', async () => {
+    const query = jest
+      .fn()
+      // batch insert
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'b1',
+            period_id: '2026-06',
+            total_jobs: 2,
+            completed_jobs: 0,
+            failed_jobs: 0,
+            status: 'running',
+            started_at: new Date(),
+            completed_at: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      // job inserts
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'j1' }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'j2' }] });
+
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const result = await repo.enqueueBatch('2026-06', ['inv-1', 'inv-2', 'inv-1']);
+    expect(result.inserted).toBe(2);
+    expect(result.batch.id).toBe('b1');
+    const batchIdUsed = query.mock.calls[0][1][0] as string;
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO pdf_render_jobs'),
+      expect.arrayContaining([
+        batchIdUsed,
+        'inv-1',
+        '2026-06',
+        buildStatementStorageKey('2026-06', 'inv-1'),
+      ]),
+    );
+  });
+
+  it('claimJobs uses a transaction and SKIP LOCKED', async () => {
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'j1',
+            batch_id: 'b1',
+            investor_id: 'inv-1',
+            period_id: '2026-06',
+            status: 'pending',
+            attempts: 0,
+            available_at: new Date(),
+            claimed_at: null,
+            storage_key: 'statements/2026-06/inv-1.pdf',
+            checksum: null,
+            error: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'j1',
+            batch_id: 'b1',
+            investor_id: 'inv-1',
+            period_id: '2026-06',
+            status: 'processing',
+            attempts: 1,
+            available_at: new Date(),
+            claimed_at: new Date(),
+            storage_key: 'statements/2026-06/inv-1.pdf',
+            checksum: null,
+            error: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined); // COMMIT
+
+    const client = { query: clientQuery, release: jest.fn() };
+    const connect = jest.fn().mockResolvedValue(client);
+    const repo = new PdfRenderJobRepository(makePool({ connect }));
+
+    const claimed = await repo.claimJobs(10, 60_000);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0].status).toBe('processing');
+    expect(clientQuery.mock.calls[1][0]).toContain('FOR UPDATE SKIP LOCKED');
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  it('markCompleted checkpoints storage_key and checksum', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    await repo.markCompleted('j1', 'statements/2026-06/inv-1.pdf', 'abc');
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'completed'"),
+      ['j1', 'statements/2026-06/inv-1.pdf', 'abc'],
+    );
+  });
+
+  it('markFailed with retryAfter returns job to pending', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const when = new Date(Date.now() + 1000);
+    await repo.markFailed('j1', 'boom', when);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'pending'"),
+      ['j1', when, 'boom'],
+    );
+  });
+
+  it('markFailed without retryAfter dead-letters', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    await repo.markFailed('j1', 'boom');
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'failed'"),
+      ['j1', 'boom'],
+    );
+  });
+
+  it('getBatch and countPending query helpers', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'b1',
+            period_id: '2026-06',
+            total_jobs: 1,
+            completed_jobs: 0,
+            failed_jobs: 0,
+            status: 'running',
+            started_at: null,
+            completed_at: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: '3' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '4' }] });
+
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    expect((await repo.getBatch('b1'))?.id).toBe('b1');
+    expect(await repo.getBatch('missing')).toBeNull();
+    expect(await repo.countPending('b1')).toBe(3);
+    expect(await repo.countPending()).toBe(4);
+  });
+
+  it('claimJobs rolls back on error', async () => {
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockRejectedValueOnce(new Error('db down'));
+    const client = { query: clientQuery, release: jest.fn() };
+    // ROLLBACK after failure
+    clientQuery.mockResolvedValueOnce(undefined);
+    const repo = new PdfRenderJobRepository(
+      makePool({ connect: jest.fn().mockResolvedValue(client) }),
+    );
+    await expect(repo.claimJobs(1, 1000)).rejects.toThrow('db down');
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  it('enqueueBatch adjusts total_jobs when inserts are skipped', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'b2',
+            period_id: '2026-06',
+            total_jobs: 2,
+            completed_jobs: 0,
+            failed_jobs: 0,
+            status: 'running',
+            started_at: new Date(),
+            completed_at: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'j1' }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const result = await repo.enqueueBatch('2026-06', ['inv-1', 'inv-2']);
+    expect(result.inserted).toBe(1);
+    expect(result.batch.total_jobs).toBe(1);
+    const batchIdUsed = query.mock.calls[0][1][0] as string;
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE pdf_render_batches SET total_jobs'),
+      [batchIdUsed, 1],
+    );
+  });
+
+  it('enqueueBatch treats undefined rowCount as zero inserts', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'b4',
+            period_id: '2026-06',
+            total_jobs: 1,
+            completed_jobs: 0,
+            failed_jobs: 0,
+            status: 'running',
+            started_at: new Date(),
+            completed_at: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const result = await repo.enqueueBatch('2026-06', ['inv-1']);
+    expect(result.inserted).toBe(0);
+    expect(result.batch.total_jobs).toBe(0);
+  });
+
+  it('enqueueBatch filters empty investor ids', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'b3',
+            period_id: '2026-06',
+            total_jobs: 1,
+            completed_jobs: 0,
+            failed_jobs: 0,
+            status: 'running',
+            started_at: new Date(),
+            completed_at: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'j1' }] });
+
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const result = await repo.enqueueBatch('2026-06', ['inv-1', '', 'inv-1']);
+    expect(result.inserted).toBe(1);
+    expect(query.mock.calls[0][1][2]).toBe(1);
+  });
+
+  it('markCompleted updates batch counters', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    await repo.markCompleted('j1', 'key', 'sum');
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[1][0]).toContain('UPDATE pdf_render_batches');
+  });
+
+  it('markFailed dead-letter updates batch counters', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    await repo.markFailed('j1', 'boom');
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[1][0]).toContain('failed_jobs = failed_jobs + 1');
+  });
+
+
+  it('claimJobs skips rows when update returns no row', async () => {
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [{ id: 'j1', batch_id: 'b1', investor_id: 'i', period_id: 'p', status: 'pending', attempts: 0, available_at: new Date(), claimed_at: null, storage_key: null, checksum: null, error: null, created_at: new Date(), updated_at: new Date() }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce(undefined);
+    const client = { query: clientQuery, release: jest.fn() };
+    const repo = new PdfRenderJobRepository(
+      makePool({ connect: jest.fn().mockResolvedValue(client) }),
+    );
+    expect(await repo.claimJobs(1, 1000)).toEqual([]);
+  });
+
+  it('countPending treats missing count as zero', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{}] });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    expect(await repo.countPending()).toBe(0);
+  });
+
+  it('getBatch maps nullable timestamps', async () => {
+    const query = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'b1',
+          period_id: 'p',
+          total_jobs: '1',
+          completed_jobs: '0',
+          failed_jobs: '0',
+          status: 'running',
+          started_at: null,
+          completed_at: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const batch = await repo.getBatch('b1');
+    expect(batch?.started_at).toBeNull();
+    expect(batch?.completed_at).toBeNull();
+  });
+
+
+  it('getBatch maps non-null timestamps', async () => {
+    const started = new Date('2020-01-01T00:00:00Z');
+    const completed = new Date('2020-01-02T00:00:00Z');
+    const query = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'b1',
+          period_id: 'p',
+          total_jobs: 1,
+          completed_jobs: 0,
+          failed_jobs: 0,
+          status: 'completed',
+          started_at: started,
+          completed_at: completed,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+    });
+    const repo = new PdfRenderJobRepository(makePool({ query }));
+    const batch = await repo.getBatch('b1');
+    expect(batch?.started_at?.toISOString()).toBe(started.toISOString());
+    expect(batch?.completed_at?.toISOString()).toBe(completed.toISOString());
+  });
+
+  it('claimJobs maps nullable job fields from update row', async () => {
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'j1',
+            batch_id: 'b1',
+            investor_id: 'i',
+            period_id: 'p',
+            status: 'pending',
+            attempts: 0,
+            available_at: new Date(),
+            claimed_at: null,
+            storage_key: null,
+            checksum: null,
+            error: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'j1',
+            batch_id: 'b1',
+            investor_id: 'i',
+            period_id: 'p',
+            status: 'processing',
+            attempts: 1,
+            available_at: new Date(),
+            claimed_at: new Date(),
+            storage_key: null,
+            checksum: null,
+            error: 'prev',
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined);
+    const client = { query: clientQuery, release: jest.fn() };
+    const repo = new PdfRenderJobRepository(
+      makePool({ connect: jest.fn().mockResolvedValue(client) }),
+    );
+    const claimed = await repo.claimJobs(1, 1000);
+    expect(claimed[0].storage_key).toBeNull();
+    expect(claimed[0].claimed_at).toBeInstanceOf(Date);
+    expect(claimed[0].error).toBe('prev');
+  });
+
+  it('claimJobs maps null claimed_at after claim', async () => {
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'j1',
+            batch_id: 'b1',
+            investor_id: 'i',
+            period_id: 'p',
+            status: 'pending',
+            attempts: 0,
+            available_at: new Date(),
+            claimed_at: null,
+            storage_key: 'k',
+            checksum: null,
+            error: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'j1',
+            batch_id: 'b1',
+            investor_id: 'i',
+            period_id: 'p',
+            status: 'processing',
+            attempts: 1,
+            available_at: new Date(),
+            claimed_at: null,
+            storage_key: 'k',
+            checksum: null,
+            error: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined);
+    const client = { query: clientQuery, release: jest.fn() };
+    const repo = new PdfRenderJobRepository(
+      makePool({ connect: jest.fn().mockResolvedValue(client) }),
+    );
+    const claimed = await repo.claimJobs(1, 1000);
+    expect(claimed[0].claimed_at).toBeNull();
+  });
+
+  it('checksumPayload hashes bytes deterministically', () => {
+    expect(checksumPayload('abc')).toBe(checksumPayload(Buffer.from('abc')));
+  });
+});

--- a/src/db/repositories/pdfRenderJobRepository.ts
+++ b/src/db/repositories/pdfRenderJobRepository.ts
@@ -1,0 +1,274 @@
+import { createHash, randomUUID } from 'crypto';
+import { Pool, PoolClient, QueryResult } from 'pg';
+
+export type PdfRenderJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+export type PdfRenderBatchStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface PdfRenderBatchRow {
+  id: string;
+  period_id: string;
+  total_jobs: number;
+  completed_jobs: number;
+  failed_jobs: number;
+  status: PdfRenderBatchStatus;
+  started_at: Date | null;
+  completed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface PdfRenderJobRow {
+  id: string;
+  batch_id: string;
+  investor_id: string;
+  period_id: string;
+  status: PdfRenderJobStatus;
+  attempts: number;
+  available_at: Date;
+  claimed_at: Date | null;
+  storage_key: string | null;
+  checksum: string | null;
+  error: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/** Deterministic storage key — resume/re-render overwrites the same object. */
+export function buildStatementStorageKey(periodId: string, investorId: string): string {
+  return `statements/${periodId}/${investorId}.pdf`;
+}
+
+export function checksumPayload(bytes: Buffer | string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Repository for pdf_render_batches / pdf_render_jobs.
+ *
+ * Checkpoints live in Postgres (job status + storage_key + checksum), never in
+ * process memory — a crashed worker leaves rows claimable again after the
+ * stale window, and completed jobs are never re-enqueued.
+ */
+export class PdfRenderJobRepository {
+  constructor(private readonly db: Pool) {}
+
+  /**
+   * Create a batch and enqueue one job per investor.
+   * Re-enqueue within the same batch is a no-op via UNIQUE + ON CONFLICT DO NOTHING.
+   */
+  async enqueueBatch(
+    periodId: string,
+    investorIds: string[],
+    client?: PoolClient,
+  ): Promise<{ batch: PdfRenderBatchRow; inserted: number }> {
+    const executor = client ?? this.db;
+    const uniqueInvestors = [...new Set(investorIds.filter(Boolean))];
+    const batchId = randomUUID();
+
+    const batchResult: QueryResult<PdfRenderBatchRow> = await executor.query(
+      `INSERT INTO pdf_render_batches (id, period_id, total_jobs, status, started_at)
+       VALUES ($1, $2, $3, 'running', NOW())
+       RETURNING *`,
+      [batchId, periodId, uniqueInvestors.length],
+    );
+    const batch = this.mapBatch(batchResult.rows[0]);
+
+    let inserted = 0;
+    for (const investorId of uniqueInvestors) {
+      const result = await executor.query(
+        `INSERT INTO pdf_render_jobs (batch_id, investor_id, period_id, storage_key)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (batch_id, investor_id, period_id) DO NOTHING
+         RETURNING id`,
+        [batchId, investorId, periodId, buildStatementStorageKey(periodId, investorId)],
+      );
+      if ((result.rowCount ?? 0) > 0) inserted += 1;
+    }
+
+    if (inserted !== uniqueInvestors.length) {
+      await executor.query(
+        `UPDATE pdf_render_batches SET total_jobs = $2 WHERE id = $1`,
+        [batchId, inserted],
+      );
+      batch.total_jobs = inserted;
+    }
+
+    return { batch, inserted };
+  }
+
+  /**
+   * Claim up to `limit` jobs:
+   *  - pending and available, OR
+   *  - processing with claimed_at older than `staleAfterMs` (crash reclaim)
+   *
+   * Uses SKIP LOCKED so concurrent workers never double-claim.
+   * Releases the row lock before rendering (status flipped to processing).
+   */
+  async claimJobs(limit: number, staleAfterMs: number): Promise<PdfRenderJobRow[]> {
+    const client = await this.db.connect();
+    try {
+      await client.query('BEGIN');
+      const staleInterval = `${Math.max(1, Math.floor(staleAfterMs / 1000))} seconds`;
+      const result: QueryResult<PdfRenderJobRow> = await client.query(
+        `SELECT * FROM pdf_render_jobs
+         WHERE (
+           (status = 'pending' AND available_at <= NOW())
+           OR (
+             status = 'processing'
+             AND claimed_at IS NOT NULL
+             AND claimed_at < NOW() - ($2::text)::interval
+           )
+         )
+         ORDER BY available_at ASC
+         LIMIT $1
+         FOR UPDATE SKIP LOCKED`,
+        [limit, staleInterval],
+      );
+
+      const claimed: PdfRenderJobRow[] = [];
+      for (const row of result.rows) {
+        const updated: QueryResult<PdfRenderJobRow> = await client.query(
+          `UPDATE pdf_render_jobs
+           SET status = 'processing', claimed_at = NOW(), attempts = attempts + 1
+           WHERE id = $1
+           RETURNING *`,
+          [row.id],
+        );
+        if (updated.rows[0]) claimed.push(this.mapJob(updated.rows[0]));
+      }
+
+      await client.query('COMMIT');
+      return claimed;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Persist successful render checkpoint (storage_key + checksum). */
+  async markCompleted(id: string, storageKey: string, checksum: string): Promise<void> {
+    await this.db.query(
+      `UPDATE pdf_render_jobs
+       SET status = 'completed',
+           storage_key = $2,
+           checksum = $3,
+           error = NULL,
+           claimed_at = NULL
+       WHERE id = $1`,
+      [id, storageKey, checksum],
+    );
+    await this.db.query(
+      `UPDATE pdf_render_batches b
+       SET completed_jobs = completed_jobs + 1,
+           status = CASE
+             WHEN completed_jobs + 1 + failed_jobs >= total_jobs THEN 'completed'
+             ELSE 'running'
+           END,
+           completed_at = CASE
+             WHEN completed_jobs + 1 + failed_jobs >= total_jobs THEN NOW()
+             ELSE completed_at
+           END
+       WHERE b.id = (SELECT batch_id FROM pdf_render_jobs WHERE id = $1)`,
+      [id],
+    );
+  }
+
+  /**
+   * Record failure. With `retryAfter`, row returns to pending (resumable).
+   * Without it, row is dead-lettered as failed.
+   */
+  async markFailed(id: string, error: string, retryAfter?: Date): Promise<void> {
+    if (retryAfter) {
+      await this.db.query(
+        `UPDATE pdf_render_jobs
+         SET status = 'pending',
+             available_at = $2,
+             error = $3,
+             claimed_at = NULL
+         WHERE id = $1`,
+        [id, retryAfter, error],
+      );
+      return;
+    }
+
+    await this.db.query(
+      `UPDATE pdf_render_jobs
+       SET status = 'failed',
+           error = $2,
+           claimed_at = NULL
+       WHERE id = $1`,
+      [id, error],
+    );
+    await this.db.query(
+      `UPDATE pdf_render_batches b
+       SET failed_jobs = failed_jobs + 1,
+           status = CASE
+             WHEN completed_jobs + failed_jobs + 1 >= total_jobs THEN 'completed'
+             ELSE 'running'
+           END,
+           completed_at = CASE
+             WHEN completed_jobs + failed_jobs + 1 >= total_jobs THEN NOW()
+             ELSE completed_at
+           END
+       WHERE b.id = (SELECT batch_id FROM pdf_render_jobs WHERE id = $1)`,
+      [id],
+    );
+  }
+
+  async getBatch(batchId: string): Promise<PdfRenderBatchRow | null> {
+    const result: QueryResult<PdfRenderBatchRow> = await this.db.query(
+      `SELECT * FROM pdf_render_batches WHERE id = $1`,
+      [batchId],
+    );
+    return result.rows[0] ? this.mapBatch(result.rows[0]) : null;
+  }
+
+  async countPending(batchId?: string): Promise<number> {
+    const result = batchId
+      ? await this.db.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM pdf_render_jobs
+           WHERE batch_id = $1 AND status IN ('pending', 'processing')`,
+          [batchId],
+        )
+      : await this.db.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM pdf_render_jobs
+           WHERE status IN ('pending', 'processing')`,
+        );
+    return parseInt(result.rows[0]?.count ?? '0', 10);
+  }
+
+  private mapBatch(row: any): PdfRenderBatchRow {
+    return {
+      id: row.id,
+      period_id: row.period_id,
+      total_jobs: Number(row.total_jobs),
+      completed_jobs: Number(row.completed_jobs),
+      failed_jobs: Number(row.failed_jobs),
+      status: row.status,
+      started_at: row.started_at ? new Date(row.started_at) : null,
+      completed_at: row.completed_at ? new Date(row.completed_at) : null,
+      created_at: new Date(row.created_at),
+      updated_at: new Date(row.updated_at),
+    };
+  }
+
+  private mapJob(row: any): PdfRenderJobRow {
+    return {
+      id: row.id,
+      batch_id: row.batch_id,
+      investor_id: row.investor_id,
+      period_id: row.period_id,
+      status: row.status,
+      attempts: Number(row.attempts),
+      available_at: new Date(row.available_at),
+      claimed_at: row.claimed_at ? new Date(row.claimed_at) : null,
+      storage_key: row.storage_key ?? null,
+      checksum: row.checksum ?? null,
+      error: row.error ?? null,
+      created_at: new Date(row.created_at),
+      updated_at: new Date(row.updated_at),
+    };
+  }
+}

--- a/src/services/statementPdfBatchWorker.test.ts
+++ b/src/services/statementPdfBatchWorker.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Tests for resumable investor-statement PDF batch pipeline (#540):
+ *  1. Enqueue creates batch + jobs; duplicate investors collapse
+ *  2. Successful drain marks completed with storage_key + checksum
+ *  3. Transient failure schedules retry (pending + retryAfter)
+ *  4. Exhausted attempts dead-letters
+ *  5. Crash mid-batch: stale reclaim + same storage_key (no duplicate outputs)
+ *  6. Deterministic render bytes / checksum across retries
+ *  7. Throughput metric emitted
+ *  8. start/stop polling loop
+ */
+
+import { MetricsCollector } from '../lib/metrics';
+import {
+  PdfRenderJobRepository,
+  PdfRenderJobRow,
+  PdfRenderBatchRow,
+  buildStatementStorageKey,
+  checksumPayload,
+} from '../db/repositories/pdfRenderJobRepository';
+import {
+  StatementPdfBatchWorker,
+  METRIC_PDF_JOBS_COMPLETED,
+  METRIC_PDF_JOBS_FAILED,
+  METRIC_PDF_THROUGHPUT,
+  METRIC_PDF_JOBS_ENQUEUED,
+  METRIC_PDF_BACKLOG,
+  createStatementPdfBatchWorker,
+} from './statementPdfBatchWorker';
+import {
+  InMemoryStatementPdfStorage,
+  makeStatementRenderFn,
+  renderStatementPdfBytes,
+} from './statementPdfService';
+
+function makeBatch(overrides: Partial<PdfRenderBatchRow> = {}): PdfRenderBatchRow {
+  return {
+    id: 'batch-1',
+    period_id: '2026-06',
+    total_jobs: 2,
+    completed_jobs: 0,
+    failed_jobs: 0,
+    status: 'running',
+    started_at: new Date(),
+    completed_at: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeJob(overrides: Partial<PdfRenderJobRow> = {}): PdfRenderJobRow {
+  const investor_id = overrides.investor_id ?? 'inv-1';
+  const period_id = overrides.period_id ?? '2026-06';
+  return {
+    id: 'job-1',
+    batch_id: 'batch-1',
+    investor_id,
+    period_id,
+    status: 'processing',
+    attempts: 1,
+    available_at: new Date(),
+    claimed_at: new Date(),
+    storage_key: buildStatementStorageKey(period_id, investor_id),
+    checksum: null,
+    error: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeRepo(jobs: PdfRenderJobRow[] = []): jest.Mocked<PdfRenderJobRepository> {
+  return {
+    enqueueBatch: jest.fn().mockResolvedValue({ batch: makeBatch(), inserted: jobs.length || 1 }),
+    claimJobs: jest.fn().mockResolvedValue(jobs),
+    markCompleted: jest.fn().mockResolvedValue(undefined),
+    markFailed: jest.fn().mockResolvedValue(undefined),
+    getBatch: jest.fn().mockResolvedValue(makeBatch()),
+    countPending: jest.fn().mockResolvedValue(0),
+  } as unknown as jest.Mocked<PdfRenderJobRepository>;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('statementPdfService', () => {
+  it('renders deterministic bytes and overwrites the same storage key', async () => {
+    const storage = new InMemoryStatementPdfStorage();
+    const render = makeStatementRenderFn(storage);
+    const job = makeJob();
+
+    const first = await render(job);
+    const second = await render(job);
+
+    expect(first.storageKey).toBe(second.storageKey);
+    expect(first.checksum).toBe(second.checksum);
+    expect(storage.size()).toBe(1);
+    expect(checksumPayload(first.bytes)).toBe(first.checksum);
+    expect(renderStatementPdfBytes(job).equals(first.bytes)).toBe(true);
+  });
+
+
+  it('InMemoryStatementPdfStorage supports get/clear/size', async () => {
+    const storage = new InMemoryStatementPdfStorage();
+    expect(await storage.getObject('missing')).toBeNull();
+    await storage.putObject('k', Buffer.from('x'));
+    expect(storage.size()).toBe(1);
+    storage.clear();
+    expect(storage.size()).toBe(0);
+  });
+
+  it('makeStatementRenderFn uses built storage key when job.storage_key is null', async () => {
+    const storage = new InMemoryStatementPdfStorage();
+    const render = makeStatementRenderFn(storage);
+    const job = makeJob({ storage_key: null });
+    const result = await render(job);
+    expect(result.storageKey).toBe(buildStatementStorageKey(job.period_id, job.investor_id));
+  });
+
+
+  it('throws when post-render checksum verification fails', async () => {
+    const storage = new InMemoryStatementPdfStorage();
+    jest
+      .spyOn(require('../db/repositories/pdfRenderJobRepository'), 'checksumPayload')
+      .mockReturnValue('tampered');
+    const render = makeStatementRenderFn(storage);
+    await expect(render(makeJob())).rejects.toThrow('statement PDF checksum mismatch');
+    jest.restoreAllMocks();
+  });
+
+  it('buildStatementStorageKey is stable per investor+period', () => {
+    expect(buildStatementStorageKey('2026-06', 'inv-1')).toBe(
+      'statements/2026-06/inv-1.pdf',
+    );
+  });
+});
+
+describe('StatementPdfBatchWorker', () => {
+  it('enqueues a period and records enqueued metric', async () => {
+
+    const repo = makeRepo();
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const spy = jest.spyOn(metrics, 'incrementCounter');
+    const worker = new StatementPdfBatchWorker(repo, jest.fn(), metrics);
+
+    const result = await worker.enqueuePeriod('2026-06', ['inv-1', 'inv-2', 'inv-1']);
+    expect(repo.enqueueBatch).toHaveBeenCalledWith('2026-06', ['inv-1', 'inv-2', 'inv-1']);
+    expect(result.batch.id).toBe('batch-1');
+    expect(spy).toHaveBeenCalledWith(
+      METRIC_PDF_JOBS_ENQUEUED,
+      expect.any(Object),
+      expect.any(Number),
+      expect.any(String),
+    );
+  });
+
+  it('marks completed on successful render and emits throughput', async () => {
+    const job = makeJob();
+    const repo = makeRepo([job]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const gaugeSpy = jest.spyOn(metrics, 'setGauge');
+    const counterSpy = jest.spyOn(metrics, 'incrementCounter');
+    const storage = new InMemoryStatementPdfStorage();
+    const worker = new StatementPdfBatchWorker(
+      repo,
+      makeStatementRenderFn(storage),
+      metrics,
+      { concurrency: 2 },
+    );
+
+    const processed = await worker.drainOnce();
+    expect(processed).toBe(1);
+    expect(repo.markCompleted).toHaveBeenCalledWith(
+      job.id,
+      job.storage_key,
+      expect.any(String),
+    );
+    expect(counterSpy).toHaveBeenCalledWith(
+      METRIC_PDF_JOBS_COMPLETED,
+      expect.any(Object),
+    );
+    expect(gaugeSpy).toHaveBeenCalledWith(
+      METRIC_PDF_THROUGHPUT,
+      expect.any(Number),
+      expect.any(Object),
+      expect.any(String),
+    );
+    expect(storage.size()).toBe(1);
+  });
+
+  it('schedules retry on transient failure before maxAttempts', async () => {
+    const job = makeJob({ attempts: 1 });
+    const repo = makeRepo([job]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const worker = new StatementPdfBatchWorker(
+      repo,
+      jest.fn().mockRejectedValue(new Error('rpc timeout')),
+      metrics,
+      { maxAttempts: 5, retryBaseMs: 100 },
+    );
+
+    await worker.drainOnce();
+    expect(repo.markFailed).toHaveBeenCalledWith(
+      job.id,
+      'rpc timeout',
+      expect.any(Date),
+    );
+    expect(repo.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it('dead-letters after maxAttempts', async () => {
+    const job = makeJob({ attempts: 5 });
+    const repo = makeRepo([job]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const counterSpy = jest.spyOn(metrics, 'incrementCounter');
+    const worker = new StatementPdfBatchWorker(
+      repo,
+      jest.fn().mockRejectedValue(new Error('permanent')),
+      metrics,
+      { maxAttempts: 5 },
+    );
+
+    await worker.drainOnce();
+    expect(repo.markFailed).toHaveBeenCalledWith(job.id, 'permanent');
+    expect(counterSpy).toHaveBeenCalledWith(
+      METRIC_PDF_JOBS_FAILED,
+      expect.any(Object),
+    );
+  });
+
+  it('crash mid-batch resume reuses the same storage key (no duplicate outputs)', async () => {
+    const storage = new InMemoryStatementPdfStorage();
+    const render = makeStatementRenderFn(storage);
+    const job = makeJob({ investor_id: 'inv-42', period_id: '2026-06' });
+
+    // First attempt "crashes" after writing object but before markCompleted
+    const first = await render(job);
+    expect(storage.size()).toBe(1);
+
+    // Worker resumes: claim returns the same job (stale reclaim), completes
+    const repo = makeRepo([{ ...job, attempts: 2 }]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const worker = new StatementPdfBatchWorker(repo, render, metrics);
+    await worker.drainOnce();
+
+    expect(storage.size()).toBe(1);
+    expect(repo.markCompleted).toHaveBeenCalledWith(
+      job.id,
+      first.storageKey,
+      first.checksum,
+    );
+    const stored = await storage.getObject(first.storageKey);
+    expect(stored && checksumPayload(stored)).toBe(first.checksum);
+  });
+
+  it('processes a claimed shard concurrently without dropping jobs', async () => {
+    const jobs = [
+      makeJob({ id: 'j1', investor_id: 'inv-1' }),
+      makeJob({ id: 'j2', investor_id: 'inv-2' }),
+      makeJob({ id: 'j3', investor_id: 'inv-3' }),
+    ];
+    const repo = makeRepo(jobs);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const storage = new InMemoryStatementPdfStorage();
+    const worker = new StatementPdfBatchWorker(
+      repo,
+      makeStatementRenderFn(storage),
+      metrics,
+      { concurrency: 3 },
+    );
+
+    const n = await worker.drainOnce();
+    expect(n).toBe(3);
+    expect(repo.markCompleted).toHaveBeenCalledTimes(3);
+    expect(storage.size()).toBe(3);
+  });
+
+  it('returns 0 and still refreshes throughput when queue is empty', async () => {
+    const repo = makeRepo([]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const gaugeSpy = jest.spyOn(metrics, 'setGauge');
+    const worker = new StatementPdfBatchWorker(repo, jest.fn(), metrics);
+    expect(await worker.drainOnce()).toBe(0);
+    expect(gaugeSpy).toHaveBeenCalledWith(
+      METRIC_PDF_THROUGHPUT,
+      expect.any(Number),
+      expect.any(Object),
+      expect.any(String),
+    );
+  });
+
+
+  it('records backlog gauge after processing jobs', async () => {
+    const job = makeJob();
+    const repo = makeRepo([job]);
+    repo.countPending.mockResolvedValue(7);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const gaugeSpy = jest.spyOn(metrics, 'setGauge');
+    const worker = new StatementPdfBatchWorker(
+      repo,
+      makeStatementRenderFn(new InMemoryStatementPdfStorage()),
+      metrics,
+    );
+    await worker.drainOnce();
+    expect(gaugeSpy).toHaveBeenCalledWith(METRIC_PDF_BACKLOG, 7, { batch: 'all' });
+  });
+
+  it('retries use generic message for non-Error throws', async () => {
+    const job = makeJob({ attempts: 1 });
+    const repo = makeRepo([job]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const worker = new StatementPdfBatchWorker(
+      repo,
+      jest.fn().mockRejectedValue('bad'),
+      metrics,
+      { maxAttempts: 5, retryBaseMs: 50 },
+    );
+    await worker.drainOnce();
+    expect(repo.markFailed).toHaveBeenCalledWith(job.id, 'render failed', expect.any(Date));
+  });
+
+  it('scheduleNext survives drainOnce rejection', async () => {
+    jest.useFakeTimers();
+    const repo = makeRepo([]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const worker = new StatementPdfBatchWorker(repo, jest.fn(), metrics, { intervalMs: 1000 });
+    jest.spyOn(worker, 'drainOnce').mockRejectedValue(new Error('poll failed'));
+    worker.start();
+    await jest.advanceTimersByTimeAsync(1000);
+    worker.stop();
+    jest.useRealTimers();
+  });
+
+  it('createStatementPdfBatchWorker returns a worker instance', () => {
+    const repo = makeRepo();
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const worker = createStatementPdfBatchWorker(repo, jest.fn(), metrics);
+    expect(worker).toBeInstanceOf(StatementPdfBatchWorker);
+  });
+
+
+
+  it('enqueuePeriod shortens dashed batch ids for backlog label', async () => {
+    const repo = makeRepo();
+    repo.enqueueBatch.mockResolvedValueOnce({
+      batch: makeBatch({ id: 'part1-part2' }),
+      inserted: 2,
+    });
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const gaugeSpy = jest.spyOn(metrics, 'setGauge');
+    const worker = new StatementPdfBatchWorker(repo, jest.fn(), metrics);
+    await worker.enqueuePeriod('2026-06', ['inv-1', 'inv-2']);
+    expect(gaugeSpy).toHaveBeenCalledWith(
+      METRIC_PDF_BACKLOG,
+      2,
+      { batch: 'part1' },
+      expect.any(String),
+    );
+  });
+
+  it('start/stop controls the polling loop', () => {
+    jest.useFakeTimers();
+    const repo = makeRepo([]);
+    const metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    const worker = new StatementPdfBatchWorker(repo, jest.fn(), metrics, {
+      intervalMs: 1000,
+    });
+    const drain = jest.spyOn(worker, 'drainOnce').mockResolvedValue(0);
+
+    worker.start();
+    worker.start(); // idempotent
+    jest.advanceTimersByTime(1000);
+    expect(drain).toHaveBeenCalled();
+    worker.stop();
+    jest.advanceTimersByTime(5000);
+    worker.stop();
+    jest.useRealTimers();
+  });
+});
+
+describe('PdfRenderJobRepository helpers', () => {
+  it('exports deterministic storage key helper', () => {
+    expect(buildStatementStorageKey('p', 'i')).toBe('statements/p/i.pdf');
+  });
+});

--- a/src/services/statementPdfBatchWorker.ts
+++ b/src/services/statementPdfBatchWorker.ts
@@ -1,0 +1,220 @@
+/**
+ * Resumable investor-statement PDF batch worker (Issue #540).
+ *
+ * Mirrors OutboxDispatcher polling + SKIP LOCKED claims, with:
+ * - Postgres checkpoints (job status / storage_key / checksum)
+ * - Stale processing reclaim after crash
+ * - Worker pool (bounded concurrency) for shard throughput
+ * - Throughput metrics (jobs/sec gauge + completed counter)
+ */
+
+import { MetricsCollector } from '../lib/metrics';
+import {
+  PdfRenderJobRepository,
+  PdfRenderJobRow,
+  PdfRenderBatchRow,
+} from '../db/repositories/pdfRenderJobRepository';
+import { StatementRenderFn } from './statementPdfService';
+
+export const METRIC_PDF_JOBS_ENQUEUED = 'statement_pdf_jobs_enqueued_total';
+export const METRIC_PDF_JOBS_COMPLETED = 'statement_pdf_jobs_completed_total';
+export const METRIC_PDF_JOBS_FAILED = 'statement_pdf_jobs_failed_total';
+export const METRIC_PDF_RENDER_DURATION = 'statement_pdf_render_duration_ms';
+export const METRIC_PDF_THROUGHPUT = 'statement_pdf_throughput_jobs_per_sec';
+export const METRIC_PDF_BACKLOG = 'statement_pdf_batch_backlog';
+
+export interface StatementPdfBatchWorkerOptions {
+  /** Jobs claimed per drain cycle. Default: 50. */
+  batchSize?: number;
+  /** Poll interval ms. Default: 5000. */
+  intervalMs?: number;
+  /** Concurrent renders inside a drain cycle. Default: 4. */
+  concurrency?: number;
+  /** Max attempts before dead-letter. Default: 5. */
+  maxAttempts?: number;
+  /** Base retry backoff ms. Default: 1000. */
+  retryBaseMs?: number;
+  /** Reclaim processing jobs older than this. Default: 15 minutes. */
+  staleAfterMs?: number;
+}
+
+function shortLabel(id: string): string {
+  return id.split('-')[0] ?? id.slice(0, 8);
+}
+
+async function mapPool<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, items.length || 1)) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export class StatementPdfBatchWorker {
+  private readonly batchSize: number;
+  private readonly intervalMs: number;
+  private readonly concurrency: number;
+  private readonly maxAttempts: number;
+  private readonly retryBaseMs: number;
+  private readonly staleAfterMs: number;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+  private completedWindow: Array<{ at: number }> = [];
+
+  constructor(
+    private readonly jobRepo: PdfRenderJobRepository,
+    private readonly render: StatementRenderFn,
+    private readonly metrics: MetricsCollector,
+    options: StatementPdfBatchWorkerOptions = {},
+  ) {
+    this.batchSize = options.batchSize ?? 50;
+    this.intervalMs = options.intervalMs ?? 5000;
+    this.concurrency = options.concurrency ?? 4;
+    this.maxAttempts = options.maxAttempts ?? 5;
+    this.retryBaseMs = options.retryBaseMs ?? 1000;
+    this.staleAfterMs = options.staleAfterMs ?? 15 * 60 * 1000;
+  }
+
+  /** Start the polling loop (idempotent). */
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.scheduleNext();
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Enqueue a period's investors into a new batch.
+   * Checkpoints are rows in pdf_render_jobs — nothing is held only in memory.
+   */
+  async enqueuePeriod(
+    periodId: string,
+    investorIds: string[],
+  ): Promise<{ batch: PdfRenderBatchRow; inserted: number }> {
+    const result = await this.jobRepo.enqueueBatch(periodId, investorIds);
+    this.metrics.incrementCounter(
+      METRIC_PDF_JOBS_ENQUEUED,
+      { period: periodId.slice(0, 16) },
+      result.inserted,
+      'Investor statement PDF jobs enqueued',
+    );
+    this.metrics.setGauge(
+      METRIC_PDF_BACKLOG,
+      result.inserted,
+      { batch: shortLabel(result.batch.id) },
+      'Pending+processing statement PDF jobs',
+    );
+    return result;
+  }
+
+  /** Single claim/render cycle. Returns jobs processed. */
+  async drainOnce(): Promise<number> {
+    const jobs = await this.jobRepo.claimJobs(this.batchSize, this.staleAfterMs);
+    if (jobs.length === 0) {
+      await this.refreshThroughput(0);
+      return 0;
+    }
+
+    await mapPool(jobs, this.concurrency, (job) => this.processJob(job));
+    await this.refreshThroughput(jobs.length);
+
+    const backlog = await this.jobRepo.countPending();
+    this.metrics.setGauge(METRIC_PDF_BACKLOG, backlog, { batch: 'all' });
+
+    return jobs.length;
+  }
+
+  private scheduleNext(): void {
+    if (!this.running) return;
+    this.timer = setTimeout(async () => {
+      try {
+        await this.drainOnce();
+      } catch {
+        // row-level errors handled in processJob
+      }
+      this.scheduleNext();
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  private async processJob(job: PdfRenderJobRow): Promise<void> {
+    const started = Date.now();
+    try {
+      const result = await this.render(job);
+      await this.jobRepo.markCompleted(job.id, result.storageKey, result.checksum);
+      this.metrics.incrementCounter(METRIC_PDF_JOBS_COMPLETED, {
+        period: job.period_id.slice(0, 16),
+      });
+      this.metrics.recordHistogram(
+        METRIC_PDF_RENDER_DURATION,
+        Date.now() - started,
+        { status: 'ok' },
+      );
+      this.completedWindow.push({ at: Date.now() });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'render failed';
+      this.metrics.recordHistogram(
+        METRIC_PDF_RENDER_DURATION,
+        Date.now() - started,
+        { status: 'error' },
+      );
+
+      if (job.attempts >= this.maxAttempts) {
+        await this.jobRepo.markFailed(job.id, message);
+        this.metrics.incrementCounter(METRIC_PDF_JOBS_FAILED, {
+          period: job.period_id.slice(0, 16),
+        });
+      } else {
+        const delayMs = this.retryBaseMs * Math.pow(2, Math.max(0, job.attempts - 1));
+        const retryAfter = new Date(Date.now() + delayMs);
+        await this.jobRepo.markFailed(job.id, message, retryAfter);
+      }
+    }
+  }
+
+  /** Sliding 60s throughput gauge (jobs completed / second). */
+  private async refreshThroughput(justProcessed: number): Promise<void> {
+    const now = Date.now();
+    this.completedWindow = this.completedWindow.filter((e) => now - e.at <= 60_000);
+    const rate = this.completedWindow.length / 60;
+    this.metrics.setGauge(
+      METRIC_PDF_THROUGHPUT,
+      Number(rate.toFixed(4)),
+      { window: '60s' },
+      'Investor statement PDF render throughput',
+    );
+    void justProcessed;
+  }
+}
+
+export function createStatementPdfBatchWorker(
+  jobRepo: PdfRenderJobRepository,
+  render: StatementRenderFn,
+  metrics: MetricsCollector,
+  options?: StatementPdfBatchWorkerOptions,
+): StatementPdfBatchWorker {
+  return new StatementPdfBatchWorker(jobRepo, render, metrics, options);
+}

--- a/src/services/statementPdfService.ts
+++ b/src/services/statementPdfService.ts
@@ -1,0 +1,89 @@
+/**
+ * Investor statement PDF rendering (Issue #540).
+ *
+ * Production would stream bytes to object storage. Here we produce a
+ * deterministic buffer + checksum so resume/retry writes the same
+ * storage_key without creating duplicate artifacts.
+ */
+
+import { createHash } from 'crypto';
+import {
+  buildStatementStorageKey,
+  checksumPayload,
+  PdfRenderJobRow,
+} from '../db/repositories/pdfRenderJobRepository';
+
+export interface StatementPdfRenderResult {
+  storageKey: string;
+  checksum: string;
+  bytes: Buffer;
+}
+
+export interface StatementPdfStorage {
+  /** Upsert bytes at storageKey (overwrite is required for crash-safe resume). */
+  putObject(storageKey: string, bytes: Buffer): Promise<void>;
+  /** Optional read for verification / tests. */
+  getObject?(storageKey: string): Promise<Buffer | null>;
+}
+
+/** In-memory store used by unit tests and local runners. */
+export class InMemoryStatementPdfStorage implements StatementPdfStorage {
+  private readonly objects = new Map<string, Buffer>();
+
+  async putObject(storageKey: string, bytes: Buffer): Promise<void> {
+    this.objects.set(storageKey, Buffer.from(bytes));
+  }
+
+  async getObject(storageKey: string): Promise<Buffer | null> {
+    const value = this.objects.get(storageKey);
+    return value ? Buffer.from(value) : null;
+  }
+
+  clear(): void {
+    this.objects.clear();
+  }
+
+  size(): number {
+    return this.objects.size;
+  }
+}
+
+/**
+ * Build a stable PDF-ish payload for an investor statement.
+ * Content is keyed only by period + investor so retries never fork artifacts.
+ */
+export function renderStatementPdfBytes(job: PdfRenderJobRow): Buffer {
+  const body = [
+    '%PDF-1.4',
+    `% Revora investor statement`,
+    `% period=${job.period_id}`,
+    `% investor=${job.investor_id}`,
+    `% batch=${job.batch_id}`,
+    `1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj`,
+    `trailer<< /Root 1 0 R >>`,
+    `%%EOF`,
+  ].join('\n');
+  return Buffer.from(body, 'utf8');
+}
+
+export type StatementRenderFn = (job: PdfRenderJobRow) => Promise<StatementPdfRenderResult>;
+
+/**
+ * Default render + store pipeline. Overwrites the deterministic key so a
+ * mid-batch crash that reclaims the job cannot leave two objects behind.
+ */
+export function makeStatementRenderFn(storage: StatementPdfStorage): StatementRenderFn {
+  return async (job: PdfRenderJobRow): Promise<StatementPdfRenderResult> => {
+    const storageKey =
+      job.storage_key ?? buildStatementStorageKey(job.period_id, job.investor_id);
+    const bytes = renderStatementPdfBytes(job);
+    const checksum = checksumPayload(bytes);
+    await storage.putObject(storageKey, bytes);
+    // Defence in depth: checksum of stored bytes must match rendered bytes.
+    const verify = createHash('sha256').update(bytes).digest('hex');
+    if (verify !== checksum) {
+      throw new Error('statement PDF checksum mismatch');
+    }
+    return { storageKey, checksum, bytes };
+  };
+}


### PR DESCRIPTION
Add Postgres-checkpointed pdf_render_jobs with SKIP LOCKED workers, stale reclaim after crash, deterministic storage keys, and throughput metrics. Closes #540 