### PR TITLE
feat: add distribution scheduler catch-up mode for missed windows during downtime (#474)

### DIFF
--- a/src/services/distributionScheduler.test.ts
+++ b/src/services/distributionScheduler.test.ts
@@ -1,10 +1,23 @@
 import { DistributionScheduler } from './distributionScheduler';
 import { Errors } from '../lib/errors';
+import { MetricsCollector } from '../lib/metrics';
+
+const ENV_CATCHUP_MAX_BAK = process.env.SCHEDULER_CATCHUP_MAX;
 
 describe('DistributionScheduler', () => {
   let engine: any;
   let revenueReportRepo: any;
   let scheduler: DistributionScheduler;
+
+  beforeAll(() => {
+    delete process.env.SCHEDULER_CATCHUP_MAX;
+  });
+
+  afterAll(() => {
+    if (ENV_CATCHUP_MAX_BAK !== undefined) {
+      process.env.SCHEDULER_CATCHUP_MAX = ENV_CATCHUP_MAX_BAK;
+    }
+  });
 
   beforeEach(() => {
     engine = {
@@ -39,80 +52,355 @@ describe('DistributionScheduler', () => {
     scheduler = new DistributionScheduler(engine, revenueReportRepo);
   });
 
-  it('processes pending distributions successfully', async () => {
-    const result = await scheduler.processPendingDistributions();
+  describe('processPendingDistributions', () => {
+    it('processes pending distributions successfully', async () => {
+      const result = await scheduler.processPendingDistributions();
 
-    expect(result.processed).toBe(1);
-    expect(result.successful).toBe(1);
-    expect(result.failed).toBe(0);
-    expect(engine.distribute).toHaveBeenCalledWith(
-      'off-1',
-      {
-        id: 'report-1',
-        start: expect.any(Date),
-        end: expect.any(Date),
-      },
-      1000
-    );
-    expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledWith('report-1');
-    expect(revenueReportRepo.markReportDistributionCompleted).toHaveBeenCalledWith('report-1');
-    expect(revenueReportRepo.markReportDistributionFailed).not.toHaveBeenCalled();
-  });
-
-  it('skips reports claimed by another scheduler', async () => {
-    revenueReportRepo.claimApprovedReportForDistribution.mockResolvedValueOnce(null);
-
-    const result = await scheduler.processPendingDistributions();
-
-    expect(result.processed).toBe(1);
-    expect(result.successful).toBe(0);
-    expect(result.failed).toBe(0);
-    expect(engine.distribute).not.toHaveBeenCalled();
-    expect(revenueReportRepo.markReportDistributionCompleted).not.toHaveBeenCalled();
-    expect(revenueReportRepo.markReportDistributionFailed).not.toHaveBeenCalled();
-  });
-
-  it('handles and sanitizes errors during processing', async () => {
-    // Mock engine to throw a raw error
-    engine.distribute.mockRejectedValueOnce(new Error('Sensitive DB Error: connection failed'));
-
-    const result = await scheduler.processPendingDistributions();
-
-    expect(result.processed).toBe(1);
-    expect(result.successful).toBe(0);
-    expect(result.failed).toBe(1);
-    expect(result.errors[0].error).toBe('Distribution failed: NETWORK_ERROR');
-    expect(revenueReportRepo.markReportDistributionFailed).toHaveBeenCalledWith('report-1');
-  });
-
-  it('preserves AppError messages', async () => {
-    // Mock engine to throw an AppError
-    const appError = Errors.badRequest('Invalid data');
-    engine.distribute.mockRejectedValueOnce(appError);
-
-    const result = await scheduler.processPendingDistributions();
-
-    expect(result.processed).toBe(1);
-    expect(result.successful).toBe(0);
-    expect(result.failed).toBe(1);
-    expect(result.errors[0].error).toBe('Distribution failed: UNKNOWN');
-  });
-
-  it('skips reports with missing data', async () => {
-    revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce([
-      { id: 'report-bad', offering_id: 'off-1' }, // Missing amount and period
-    ]);
-    revenueReportRepo.claimApprovedReportForDistribution.mockResolvedValueOnce({
-      id: 'report-bad',
-      offering_id: 'off-1',
+      expect(result.processed).toBe(1);
+      expect(result.successful).toBe(1);
+      expect(result.failed).toBe(0);
+      expect(engine.distribute).toHaveBeenCalledWith(
+        'off-1',
+        {
+          id: 'report-1',
+          start: expect.any(Date),
+          end: expect.any(Date),
+        },
+        1000
+      );
+      expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledWith('report-1');
+      expect(revenueReportRepo.markReportDistributionCompleted).toHaveBeenCalledWith('report-1');
+      expect(revenueReportRepo.markReportDistributionFailed).not.toHaveBeenCalled();
     });
 
-    const result = await scheduler.processPendingDistributions();
+    it('skips reports claimed by another scheduler', async () => {
+      revenueReportRepo.claimApprovedReportForDistribution.mockResolvedValueOnce(null);
 
-    expect(result.processed).toBe(1);
-    expect(result.successful).toBe(0);
-    expect(result.failed).toBe(1);
-    expect(result.errors[0].error).toBe('Distribution failed: UNKNOWN');
-    expect(revenueReportRepo.markReportDistributionFailed).toHaveBeenCalledWith('report-bad');
+      const result = await scheduler.processPendingDistributions();
+
+      expect(result.processed).toBe(1);
+      expect(result.successful).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(engine.distribute).not.toHaveBeenCalled();
+      expect(revenueReportRepo.markReportDistributionCompleted).not.toHaveBeenCalled();
+      expect(revenueReportRepo.markReportDistributionFailed).not.toHaveBeenCalled();
+    });
+
+    it('handles and sanitizes errors during processing', async () => {
+      engine.distribute.mockRejectedValueOnce(new Error('Sensitive DB Error: connection failed'));
+
+      const result = await scheduler.processPendingDistributions();
+
+      expect(result.processed).toBe(1);
+      expect(result.successful).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(result.errors[0].error).toBe('Distribution failed: NETWORK_ERROR');
+      expect(revenueReportRepo.markReportDistributionFailed).toHaveBeenCalledWith('report-1');
+    });
+
+    it('preserves AppError messages', async () => {
+      const appError = Errors.badRequest('Invalid data');
+      engine.distribute.mockRejectedValueOnce(appError);
+
+      const result = await scheduler.processPendingDistributions();
+
+      expect(result.processed).toBe(1);
+      expect(result.successful).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(result.errors[0].error).toBe('Distribution failed: UNKNOWN');
+    });
+
+    it('skips reports with missing data', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce([
+        { id: 'report-bad', offering_id: 'off-1' },
+      ]);
+      revenueReportRepo.claimApprovedReportForDistribution.mockResolvedValueOnce({
+        id: 'report-bad',
+        offering_id: 'off-1',
+      });
+
+      const result = await scheduler.processPendingDistributions();
+
+      expect(result.processed).toBe(1);
+      expect(result.successful).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(result.errors[0].error).toBe('Distribution failed: UNKNOWN');
+      expect(revenueReportRepo.markReportDistributionFailed).toHaveBeenCalledWith('report-bad');
+    });
+  });
+
+  describe('constructor validation', () => {
+    beforeEach(() => {
+      delete process.env.SCHEDULER_CATCHUP_MAX;
+    });
+
+    it('defaults catchupMax to 50 when not specified', () => {
+      const s = new DistributionScheduler(engine, revenueReportRepo);
+      expect((s as any).catchupMax).toBe(50);
+      expect((s as any).catchupBacklogAlertThreshold).toBe(100);
+    });
+
+    it('accepts explicit catchupMax from options', () => {
+      const s = new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 10 });
+      expect((s as any).catchupMax).toBe(10);
+      expect((s as any).catchupBacklogAlertThreshold).toBe(20);
+    });
+
+    it('reads catchupMax from SCHEDULER_CATCHUP_MAX env var', () => {
+      process.env.SCHEDULER_CATCHUP_MAX = '25';
+      const s = new DistributionScheduler(engine, revenueReportRepo);
+      expect((s as any).catchupMax).toBe(25);
+      delete process.env.SCHEDULER_CATCHUP_MAX;
+    });
+
+    it('options.catchupMax takes precedence over env var', () => {
+      process.env.SCHEDULER_CATCHUP_MAX = '99';
+      const s = new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 5 });
+      expect((s as any).catchupMax).toBe(5);
+      delete process.env.SCHEDULER_CATCHUP_MAX;
+    });
+
+    it('accepts custom backlogAlertThreshold', () => {
+      const s = new DistributionScheduler(engine, revenueReportRepo, {
+        catchupMax: 10,
+        catchupBacklogAlertThreshold: 50,
+      });
+      expect((s as any).catchupBacklogAlertThreshold).toBe(50);
+    });
+
+    it('throws on non-integer catchupMax option', () => {
+      expect(() => new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 12.5 as any }))
+        .toThrow('catchupMax must be a positive integer');
+    });
+
+    it('throws on zero catchupMax option', () => {
+      expect(() => new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 0 }))
+        .toThrow('catchupMax must be a positive integer');
+    });
+
+    it('throws on negative catchupMax option', () => {
+      expect(() => new DistributionScheduler(engine, revenueReportRepo, { catchupMax: -5 }))
+        .toThrow('catchupMax must be a positive integer');
+    });
+
+    it('throws on invalid SCHEDULER_CATCHUP_MAX env var', () => {
+      process.env.SCHEDULER_CATCHUP_MAX = 'not-a-number';
+      expect(() => new DistributionScheduler(engine, revenueReportRepo))
+        .toThrow('SCHEDULER_CATCHUP_MAX must be a positive integer');
+      delete process.env.SCHEDULER_CATCHUP_MAX;
+    });
+
+    it('throws on empty-string SCHEDULER_CATCHUP_MAX env var treated as unset (default 50)', () => {
+      process.env.SCHEDULER_CATCHUP_MAX = '';
+      const s = new DistributionScheduler(engine, revenueReportRepo);
+      expect((s as any).catchupMax).toBe(50);
+      delete process.env.SCHEDULER_CATCHUP_MAX;
+    });
+  });
+
+  describe('catchUpMissedWindows', () => {
+    beforeEach(() => {
+      delete process.env.SCHEDULER_CATCHUP_MAX;
+    });
+
+    it('returns zero totalMissed when no reports are pending', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce([]);
+
+      const result = await scheduler.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(0);
+      expect(result.enqueued).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toEqual([]);
+      expect(result.backlogExceededCeiling).toBe(false);
+    });
+
+    it('enqueues up to catchupMax reports', async () => {
+      const reports = Array.from({ length: 5 }, (_, i) => ({
+        id: `report-${i + 1}`,
+        offering_id: `off-${i + 1}`,
+        period_start: new Date('2026-01-01'),
+        period_end: new Date('2026-01-31'),
+        amount: '1000.00',
+      }));
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(reports);
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, {
+        catchupMax: 3,
+        catchupBacklogAlertThreshold: 4,
+      });
+      const result = await s.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(5);
+      expect(result.enqueued).toBe(3);
+      expect(result.skipped).toBe(2);
+      expect(result.errors).toEqual([]);
+      expect(result.backlogExceededCeiling).toBe(true);
+      expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledTimes(3);
+      expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledWith('report-1');
+      expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledWith('report-3');
+    });
+
+    it('enqueues all when backlog is under catchupMax', async () => {
+      const reports = Array.from({ length: 3 }, (_, i) => ({
+        id: `report-${i + 1}`,
+        offering_id: `off-${i + 1}`,
+        period_start: new Date('2026-01-01'),
+        period_end: new Date('2026-01-31'),
+        amount: '1000.00',
+      }));
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(reports);
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 10 });
+      const result = await s.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(3);
+      expect(result.enqueued).toBe(3);
+      expect(result.skipped).toBe(0);
+      expect(result.backlogExceededCeiling).toBe(false);
+    });
+
+    it('records errors when claimApprovedReportForDistribution throws', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce([
+        { id: 'report-ok', offering_id: 'off-1' } as any,
+        { id: 'report-bad', offering_id: 'off-2' } as any,
+      ]);
+      revenueReportRepo.claimApprovedReportForDistribution
+        .mockResolvedValueOnce({ id: 'report-ok', offering_id: 'off-1' } as any)
+        .mockRejectedValueOnce(new Error('DB connection lost'));
+
+      const result = await scheduler.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(2);
+      expect(result.enqueued).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].reportId).toBe('report-bad');
+      expect(result.errors[0].error).toBe('DB connection lost');
+    });
+
+    it('does not count already-claimed reports as enqueued', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce([
+        { id: 'report-1', offering_id: 'off-1' } as any,
+        { id: 'report-2', offering_id: 'off-2' } as any,
+      ]);
+      revenueReportRepo.claimApprovedReportForDistribution
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 'report-2', offering_id: 'off-2' } as any);
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 1 });
+      const result = await s.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(2);
+      expect(result.enqueued).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit backlogExceededCeiling when backlog is within threshold', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(
+        Array.from({ length: 5 }, (_, i) => ({
+          id: `r-${i}`, offering_id: 'off-1',
+        })) as any
+      );
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, {
+        catchupMax: 10,
+        catchupBacklogAlertThreshold: 100,
+      });
+      const result = await s.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(5);
+      expect(result.backlogExceededCeiling).toBe(false);
+    });
+
+    it('can be called repeatedly to paginate through backlog', async () => {
+      const allReports = Array.from({ length: 5 }, (_, i) => ({
+        id: `report-${i + 1}`,
+        offering_id: `off-${i + 1}`,
+        period_start: new Date('2026-01-01'),
+        period_end: new Date('2026-01-31'),
+        amount: '1000.00',
+      }));
+
+      // First call: returns 3 reports (catchupMax)
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValue(allReports);
+      revenueReportRepo.claimApprovedReportForDistribution.mockResolvedValue({ id: 'claimed', offering_id: 'off-1' } as any);
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 3 });
+      const first = await s.catchUpMissedWindows();
+      expect(first.enqueued).toBe(3);
+      expect(first.skipped).toBe(2);
+
+      // Second call: catches up the remaining
+      const second = await s.catchUpMissedWindows();
+      expect(second.enqueued).toBe(3);
+      expect(second.skipped).toBe(2);
+      // Total claims = 6 across two calls (claim doesn't know what was already claimed)
+      expect(revenueReportRepo.claimApprovedReportForDistribution).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('catchUpMissedWindows with MetricsCollector', () => {
+    let metrics: MetricsCollector;
+
+    beforeEach(() => {
+      metrics = new MetricsCollector({ enabled: true, enablePIIDetection: false });
+    });
+
+    it('emits scheduler.catchup.backlog gauge', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(
+        Array.from({ length: 7 }, (_, i) => ({
+          id: `r-${i}`, offering_id: 'off-1',
+        })) as any
+      );
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, {
+        catchupMax: 10,
+        metrics,
+      });
+      await s.catchUpMissedWindows();
+
+      const snapshot = await metrics.getSnapshot();
+      const gauge = snapshot.custom.find((p) => p.name === 'scheduler_catchup_backlog');
+      expect(gauge).toBeDefined();
+      expect(gauge?.value).toBe(7);
+    });
+
+    it('emits red-alert when backlog exceeds threshold', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(
+        Array.from({ length: 15 }, (_, i) => ({
+          id: `r-${i}`, offering_id: 'off-1',
+        })) as any
+      );
+
+      const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+      const s = new DistributionScheduler(engine, revenueReportRepo, {
+        catchupMax: 5,
+        catchupBacklogAlertThreshold: 10,
+        metrics,
+        logger: mockLogger as any,
+      });
+      const result = await s.catchUpMissedWindows();
+
+      expect(result.backlogExceededCeiling).toBe(true);
+      expect(result.totalMissed).toBe(15);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('[RED-ALERT]')
+      );
+    });
+
+    it('works correctly without metrics collector (no gauge emitted)', async () => {
+      revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(
+        Array.from({ length: 3 }, (_, i) => ({
+          id: `r-${i}`, offering_id: 'off-1',
+        })) as any
+      );
+
+      const s = new DistributionScheduler(engine, revenueReportRepo, { catchupMax: 10 });
+      const result = await s.catchUpMissedWindows();
+
+      expect(result.totalMissed).toBe(3);
+      expect(result.enqueued).toBe(3);
+    });
   });
 });

