### PR TITLE
feat: OIDC JWKS staleness alarm + force-refresh endpoint (#498)

### DIFF
--- a/docs/oidc-jwks-staleness-alarm.md
+++ b/docs/oidc-jwks-staleness-alarm.md
@@ -1,0 +1,36 @@
+# OIDC JWKS Cache Staleness Alarm and Force Refresh
+
+## Purpose
+
+This document describes the implementation of a per-issuer OIDC JWKS cache age gauge and an admin-only endpoint to force refresh cached JWKS bundles.
+
+## Changes
+
+- `src/auth/oidc/jwksCache.ts`
+  - Added `JwksCacheService.refresh()` with in-flight request coalescing.
+  - Added per-issuer `issuerLastRefresh` tracking.
+  - Emit `oidc.jwks.age_seconds` gauge with label `issuer`.
+  - Added `getCacheAgeSeconds(issuer)` helper.
+
+- `src/auth/oidc/oidcAdapterService.ts`
+  - Forward issuer URL to JWKS cache lookups so cache age is tracked per issuer.
+  - Added `refreshJwks(issuerUrl)` for service-driven refreshes.
+
+- `src/auth/oidc/oidcRoute.ts`
+  - Added admin-only POST `/api/auth/oidc/jwks/refresh` endpoint.
+  - Requires dual confirmation: both header `x-revora-oidc-jwks-confirmation: true` and body `confirmation: true`.
+  - Enforces per-actor rate limiting (1 request per 60 seconds).
+  - Emits audit events via optional `auditRefresh` hook.
+
+## Security and correctness notes
+
+- The refresh endpoint is protected by `requireAdmin`.
+- Dual confirmation mitigates accidental refreshes and provides an explicit incident escalation step.
+- Rate limiting prevents repeated attacker/exhaustion attempts from a valid admin session.
+- Concurrent refresh requests for the same JWKS URI coalesce into a single upstream fetch.
+- Cache age metrics call out stale issuer state for monitoring and alerting.
+
+## Testing
+
+- `npx jest --runInBand src/auth/oidc/oidc.test.ts`
+- Verified 34 passing tests for both `JwksCacheService` and `createOidcRouter` refresh behavior.

--- a/src/auth/oidc/jwksCache.ts
+++ b/src/auth/oidc/jwksCache.ts
@@ -1,8 +1,18 @@
 import { createPublicKey, KeyObject } from 'crypto';
+import { globalMetrics } from '../../lib/metrics';
 
 interface JwksCacheEntry {
   keys: Map<string, KeyObject>;
   fetchedAt: number;
+  issuer?: string;
+}
+
+interface JwksCacheMetrics {
+  setGauge(name: string, value: number, labels?: Record<string, string>, help?: string): void;
+}
+
+interface JwksCacheServiceOptions {
+  metrics?: JwksCacheMetrics;
 }
 
 const JWKS_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -14,11 +24,18 @@ const JWKS_TTL_MS = 60 * 60 * 1000; // 1 hour
  */
 export class JwksCacheService {
   private readonly cache = new Map<string, JwksCacheEntry>();
+  private readonly issuerLastRefresh = new Map<string, number>();
+  private readonly inFlightRefreshes = new Map<string, Promise<JwksCacheEntry>>();
+  private readonly metrics: JwksCacheMetrics;
 
-  async getKey(jwksUri: string, kid: string): Promise<KeyObject> {
+  constructor(options: JwksCacheServiceOptions = {}) {
+    this.metrics = options.metrics ?? globalMetrics;
+  }
+
+  async getKey(jwksUri: string, kid: string, issuer?: string): Promise<KeyObject> {
     let entry = this.cache.get(jwksUri);
     if (!entry || Date.now() - entry.fetchedAt > JWKS_TTL_MS) {
-      entry = await this.fetchAndCache(jwksUri);
+      entry = await this.refresh(jwksUri, issuer ?? entry?.issuer);
     }
 
     const key = entry.keys.get(kid);
@@ -26,18 +43,49 @@ export class JwksCacheService {
 
     // kid missing — may be a provider rotation; evict and retry once
     this.cache.delete(jwksUri);
-    entry = await this.fetchAndCache(jwksUri);
+    entry = await this.refresh(jwksUri, issuer ?? entry?.issuer);
 
     const rotated = entry.keys.get(kid);
     if (!rotated) throw new Error(`Unknown kid="${kid}" at ${jwksUri} after rotation`);
     return rotated;
   }
 
+  getCacheAgeSeconds(issuer: string): number {
+    const lastRefresh = this.issuerLastRefresh.get(issuer);
+    if (!lastRefresh) return 0;
+    return Math.max(0, Math.floor((Date.now() - lastRefresh) / 1000));
+  }
+
+  async refresh(jwksUri: string, issuer?: string): Promise<JwksCacheEntry> {
+    const existing = this.inFlightRefreshes.get(jwksUri);
+    if (existing) return existing;
+
+    const pending = this.fetchAndCache(jwksUri, issuer)
+      .then((entry) => {
+        if (issuer) {
+          this.issuerLastRefresh.set(issuer, entry.fetchedAt);
+          this.metrics.setGauge(
+            'oidc.jwks.age_seconds',
+            this.getCacheAgeSeconds(issuer),
+            { issuer },
+            'Age in seconds of the cached JWKS bundle per issuer',
+          );
+        }
+        return entry;
+      })
+      .finally(() => {
+        this.inFlightRefreshes.delete(jwksUri);
+      });
+
+    this.inFlightRefreshes.set(jwksUri, pending);
+    return pending;
+  }
+
   evict(jwksUri: string): void {
     this.cache.delete(jwksUri);
   }
 
-  private async fetchAndCache(jwksUri: string): Promise<JwksCacheEntry> {
+  private async fetchAndCache(jwksUri: string, issuer?: string): Promise<JwksCacheEntry> {
     const res = await fetch(jwksUri);
     if (!res.ok) throw new Error(`JWKS fetch failed: ${res.status} ${res.statusText}`);
 
@@ -52,7 +100,7 @@ export class JwksCacheService {
       } catch { /* skip malformed entries */ }
     }
 
-    const entry: JwksCacheEntry = { keys: keyMap, fetchedAt: Date.now() };
+    const entry: JwksCacheEntry = { keys: keyMap, fetchedAt: Date.now(), issuer };
     this.cache.set(jwksUri, entry);
     return entry;
   }

--- a/src/auth/oidc/oidc.test.ts
+++ b/src/auth/oidc/oidc.test.ts
@@ -1,6 +1,9 @@
 import { createSign, generateKeyPairSync } from 'crypto';
+import express from 'express';
+import request from 'supertest';
 import { OidcAdapterService } from './oidcAdapterService';
 import { JwksCacheService } from './jwksCache';
+import { createOidcRouter } from './oidcRoute';
 import { ALLOWED_ID_TOKEN_ALGORITHMS, OidcProviderRow } from './types';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -264,6 +267,7 @@ describe('OidcAdapterService', () => {
 describe('JwksCacheService', () => {
   let cache: JwksCacheService;
   const uri = 'https://idp.example.com/.well-known/jwks.json';
+  const issuer = 'https://idp.example.com';
   const { publicKey: ecPub } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
   const jwk = ecPub.export({ type: 'spki', format: 'jwk' });
 
@@ -319,5 +323,86 @@ describe('JwksCacheService', () => {
   it('throws on non-200 JWKS response', async () => {
     global.fetch = jest.fn().mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' } as any);
     await expect(cache.getKey(uri, 'k')).rejects.toThrow(/JWKS fetch failed/);
+  });
+
+  it('coalesces concurrent refreshes and exposes issuer age', async () => {
+    const metrics = { setGauge: jest.fn() } as any;
+    const freshCache = new JwksCacheService({ metrics });
+    global.fetch = jest.fn().mockResolvedValueOnce(mockJwks([{ ...jwk, kid: 'k4' }]));
+
+    await Promise.all([
+      freshCache.refresh(uri, issuer),
+      freshCache.refresh(uri, issuer),
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(freshCache.getCacheAgeSeconds(issuer)).toBeGreaterThanOrEqual(0);
+    expect(metrics.setGauge).toHaveBeenCalledWith(
+      'oidc.jwks.age_seconds',
+      expect.any(Number),
+      { issuer },
+      expect.any(String),
+    );
+  });
+});
+
+// ── OIDC route ───────────────────────────────────────────────────────────
+
+describe('createOidcRouter JWKS refresh', () => {
+  it('requires admin dual confirmation before refreshing JWKS', async () => {
+    const oidcAdapter = {
+      getDiscovery: jest.fn(),
+      refreshJwks: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const oidcProviderRepo = {} as any;
+    const auditRefresh = jest.fn();
+    const requireAdmin = (req: any, _res: any, next: () => void) => {
+      req.user = { id: 'admin-1' };
+      next();
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(createOidcRouter({ oidcAdapter, oidcProviderRepo, requireAdmin, auditRefresh }));
+
+    const missingConfirmation = await request(app)
+      .post('/api/auth/oidc/jwks/refresh')
+      .set('x-revora-oidc-jwks-confirmation', 'true')
+      .send({ confirmation: false, issuerUrl: 'https://idp.example.com' });
+
+    expect(missingConfirmation.status).toBe(400);
+    expect(oidcAdapter.refreshJwks).not.toHaveBeenCalled();
+    expect(auditRefresh).toHaveBeenCalledWith(expect.objectContaining({ status: 'blocked' }));
+  });
+
+  it('rate-limits repeated refresh attempts for the same actor', async () => {
+    const oidcAdapter = {
+      getDiscovery: jest.fn(),
+      refreshJwks: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const oidcProviderRepo = {} as any;
+    const auditRefresh = jest.fn();
+    const requireAdmin = (req: any, _res: any, next: () => void) => {
+      req.user = { id: 'admin-2' };
+      next();
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(createOidcRouter({ oidcAdapter, oidcProviderRepo, requireAdmin, auditRefresh }));
+
+    const first = await request(app)
+      .post('/api/auth/oidc/jwks/refresh')
+      .set('x-revora-oidc-jwks-confirmation', 'true')
+      .send({ confirmation: true, issuerUrl: 'https://idp.example.com' });
+
+    const second = await request(app)
+      .post('/api/auth/oidc/jwks/refresh')
+      .set('x-revora-oidc-jwks-confirmation', 'true')
+      .send({ confirmation: true, issuerUrl: 'https://idp.example.com' });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(oidcAdapter.refreshJwks).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auth/oidc/oidcAdapterService.ts
+++ b/src/auth/oidc/oidcAdapterService.ts
@@ -140,6 +140,11 @@ export class OidcAdapterService {
     return res.json() as Promise<OidcTokenResponse>;
   }
 
+  async refreshJwks(issuerUrl: string): Promise<void> {
+    const discovery = await this.getDiscovery(issuerUrl);
+    await this.jwksCache.refresh(discovery.jwks_uri, issuerUrl);
+  }
+
   // ── ID Token validation ───────────────────────────────────────────────
 
   async validateIdToken(
@@ -166,7 +171,7 @@ export class OidcAdapterService {
     }
     if (!header.kid) throw new Error('ID token missing kid header');
 
-    let publicKey = await this.jwksCache.getKey(discovery.jwks_uri, header.kid);
+    let publicKey = await this.jwksCache.getKey(discovery.jwks_uri, header.kid, provider.issuer_url);
 
     const verifyOpts: jwt.VerifyOptions = {
       algorithms: [...ALLOWED_ID_TOKEN_ALGORITHMS] as jwt.Algorithm[],
@@ -183,7 +188,7 @@ export class OidcAdapterService {
       if (msg.includes('invalid signature') || msg.includes('unable to verify')) {
         // Signature failure — rotate JWKS and retry once
         this.jwksCache.evict(discovery.jwks_uri);
-        publicKey = await this.jwksCache.getKey(discovery.jwks_uri, header.kid);
+        publicKey = await this.jwksCache.getKey(discovery.jwks_uri, header.kid, provider.issuer_url);
         try {
           claims = jwt.verify(idToken, publicKey as unknown as string, verifyOpts) as OidcIdTokenClaims;
         } catch {

--- a/src/auth/oidc/oidcRoute.ts
+++ b/src/auth/oidc/oidcRoute.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response, Router } from 'express';
+import { AuthenticatedRequest } from '../../middleware/auth';
 import { OidcAdapterService } from './oidcAdapterService';
 import { OidcProviderRepository, CreateOidcProviderInput } from '../../db/repositories/oidcProviderRepository';
 
@@ -7,6 +8,8 @@ export interface OidcRouterDependencies {
   oidcProviderRepo: OidcProviderRepository;
   /** Express middleware that enforces admin role and attaches req.user */
   requireAdmin: (req: Request, res: Response, next: NextFunction) => void;
+  /** Optional audit hook for JWKS refresh events */
+  auditRefresh?: (event: Record<string, unknown>) => void | Promise<void>;
 }
 
 /**
@@ -19,8 +22,48 @@ export interface OidcRouterDependencies {
  *  GET  /api/auth/oidc/providers               — (admin) list providers
  */
 export function createOidcRouter(deps: OidcRouterDependencies): Router {
-  const { oidcAdapter, oidcProviderRepo, requireAdmin } = deps;
+  const { oidcAdapter, oidcProviderRepo, requireAdmin, auditRefresh } = deps;
   const router = Router();
+  const refreshCooldownMs = 60_000;
+  const refreshAttempts = new Map<string, number>();
+
+  const handleRefreshRequest = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const issuerUrl = typeof req.body?.issuerUrl === 'string' ? req.body.issuerUrl : undefined;
+      const confirmationHeader = req.get('x-revora-oidc-jwks-confirmation') === 'true';
+      const confirmationBody = req.body?.confirmation === true || req.body?.confirmation === 'true';
+      const confirmed = confirmationHeader && confirmationBody;
+      const actorId = req.user?.id ?? req.ip ?? 'anonymous';
+      const key = `${actorId}:${issuerUrl ?? 'global'}`;
+      const now = Date.now();
+
+      if (!issuerUrl) {
+        await auditRefresh?.({ action: 'jwks_refresh', actorId, issuerUrl, status: 'blocked', reason: 'missing_issuer' });
+        res.status(400).json({ error: 'Bad Request', message: 'issuerUrl is required' });
+        return;
+      }
+
+      if (!confirmed) {
+        await auditRefresh?.({ action: 'jwks_refresh', actorId, issuerUrl, status: 'blocked', reason: 'missing_confirmation' });
+        res.status(400).json({ error: 'Bad Request', message: 'Dual confirmation is required' });
+        return;
+      }
+
+      const lastAttempt = refreshAttempts.get(key) ?? 0;
+      if (now - lastAttempt < refreshCooldownMs) {
+        await auditRefresh?.({ action: 'jwks_refresh', actorId, issuerUrl, status: 'blocked', reason: 'rate_limited' });
+        res.status(429).json({ error: 'Too Many Requests', message: 'JWKS refresh is rate-limited for this actor' });
+        return;
+      }
+
+      refreshAttempts.set(key, now);
+      await oidcAdapter.refreshJwks(issuerUrl);
+      await auditRefresh?.({ action: 'jwks_refresh', actorId, issuerUrl, status: 'success' });
+      res.status(200).json({ ok: true, issuerUrl, refreshedAt: new Date().toISOString() });
+    } catch (err) {
+      next(err);
+    }
+  };
 
   // ── Start SSO flow ───────────────────────────────────────────────────────
   router.get('/api/auth/oidc/authorize', async (req: Request, res: Response, next: NextFunction) => {
@@ -83,6 +126,9 @@ export function createOidcRouter(deps: OidcRouterDependencies): Router {
       next(err);
     }
   });
+
+  router.post('/api/auth/oidc/jwks/refresh', requireAdmin, handleRefreshRequest);
+  router.post('/auth/oidc/jwks/refresh', requireAdmin, handleRefreshRequest);
 
   // ── Admin: register provider ─────────────────────────────────────────────
   router.post('/api/auth/oidc/providers', requireAdmin, async (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
Closes #498 

Description
Added oidc.jwks.age_seconds gauge to track JWKS cache age per issuer
Implemented JwksCacheService.refresh() with in-flight request coalescing
Added admin-only POST /api/auth/oidc/jwks/refresh endpoint
Enforced dual confirmation and per-actor rate limiting for forced refreshes
Added audit hook support for JWKS refresh actions
Added documentation in oidc-jwks-staleness-alarm.md
Verified with npx jest --runInBand src/auth/oidc/oidc.test.ts (34 passed)