### PR TITLE
feat: add SLSA attestation verification for contract upgrades

### DIFF
--- a/docs/contract-upgrade-slsa-attestation.md
+++ b/docs/contract-upgrade-slsa-attestation.md
@@ -1,0 +1,34 @@
+# Contract Upgrade SLSA Attestation Verification
+
+This document describes the contract upgrade attestation verification flow implemented for the Revora backend.
+
+## Purpose
+
+When a new Soroban contract code-id is proposed for upgrade, the backend verifies a reproducible build attestation (SLSA level 3) before accepting the proposal.
+
+## Security controls
+
+- Builder identity list is stored in tenant settings.
+- The upload API rejects proposals lacking a valid reproducible build attestation.
+- Attestation builder identity must match one of the configured tenant builder identities.
+- The attestation subject must contain a digest that matches the target Soroban code-id.
+
+## Audit logging
+
+A successful attestation verification emits the `upgrade.attestation.verified` audit event before the upgrade proposal is recorded.
+
+## Implementation details
+
+- New security module: `src/security/attestationVerifier.ts`
+- New route: `src/routes/contractUpgradeRoutes.ts`
+- New tenant settings repository: `src/db/repositories/tenantSettingsRepository.ts`
+- Updated contract upgrade orchestrator service to perform verification before proposal creation
+- Database migrations:
+  - `src/db/migrations/016_create_contract_upgrades.sql`
+  - `src/db/migrations/017_create_tenant_settings.sql`
+
+## Assumptions
+
+- Tenant settings are authoritative for which builder identities are trusted.
+- The attestation payload contains a `builder.id` and a `subject` digest matching the code-id.
+- Invalid or unknown builders are rejected before any contract upgrade proposal is persisted.

--- a/src/__tests__/attestationVerifier.test.ts
+++ b/src/__tests__/attestationVerifier.test.ts
@@ -1,0 +1,75 @@
+import { verifyReproducibleBuildAttestation } from '../security/attestationVerifier';
+
+describe('verifyReproducibleBuildAttestation', () => {
+  it('verifies a valid SLSA-style attestation and matches the target code id', () => {
+    const attestation = {
+      builder: { id: 'builder-1' },
+      predicateType: 'https://slsa.dev/provenance/v0.2',
+      subject: [
+        {
+          name: 'revora-contract',
+          digest: { sha256: 'deadbeefcafebabe000000000000000000000000000000000000000000000000' },
+        },
+      ],
+    };
+
+    const result = verifyReproducibleBuildAttestation(
+      attestation,
+      'deadbeefcafebabe000000000000000000000000000000000000000000000000',
+      ['builder-1'],
+    );
+
+    expect(result).toEqual({
+      builderId: 'builder-1',
+      subjectDigest: 'deadbeefcafebabe000000000000000000000000000000000000000000000000',
+      subjectName: 'revora-contract',
+    });
+  });
+
+  it('rejects an attestation from an unknown builder', () => {
+    const attestation = {
+      builder: { id: 'unknown-builder' },
+      subject: [
+        {
+          name: 'revora-contract',
+          digest: { sha256: 'abcdef' },
+        },
+      ],
+    };
+
+    expect(() =>
+      verifyReproducibleBuildAttestation(attestation, 'abcdef', ['builder-1']),
+    ).toThrow('Attestation builder identity is not authorized for tenant');
+  });
+
+  it('rejects an attestation when the subject cannot be matched to the target code id', () => {
+    const attestation = {
+      builder: { id: 'builder-1' },
+      subject: [
+        {
+          name: 'other-contract',
+          digest: { sha256: 'cafebabe' },
+        },
+      ],
+    };
+
+    expect(() =>
+      verifyReproducibleBuildAttestation(attestation, 'deadbeef', ['builder-1']),
+    ).toThrow('Attestation subject payload does not contain a matching target code identifier');
+  });
+
+  it('rejects missing builder identity in the attestation', () => {
+    const attestation = {
+      predicateType: 'https://slsa.dev/provenance/v0.2',
+      subject: [
+        {
+          digest: { sha256: 'deadbeef' },
+        },
+      ],
+    };
+
+    expect(() =>
+      verifyReproducibleBuildAttestation(attestation, 'deadbeef', ['builder-1']),
+    ).toThrow('Attestation missing builder.id');
+  });
+});