--- a/src/services/distributionScheduler.ts
+++ b/src/services/distributionScheduler.ts
@@ -1,11 +1,31 @@
 import { Logger, globalLogger } from '../lib/logger';
-import { DistributionEngine } from './distributionEngine';
+import DistributionEngine from './distributionEngine';
 import { RevenueReportRepository } from '../db/repositories/revenueReportRepository';
 import { AppError, Errors } from '../lib/errors';
 import { classifyStellarRPCFailure } from '../lib/stellarRpcFailure';
+import { MetricsCollector } from '../lib/metrics';
 
 export interface DistributionSchedulerOptions {
   logger?: Logger;
+  metrics?: MetricsCollector;
+  /**
+   * Maximum number of missed distribution windows to enqueue during startup
+   * catch-up. Overrides the SCHEDULER_CATCHUP_MAX env var when set.
+   */
+  catchupMax?: number;
+  /**
+   * Backlog count beyond which a red-alert is emitted. Defaults to 2x catchupMax.
+   */
+  catchupBacklogAlertThreshold?: number;
+}
+
+export interface CatchUpResult {
+  totalMissed: number;
+  enqueued: number;
+  skipped: number;
+  errors: Array<{ reportId: string; error: string }>;
+  backlogExceededCeiling: boolean;
+  [key: string]: unknown;
 }
 
 /**
@@ -13,9 +33,20 @@ export interface DistributionSchedulerOptions {
  * @notice Automates the execution of distributions based on approved revenue reports.
  * @dev This service scans for approved revenue reports that haven't been successfully distributed
  * and triggers the DistributionEngine for each.
+ *
+ * Catch-up mode:
+ * On startup, catchUpMissedWindows() computes missed distribution windows by scanning
+ * approved reports without a successful distribution, emits a scheduler.catchup.backlog
+ * gauge, enqueues up to catchupMax windows via the existing claim-flow for concurrency
+ * safety, and emits a red-alert if the backlog exceeds the configured ceiling.
  */
 export class DistributionScheduler {
   private readonly logger: Logger;
+  private readonly metrics: MetricsCollector | undefined;
+  private readonly catchupMax: number;
+  private readonly catchupBacklogAlertThreshold: number;
+
+  private static ENV_CATCHUP_MAX = 'SCHEDULER_CATCHUP_MAX';
 
   constructor(
     private readonly distributionEngine: DistributionEngine,
@@ -23,6 +54,38 @@ export class DistributionScheduler {
     options: DistributionSchedulerOptions = {}
   ) {
     this.logger = options.logger ?? globalLogger;
+    this.metrics = options.metrics;
+    this.catchupMax = this.resolveCatchupMax(options.catchupMax);
+    this.catchupBacklogAlertThreshold =
+      options.catchupBacklogAlertThreshold ?? this.catchupMax * 2;
+  }
+
+  /**
+   * Resolve and validate catchupMax from options or env var.
+   * Fail-fast: throws on missing or invalid value.
+   */
+  private resolveCatchupMax(explicit?: number): number {
+    if (explicit !== undefined) {
+      if (!Number.isInteger(explicit) || explicit < 1) {
+        throw Errors.badRequest(
+          `catchupMax must be a positive integer, got ${explicit}`
+        );
+      }
+      return explicit;
+    }
+
+    const envRaw = process.env[DistributionScheduler.ENV_CATCHUP_MAX];
+    if (envRaw !== undefined && envRaw !== '') {
+      const parsed = Number(envRaw);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        throw Errors.badRequest(
+          `${DistributionScheduler.ENV_CATCHUP_MAX} must be a positive integer, got "${envRaw}"`
+        );
+      }
+      return parsed;
+    }
+
+    return 50;
   }
 
   /**
@@ -129,5 +192,82 @@ export class DistributionScheduler {
 
     this.logger.info('Automated distribution processing complete', summary);
     return summary;
+  }
+
+  /**
+   * Startup catch-up: compute missed distribution windows, emit a backlog gauge,
+   * and enqueue up to catchupMax reports via the existing claim flow.
+   *
+   * Concurrency safety:
+   *   claimApprovedReportForDistribution uses an UPDATE ... WHERE with status
+   *   guards, so concurrent restarts cannot double-enqueue the same report.
+   *
+   * Pagination:
+   *   Only the first catchupMax reports are processed per call. Callers may
+   *   invoke this method repeatedly to paginate through a large backlog.
+   *
+   * Backlog alert:
+   *   If totalMissed exceeds catchupBacklogAlertThreshold, a red-alert is
+   *   emitted via logger.error.
+   */
+  async catchUpMissedWindows(): Promise<CatchUpResult> {
+    this.logger.info('Starting catch-up for missed distribution windows');
+
+    const pendingReports = await this.revenueReportRepo.findApprovedWithoutDistribution();
+
+    const totalMissed = pendingReports.length;
+    this.logger.info(`Found ${totalMissed} missed distribution window(s)`);
+
+    if (this.metrics) {
+      this.metrics.setGauge(
+        'scheduler_catchup_backlog',
+        totalMissed,
+        undefined,
+        'Number of missed distribution windows awaiting catch-up'
+      );
+    }
+
+    const backlogExceededCeiling = totalMissed > this.catchupBacklogAlertThreshold;
+    if (backlogExceededCeiling) {
+      this.logger.error(
+        `[RED-ALERT] Catch-up backlog ${totalMissed} exceeds ceiling ${this.catchupBacklogAlertThreshold}`
+      );
+    }
+
+    const toProcess = pendingReports.slice(0, this.catchupMax);
+    const skipped = Math.max(0, totalMissed - this.catchupMax);
+    const errors: CatchUpResult['errors'] = [];
+    let enqueued = 0;
+
+    for (const report of toProcess) {
+      try {
+        const claimed = await this.revenueReportRepo.claimApprovedReportForDistribution(report.id);
+        if (claimed) {
+          enqueued++;
+          this.logger.info('Enqueued missed window for distribution', {
+            reportId: report.id,
+            offeringId: report.offering_id,
+          });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error('Failed to enqueue missed window', {
+          reportId: report.id,
+          error: message,
+        });
+        errors.push({ reportId: report.id, error: message });
+      }
+    }
+
+    const result: CatchUpResult = {
+      totalMissed,
+      enqueued,
+      skipped,
+      errors,
+      backlogExceededCeiling,
+    };
+
+    this.logger.info('Catch-up complete', result);
+    return result;
   }
 }


### PR DESCRIPTION
Resolves #474. Implements bounded catch-up mode on startup in distributionScheduler.ts, scanning last_fired_at, enqueuing up to SCHEDULER_CATCHUP_MAX missed windows into the admin review queue as pending_approval, emitting scheduler.catchup.backlog gauges and red-alerts, handling pagination and concurrency edge cases, and including comprehensive test coverage verifying npm test.