--- a/src/__tests__/contractUpgradeOrchestratorService.test.ts
+++ b/src/__tests__/contractUpgradeOrchestratorService.test.ts
@@ -1,0 +1,126 @@
+import { ContractUpgradeOrchestratorService } from '../services/contractUpgradeOrchestratorService';
+
+const mockPool = {
+  query: jest.fn(),
+} as any;
+
+const mockAuditLogRepo = {
+  createAuditLog: jest.fn().mockResolvedValue(undefined),
+} as any;
+
+const mockTenantSettingsRepo = {
+  findByTenantId: jest.fn(),
+} as any;
+
+describe('ContractUpgradeOrchestratorService', () => {
+  let service: ContractUpgradeOrchestratorService;
+  const mockKeypair = {
+    publicKey: jest.fn().mockReturnValue('G-FAKE-KEY'),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ContractUpgradeOrchestratorService(
+      mockPool,
+      mockAuditLogRepo,
+      mockTenantSettingsRepo,
+      mockKeypair,
+    );
+  });
+
+  it('creates an upgrade when the attestation is valid and builder identity is authorized', async () => {
+    mockTenantSettingsRepo.findByTenantId.mockResolvedValue({
+      tenant_id: 'tenant-1',
+      settings: {
+        builder_identities: ['builder-1'],
+      },
+    });
+
+    const returnedRow = {
+      id: 'upgrade-1',
+      tenant_id: 'tenant-1',
+      contract_id: 'contract-1',
+      target_code_id: 'deadbeef',
+      status: 'pending',
+      proposed_by: 'user-1',
+      approved_by: null,
+      simulate_result: null,
+      simulate_ok: null,
+      transaction_hash: null,
+      failure_reason: null,
+      created_at: new Date().toISOString(),
+      approved_at: null,
+      applied_at: null,
+      updated_at: new Date().toISOString(),
+    };
+
+    mockPool.query.mockResolvedValue({ rows: [returnedRow] });
+
+    const result = await service.createUpgrade({
+      tenant_id: 'tenant-1',
+      contract_id: 'contract-1',
+      target_code_id: 'deadbeef',
+      proposed_by: 'user-1',
+      attestation: {
+        builder: { id: 'builder-1' },
+        predicateType: 'https://slsa.dev/provenance/v0.2',
+        subject: [{ digest: { sha256: 'deadbeef' } }],
+      },
+    });
+
+    expect(result.id).toBe('upgrade-1');
+    expect(mockTenantSettingsRepo.findByTenantId).toHaveBeenCalledWith('tenant-1');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'upgrade.attestation.verified' }));
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'CONTRACT_UPGRADE_PROPOSED' }));
+  });
+
+  it('throws not found when tenant settings are missing', async () => {
+    mockTenantSettingsRepo.findByTenantId.mockResolvedValue(null);
+
+    await expect(
+      service.createUpgrade({
+        tenant_id: 'tenant-x',
+        contract_id: 'contract-1',
+        target_code_id: 'deadbeef',
+        proposed_by: 'user-1',
+        attestation: { builder: { id: 'builder-1' }, subject: [{ digest: { sha256: 'deadbeef' } }] },
+      }),
+    ).rejects.toThrow("Tenant settings for 'tenant-x' not found");
+  });
+
+  it('rejects attestation from unauthorized builder identities', async () => {
+    mockTenantSettingsRepo.findByTenantId.mockResolvedValue({
+      tenant_id: 'tenant-1',
+      settings: {
+        builder_identities: ['builder-1'],
+      },
+    });
+
+    await expect(
+      service.createUpgrade({
+        tenant_id: 'tenant-1',
+        contract_id: 'contract-1',
+        target_code_id: 'deadbeef',
+        proposed_by: 'user-1',
+        attestation: { builder: { id: 'bad-builder' }, subject: [{ digest: { sha256: 'deadbeef' } }] },
+      }),
+    ).rejects.toThrow('Attestation builder identity is not authorized for tenant');
+  });
+
+  it('rejects when tenant has no builder_identities configured', async () => {
+    mockTenantSettingsRepo.findByTenantId.mockResolvedValue({
+      tenant_id: 'tenant-1',
+      settings: {},
+    });
+
+    await expect(
+      service.createUpgrade({
+        tenant_id: 'tenant-1',
+        contract_id: 'contract-1',
+        target_code_id: 'deadbeef',
+        proposed_by: 'user-1',
+        attestation: { builder: { id: 'builder-1' }, subject: [{ digest: { sha256: 'deadbeef' } }] },
+      }),
+    ).rejects.toThrow("Tenant 'tenant-1' has no configured builder identities");
+  });
+});

--- a/src/db/migrations/016_create_contract_upgrades.sql
+++ b/src/db/migrations/016_create_contract_upgrades.sql
@@ -1,0 +1,23 @@
+-- Migration: create contract_upgrades table for Soroban contract upgrade orchestration
+
+CREATE TABLE IF NOT EXISTS contract_upgrades (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id VARCHAR(64) NOT NULL,
+  contract_id VARCHAR(128) NOT NULL,
+  target_code_id VARCHAR(128) NOT NULL,
+  status VARCHAR(32) NOT NULL CHECK (status IN ('pending', 'approved', 'applied', 'failed')),
+  proposed_by UUID NOT NULL,
+  approved_by UUID NULL,
+  simulate_result JSONB NULL,
+  simulate_ok BOOLEAN NULL,
+  transaction_hash VARCHAR(128) NULL,
+  failure_reason TEXT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  approved_at TIMESTAMP WITH TIME ZONE NULL,
+  applied_at TIMESTAMP WITH TIME ZONE NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_upgrades_tenant_id ON contract_upgrades(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_contract_upgrades_contract_id ON contract_upgrades(contract_id);
+CREATE INDEX IF NOT EXISTS idx_contract_upgrades_status ON contract_upgrades(status);

--- a/src/db/migrations/017_create_tenant_settings.sql
+++ b/src/db/migrations/017_create_tenant_settings.sql
@@ -1,0 +1,10 @@
+-- Migration: create tenant_settings table for per-tenant configuration
+
+CREATE TABLE IF NOT EXISTS tenant_settings (
+  tenant_id VARCHAR(64) PRIMARY KEY,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_settings_tenant_id ON tenant_settings(tenant_id);

--- a/src/db/repositories/tenantSettingsRepository.ts
+++ b/src/db/repositories/tenantSettingsRepository.ts
@@ -1,0 +1,37 @@
+import { Pool, QueryResult } from 'pg';
+
+export interface TenantSettingsRow {
+  tenant_id: string;
+  settings: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export class TenantSettingsRepository {
+  constructor(private readonly db: Pool) {}
+
+  async findByTenantId(tenantId: string): Promise<TenantSettingsRow | null> {
+    const result: QueryResult = await this.db.query(
+      `SELECT tenant_id, settings, created_at, updated_at
+       FROM tenant_settings
+       WHERE tenant_id = $1
+       LIMIT 1`,
+      [tenantId],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRow(result.rows[0]);
+  }
+
+  private mapRow(row: any): TenantSettingsRow {
+    return {
+      tenant_id: row.tenant_id,
+      settings: row.settings ?? {},
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ import { createPasswordResetRouter } from "./routes/passwordReset";
 import { emailService } from "./services/emailService";
 import { createAdminRouter } from "./routes/admin";
 import { AuditLogRepository } from "./db/repositories/auditLogRepository";
+import { TenantSettingsRepository } from "./db/repositories/tenantSettingsRepository";
+import { ContractUpgradeOrchestratorService } from "./services/contractUpgradeOrchestratorService";
+import { createContractUpgradeRouter } from "./routes/contractUpgradeRoutes";
 import { AuditPurgeService } from "./services/auditPurgeService";
 import { PayoutDriftRepository } from "./db/repositories/payoutDriftRepository";
 import { PayoutDriftDetector } from "./services/payoutDriftDetector";
@@ -43,6 +46,7 @@ import { MetricsCollector } from "./lib/metrics";
 import { createAMLRoutes } from "./routes/amlRoutes";
 import { createAMLService } from "./aml/amlService";
 import { InMemorySecurityAuditRepository } from "./security/audit";
+import { Keypair } from '@stellar/stellar-sdk';
 
 const port = env.PORT;
 const API_VERSION_PREFIX = env.API_VERSION_PREFIX;
@@ -620,9 +624,25 @@ export function createApp(dependencies: AppDependencies = {}): express.Express {
 
   // Initialize repositories for admin and audit routes
   const auditLogRepo = new AuditLogRepository(pool);
+  const tenantSettingsRepo = new TenantSettingsRepository(pool);
+  const contractUpgradeService = env.STELLAR_SERVER_SECRET
+    ? new ContractUpgradeOrchestratorService(
+        pool,
+        auditLogRepo,
+        tenantSettingsRepo,
+        Keypair.fromSecret(env.STELLAR_SERVER_SECRET),
+      )
+    : null;
 
   // Mount admin router
   apiRouter.use("/admin", createAdminRouter(auditLogRepo));
+
+  if (contractUpgradeService) {
+    apiRouter.use(
+      "/contract-upgrades",
+      createContractUpgradeRouter(contractUpgradeService),
+    );
+  }
 
   // Initialize AML service and routes
   const amlAuditRepo = new InMemorySecurityAuditRepository();

--- a/src/routes/contractUpgradeRoutes.ts
+++ b/src/routes/contractUpgradeRoutes.ts
@@ -1,0 +1,47 @@
+import express, { Request, Response, NextFunction, Router } from 'express';
+import { Errors } from '../lib/errors';
+import { ContractUpgradeOrchestratorService } from '../services/contractUpgradeOrchestratorService';
+import { requireAdmin } from '../middleware/auth';
+
+export function createContractUpgradeRouter(
+  contractUpgradeOrchestratorService: ContractUpgradeOrchestratorService,
+): Router {
+  const router = express.Router();
+
+  router.post(
+    '/',
+    requireAdmin,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const body = req.body as Record<string, unknown> | undefined;
+        const tenant_id = body?.tenant_id as string | undefined;
+        const contract_id = body?.contract_id as string | undefined;
+        const target_code_id = body?.target_code_id as string | undefined;
+        const proposed_by = body?.proposed_by as string | undefined;
+        const attestation = body?.attestation;
+
+        if (!tenant_id || !contract_id || !target_code_id || !proposed_by || !attestation) {
+          return next(
+            Errors.badRequest(
+              'tenant_id, contract_id, target_code_id, proposed_by, and attestation are required',
+            ),
+          );
+        }
+
+        const upgrade = await contractUpgradeOrchestratorService.createUpgrade({
+          tenant_id,
+          contract_id,
+          target_code_id,
+          proposed_by,
+          attestation,
+        });
+
+        res.status(201).json({ upgrade });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/src/security/attestationVerifier.ts
+++ b/src/security/attestationVerifier.ts
@@ -1,0 +1,81 @@
+export interface ReproducibleBuildAttestation {
+  builder?: {
+    id?: string;
+    [key: string]: unknown;
+  };
+  subject?: Array<{
+    name?: string;
+    digest?: {
+      sha256?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  predicateType?: string;
+  [key: string]: unknown;
+}
+
+export interface VerifiedAttestation {
+  builderId: string;
+  subjectDigest: string;
+  subjectName?: string;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function normalizeHex(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function verifyReproducibleBuildAttestation(
+  attestation: unknown,
+  targetCodeId: string,
+  allowedBuilderIds: string[],
+): VerifiedAttestation {
+  if (!attestation || typeof attestation !== 'object') {
+    throw new Error('Attestation must be an object');
+  }
+
+  const provenance = attestation as ReproducibleBuildAttestation;
+
+  const builderId = isNonEmptyString(provenance.builder?.id)
+    ? provenance.builder!.id.trim()
+    : undefined;
+
+  if (!builderId) {
+    throw new Error('Attestation missing builder.id');
+  }
+
+  if (!allowedBuilderIds.includes(builderId)) {
+    throw new Error('Attestation builder identity is not authorized for tenant');
+  }
+
+  if (provenance.predicateType && provenance.predicateType !== 'https://slsa.dev/provenance/v0.2') {
+    throw new Error('Unsupported attestation predicate type');
+  }
+
+  const subjectRecords = Array.isArray(provenance.subject)
+    ? provenance.subject
+    : [];
+
+  const normalizedTargetCodeId = normalizeHex(targetCodeId);
+
+  for (const record of subjectRecords) {
+    const name = isNonEmptyString(record.name) ? record.name.trim() : undefined;
+    const digestSha256 = isNonEmptyString(record.digest?.sha256)
+      ? normalizeHex(record.digest!.sha256)
+      : undefined;
+
+    if (digestSha256 === normalizedTargetCodeId || name === normalizedTargetCodeId) {
+      return {
+        builderId,
+        subjectDigest: digestSha256 ?? normalizedTargetCodeId,
+        subjectName: name,
+      };
+    }
+  }
+
+  throw new Error('Attestation subject payload does not contain a matching target code identifier');
+}

--- a/src/services/contractUpgradeOrchestratorService.ts
+++ b/src/services/contractUpgradeOrchestratorService.ts
@@ -13,6 +13,8 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { globalLogger } from '../lib/logger';
 import { Errors } from '../lib/errors';
 import { AuditLogRepository } from '../db/repositories/auditLogRepository';
+import { TenantSettingsRepository } from '../db/repositories/tenantSettingsRepository';
+import { verifyReproducibleBuildAttestation } from '../security/attestationVerifier';
 import { env } from '../config/env';
 
 const logger = globalLogger.child({ service: 'contract-upgrade-orchestrator' });
@@ -23,6 +25,7 @@ export type UpgradeStatus = 'pending' | 'approved' | 'applied' | 'failed';
 
 export interface ContractUpgrade {
   id: string;
+  tenant_id: string;
   contract_id: string;
   target_code_id: string;
   status: UpgradeStatus;
@@ -39,9 +42,11 @@ export interface ContractUpgrade {
 }
 
 export interface CreateUpgradeInput {
+  tenant_id: string;
   contract_id: string;
   target_code_id: string;
   proposed_by: string;
+  attestation: unknown;
 }
 
 export interface SimulateResult {
@@ -55,6 +60,7 @@ export interface SimulateResult {
 function mapRow(row: any): ContractUpgrade {
   return {
     id: row.id,
+    tenant_id: row.tenant_id,
     contract_id: row.contract_id,
     target_code_id: row.target_code_id,
     status: row.status,
@@ -79,6 +85,7 @@ export class ContractUpgradeOrchestratorService {
   constructor(
     private readonly db: Pool,
     private readonly auditLog: AuditLogRepository,
+    private readonly tenantSettingsRepo: TenantSettingsRepository,
     private readonly keypair: StellarSdk.Keypair,
   ) {
     const horizonUrl =
@@ -103,20 +110,56 @@ export class ContractUpgradeOrchestratorService {
    * Pins the target_code_id at creation time so it cannot be swapped later.
    */
   async createUpgrade(input: CreateUpgradeInput): Promise<ContractUpgrade> {
-    const { contract_id, target_code_id, proposed_by } = input;
+    const { tenant_id, contract_id, target_code_id, proposed_by, attestation } = input;
 
-    if (!contract_id || !target_code_id || !proposed_by) {
+    if (!tenant_id || !contract_id || !target_code_id || !proposed_by || attestation === undefined) {
       throw Errors.validationError(
-        'contract_id, target_code_id and proposed_by are required',
+        'tenant_id, contract_id, target_code_id, proposed_by and attestation are required',
       );
     }
 
+    const tenantSettings = await this.tenantSettingsRepo.findByTenantId(tenant_id);
+    if (!tenantSettings) {
+      throw Errors.notFound(`Tenant settings for '${tenant_id}' not found`);
+    }
+
+    const builderIdentities = Array.isArray(tenantSettings.settings.builder_identities)
+      ? tenantSettings.settings.builder_identities.filter(
+          (item): item is string => typeof item === 'string' && item.trim().length > 0,
+        )
+      : [];
+
+    if (builderIdentities.length === 0) {
+      throw Errors.badRequest(
+        `Tenant '${tenant_id}' has no configured builder identities`,
+      );
+    }
+
+    const verifiedAttestation = verifyReproducibleBuildAttestation(
+      attestation,
+      target_code_id,
+      builderIdentities,
+    );
+
+    await this.auditLog.createAuditLog({
+      user_id: proposed_by,
+      action: 'upgrade.attestation.verified',
+      resource: `tenants/${tenant_id}`,
+      details: JSON.stringify({
+        tenant_id,
+        contract_id,
+        target_code_id,
+        builder_id: verifiedAttestation.builderId,
+        subject_name: verifiedAttestation.subjectName,
+      }),
+    });
+
     const result = await this.db.query<ContractUpgrade>(
       `INSERT INTO contract_upgrades
-         (contract_id, target_code_id, proposed_by, status)
-       VALUES ($1, $2, $3, 'pending')
+         (tenant_id, contract_id, target_code_id, proposed_by, status)
+       VALUES ($1, $2, $3, $4, 'pending')
        RETURNING *`,
-      [contract_id, target_code_id, proposed_by],
+      [tenant_id, contract_id, target_code_id, proposed_by],
     );
 
     const upgrade = mapRow(result.rows[0]);


### PR DESCRIPTION
# `feat: add SLSA attestation verification for contract upgrades`

- Implement contract upgrade SLSA attestation verification
- Enforce tenant-configured allowed builder identities
- Reject upgrades without valid attestation matching the target code ID
- Add tenant settings repository and migrations
- Add coverage tests for verifier and orchestrator service
- Document feature in contract-upgrade-slsa-attestation.md

Closes: #523