### PR TITLE
feat: dual-control OFAC review queue

### DIFF
--- a/docs/aml-transaction-monitoring.md
+++ b/docs/aml-transaction-monitoring.md
@@ -359,3 +359,23 @@ Potential improvements:
 - Integration with external watchlists
 - Automated case assignment
 - Regulatory report generation
+## OFAC False-Positive Review Queue
+
+OFAC name-collision hits can be placed into `ofac_reviews` instead of being
+silently paused. Reviews are visible through the AML admin queue and move
+through `pending_first_approval`, `pending_second_approval`, and `cleared`.
+
+Clearance requires dual control:
+
+- The review creator cannot approve the clearance.
+- The second approver must be different from the first approver.
+- Each approval requires a written rationale.
+- Final clearance records `ofac_review_cleared` in the immutable security audit
+  event stream with approver IDs, review ID, alert ID, investor ID, and rationale
+  metadata.
+
+Queue endpoints are restricted to admin/compliance actors. Mutating review
+endpoints require a CSRF token via `x-csrf-token`; when a `csrfToken` cookie is
+present, the header must match it. Pending second-approval reviews whose
+`expires_at` has passed are reset to `pending_first_approval` and re-enter the
+queue so stale single approvals cannot clear an investor later.

--- a/src/aml/amlService.test.ts
+++ b/src/aml/amlService.test.ts
@@ -10,7 +10,15 @@ import { AMLRuleRepository } from './amlRuleRepository';
 import { AMLAlertRepository } from './amlAlertRepository';
 import { RuleEvaluator } from './ruleEvaluator';
 import { SecurityAuditRepository, AuditEvent } from '../security/types';
-import { CreateRuleInput, UpdateRuleInput, CreateCaseInput, UpdateCaseInput, SemVer } from './types';
+import {
+  CreateOFACReviewInput,
+  CreateRuleInput,
+  OFACReview,
+  UpdateRuleInput,
+  CreateCaseInput,
+  UpdateCaseInput,
+  SemVer,
+} from './types';
 
 // Mock repositories
 class MockRuleRepository {
@@ -197,6 +205,93 @@ class MockAuditRepository {
   }
 }
 
+class MockOFACReviewRepository {
+  private reviews: OFACReview[] = [];
+
+  async create(input: CreateOFACReviewInput, creatorId: string): Promise<OFACReview> {
+    const review: OFACReview = {
+      id: `ofac_${Date.now()}_${this.reviews.length}`,
+      alert_id: input.alert_id,
+      case_id: input.case_id,
+      investor_id: input.investor_id,
+      matched_name: input.matched_name,
+      list_entry_id: input.list_entry_id,
+      status: 'pending_first_approval',
+      created_by: creatorId,
+      created_at: new Date(),
+      clearance_rationale: input.rationale,
+      expires_at: input.expires_at || new Date(Date.now() + 86400000),
+      updated_at: new Date(),
+    };
+    this.reviews.push(review);
+    return review;
+  }
+
+  async findQueue(now = new Date()): Promise<OFACReview[]> {
+    await this.reopenExpired(now);
+    return this.reviews.filter(review =>
+      review.status === 'pending_first_approval' || review.status === 'pending_second_approval'
+    );
+  }
+
+  async findById(reviewId: string): Promise<OFACReview | null> {
+    return this.reviews.find(review => review.id === reviewId) || null;
+  }
+
+  async approve(reviewId: string, approverId: string, rationale: string, now = new Date()): Promise<OFACReview> {
+    const review = await this.findById(reviewId);
+    if (!review) throw new Error(`OFAC review ${reviewId} not found`);
+
+    if (review.expires_at.getTime() <= now.getTime() && review.status !== 'cleared') {
+      review.status = 'pending_first_approval';
+      review.first_approver_id = undefined;
+      review.first_approval_rationale = undefined;
+      review.first_approved_at = undefined;
+    }
+
+    if (review.created_by === approverId) {
+      throw new Error('Review creator cannot approve their own OFAC clearance');
+    }
+    if (review.first_approver_id === approverId) {
+      throw new Error('Same compliance officer cannot approve an OFAC review twice');
+    }
+
+    if (review.status === 'pending_first_approval') {
+      review.status = 'pending_second_approval';
+      review.first_approver_id = approverId;
+      review.first_approval_rationale = rationale;
+      review.first_approved_at = now;
+      review.updated_at = now;
+      return review;
+    }
+
+    review.status = 'cleared';
+    review.second_approver_id = approverId;
+    review.second_approval_rationale = rationale;
+    review.second_approved_at = now;
+    review.cleared_at = now;
+    review.clearance_rationale = [
+      review.clearance_rationale,
+      `first approver ${review.first_approver_id}: ${review.first_approval_rationale}`,
+      `second approver ${approverId}: ${rationale}`,
+    ].join('\n');
+    review.updated_at = now;
+    return review;
+  }
+
+  async reopenExpired(now = new Date()): Promise<void> {
+    for (const review of this.reviews) {
+      if (review.status === 'pending_second_approval' && review.expires_at.getTime() <= now.getTime()) {
+        review.status = 'pending_first_approval';
+        review.first_approver_id = undefined;
+        review.first_approval_rationale = undefined;
+        review.first_approved_at = undefined;
+        review.updated_at = now;
+      }
+    }
+  }
+}
+
 class MockRuleEvaluator {
   async evaluate(context: any, rules: any[]): Promise<any[]> {
     return rules.map(rule => ({
@@ -216,13 +311,15 @@ describe('AMLService', () => {
   let alertRepo: MockAlertRepository;
   let evaluator: MockRuleEvaluator;
   let auditRepo: MockAuditRepository;
+  let ofacReviewRepo: MockOFACReviewRepository;
 
   beforeEach(() => {
     ruleRepo = new MockRuleRepository();
     alertRepo = new MockAlertRepository();
     evaluator = new MockRuleEvaluator();
     auditRepo = new MockAuditRepository();
-    service = new AMLService(ruleRepo as any, alertRepo as any, evaluator as any, auditRepo, 'test_user');
+    ofacReviewRepo = new MockOFACReviewRepository();
+    service = new AMLService(ruleRepo as any, alertRepo as any, evaluator as any, auditRepo, 'test_user', ofacReviewRepo as any);
   });
 
   describe('Transaction Evaluation', () => {
@@ -570,6 +667,65 @@ describe('AMLService', () => {
       const events = auditRepo.getEvents();
       expect(events).toHaveLength(1);
       expect(events[0].action).toBe('aml_alert_dismissed');
+    });
+  });
+
+  describe('OFAC Review Queue', () => {
+    const createReview = async (expires_at?: Date) => service.createOFACReview({
+      alert_id: 'alert_ofac_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      list_entry_id: 'ofac_sdn_123',
+      rationale: 'Documented legal name collision with verified date of birth mismatch.',
+      expires_at,
+    }, 'case_creator');
+
+    it('should require two independent approvals before clearing a review', async () => {
+      const review = await createReview();
+
+      const first = await service.approveOFACReview(review.id, 'officer_1', 'Government ID and DOB do not match SDN entry.');
+      expect(first.status).toBe('pending_second_approval');
+
+      const cleared = await service.approveOFACReview(review.id, 'officer_2', 'Second review confirms false positive.');
+      expect(cleared.status).toBe('cleared');
+      expect(cleared.first_approver_id).toBe('officer_1');
+      expect(cleared.second_approver_id).toBe('officer_2');
+
+      const events = auditRepo.getEvents();
+      expect(events.map(event => event.action)).toEqual([
+        'ofac_review_created',
+        'ofac_review_first_approved',
+        'ofac_review_cleared',
+      ]);
+    });
+
+    it('should reject same-user double approval', async () => {
+      const review = await createReview();
+      await service.approveOFACReview(review.id, 'officer_1', 'First review rationale is complete.');
+
+      await expect(
+        service.approveOFACReview(review.id, 'officer_1', 'Trying to approve twice.')
+      ).rejects.toThrow('Same compliance officer cannot approve an OFAC review twice');
+    });
+
+    it('should reject approval from the case creator', async () => {
+      const review = await createReview();
+
+      await expect(
+        service.approveOFACReview(review.id, 'case_creator', 'Creator attempts clearance.')
+      ).rejects.toThrow('Review creator cannot approve their own OFAC clearance');
+    });
+
+    it('should re-enter expired pending reviews into the first-approval queue', async () => {
+      const expiresAt = new Date(Date.now() + 1000);
+      const review = await createReview(expiresAt);
+      await service.approveOFACReview(review.id, 'officer_1', 'Initial review before timeout.');
+
+      const queue = await service.getOFACReviewQueue(new Date(expiresAt.getTime() + 1000));
+
+      expect(queue).toHaveLength(1);
+      expect(queue[0].status).toBe('pending_first_approval');
+      expect(queue[0].first_approver_id).toBeUndefined();
     });
   });
 });

--- a/src/aml/amlService.ts
+++ b/src/aml/amlService.ts
@@ -8,6 +8,7 @@
 import { Pool } from 'pg';
 import { AMLRuleRepository } from './amlRuleRepository';
 import { AMLAlertRepository } from './amlAlertRepository';
+import { OFACReviewRepository } from './ofacReviewRepository';
 import { RuleEvaluator } from './ruleEvaluator';
 import { InvestmentRepository } from '../db/repositories/investmentRepository';
 import { SecurityAuditRepository, AuditEvent } from '../security/types';
@@ -20,6 +21,8 @@ import {
   UpdateCaseInput,
   AMLCase,
   AMLAlert,
+  CreateOFACReviewInput,
+  OFACReview,
   SemVer,
 } from './types';
 
@@ -32,7 +35,8 @@ export class AMLService {
     private alertRepo: AMLAlertRepository,
     private evaluator: RuleEvaluator,
     private auditRepo: SecurityAuditRepository,
-    private currentUserId: string
+    private currentUserId: string,
+    private ofacReviewRepo?: OFACReviewRepository
   ) {}
 
   /**
@@ -369,6 +373,54 @@ export class AMLService {
     return alert;
   }
 
+  async createOFACReview(input: CreateOFACReviewInput, creatorId = this.currentUserId): Promise<OFACReview> {
+    const repo = this.requireOFACReviewRepo();
+    const review = await repo.create(input, creatorId);
+
+    await this.recordAudit('VALIDATION', creatorId, 'ofac_review_created', `ofac_review/${review.id}`, {
+      review_id: review.id,
+      alert_id: input.alert_id,
+      investor_id: input.investor_id,
+      matched_name: input.matched_name,
+      expires_at: review.expires_at,
+    });
+
+    return review;
+  }
+
+  async getOFACReviewQueue(now = new Date()): Promise<OFACReview[]> {
+    return this.requireOFACReviewRepo().findQueue(now);
+  }
+
+  async approveOFACReview(
+    reviewId: string,
+    approverId: string,
+    rationale: string,
+    now = new Date()
+  ): Promise<OFACReview> {
+    if (!rationale.trim()) {
+      throw new Error('OFAC clearance rationale is required');
+    }
+
+    const repo = this.requireOFACReviewRepo();
+    const before = await repo.findById(reviewId);
+    const review = await repo.approve(reviewId, approverId, rationale, now);
+    const action = review.status === 'cleared' ? 'ofac_review_cleared' : 'ofac_review_first_approved';
+
+    await this.recordAudit('VALIDATION', approverId, action, `ofac_review/${review.id}`, {
+      review_id: review.id,
+      alert_id: review.alert_id,
+      investor_id: review.investor_id,
+      status: review.status,
+      first_approver_id: review.first_approver_id,
+      second_approver_id: review.second_approver_id,
+      previous_status: before?.status,
+      rationale,
+    });
+
+    return review;
+  }
+
   /**
    * Generate unique audit ID
    */
@@ -382,6 +434,38 @@ export class AMLService {
   private generateRequestId(): string {
     return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   }
+
+  private requireOFACReviewRepo(): OFACReviewRepository {
+    if (!this.ofacReviewRepo) {
+      throw new Error('OFAC review repository is not configured');
+    }
+    return this.ofacReviewRepo;
+  }
+
+  private async recordAudit(
+    type: AuditEvent['type'],
+    userId: string,
+    action: string,
+    resource: string,
+    details: Record<string, unknown>
+  ): Promise<void> {
+    await this.auditRepo.record({
+      id: this.generateAuditId(),
+      type,
+      userId,
+      action,
+      resource,
+      outcome: 'SUCCESS',
+      details,
+      securityContext: {
+        requestId: this.generateRequestId(),
+        ipAddress: 'system',
+        userAgent: 'aml-service',
+        timestamp: new Date(),
+      },
+      timestamp: new Date(),
+    });
+  }
 }
 
 /**
@@ -391,7 +475,8 @@ export function createAMLService(db: Pool, auditRepo: SecurityAuditRepository, u
   const investmentRepo = new InvestmentRepository(db);
   const ruleRepo = new AMLRuleRepository(db);
   const alertRepo = new AMLAlertRepository(db);
+  const ofacReviewRepo = new OFACReviewRepository(db);
   const evaluator = new RuleEvaluator(investmentRepo);
 
-  return new AMLService(ruleRepo, alertRepo, evaluator, auditRepo, userId);
+  return new AMLService(ruleRepo, alertRepo, evaluator, auditRepo, userId, ofacReviewRepo);
 }

--- a/src/aml/ofacReviewRepository.test.ts
+++ b/src/aml/ofacReviewRepository.test.ts
@@ -1,0 +1,231 @@
+import { OFACReviewRepository } from './ofacReviewRepository';
+
+class MockClient {
+  constructor(private pool: MockPool) {}
+
+  async query(text: string, values?: any[]): Promise<any> {
+    return this.pool.query(text, values);
+  }
+
+  release(): void {}
+}
+
+class MockPool {
+  reviews: any[] = [];
+  queries: string[] = [];
+
+  async connect(): Promise<MockClient> {
+    return new MockClient(this);
+  }
+
+  async query(text: string, values: any[] = []): Promise<any> {
+    this.queries.push(text);
+
+    if (text.includes('INSERT INTO ofac_reviews')) {
+      const row = {
+        id: values[0],
+        alert_id: values[1],
+        case_id: values[2],
+        investor_id: values[3],
+        matched_name: values[4],
+        list_entry_id: values[5],
+        status: 'pending_first_approval',
+        created_by: values[6],
+        clearance_rationale: values[7],
+        expires_at: values[8],
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      this.reviews.push(row);
+      return { rows: [row] };
+    }
+
+    if (text.includes('SELECT * FROM ofac_reviews WHERE id = $1 FOR UPDATE')) {
+      return { rows: this.reviews.filter(review => review.id === values[0]) };
+    }
+
+    if (text.includes('SELECT * FROM ofac_reviews WHERE id = $1')) {
+      return { rows: this.reviews.filter(review => review.id === values[0]) };
+    }
+
+    if (text.includes("WHERE status IN ('pending_first_approval', 'pending_second_approval')")) {
+      return {
+        rows: this.reviews.filter(review =>
+          review.status === 'pending_first_approval' || review.status === 'pending_second_approval'
+        ),
+      };
+    }
+
+    if (text.includes("WHERE status = 'pending_second_approval' AND expires_at <= $1")) {
+      for (const review of this.reviews) {
+        if (review.status === 'pending_second_approval' && review.expires_at <= values[0]) {
+          review.status = 'pending_first_approval';
+          review.first_approver_id = null;
+          review.first_approval_rationale = null;
+          review.first_approved_at = null;
+        }
+      }
+      return { rows: [] };
+    }
+
+    if (text.includes('WHERE id = $1 AND expires_at <= $2')) {
+      const review = this.reviews.find(item => item.id === values[0] && item.expires_at <= values[1]);
+      Object.assign(review, {
+        status: 'pending_first_approval',
+        first_approver_id: null,
+        first_approval_rationale: null,
+        first_approved_at: null,
+        second_approver_id: null,
+        second_approval_rationale: null,
+        second_approved_at: null,
+        cleared_at: null,
+        updated_at: new Date(),
+      });
+      return { rows: [review] };
+    }
+
+    if (text.includes("SET status = 'pending_second_approval'")) {
+      const review = this.reviews.find(item => item.id === values[3]);
+      Object.assign(review, {
+        status: 'pending_second_approval',
+        first_approver_id: values[0],
+        first_approval_rationale: values[1],
+        first_approved_at: values[2],
+        updated_at: new Date(),
+      });
+      return { rows: [review] };
+    }
+
+    if (text.includes("SET status = 'cleared'")) {
+      const review = this.reviews.find(item => item.id === values[4]);
+      Object.assign(review, {
+        status: 'cleared',
+        second_approver_id: values[0],
+        second_approval_rationale: values[1],
+        second_approved_at: values[2],
+        clearance_rationale: values[3],
+        cleared_at: values[2],
+        updated_at: new Date(),
+      });
+      return { rows: [review] };
+    }
+
+    if (text.trim() === 'BEGIN' || text.trim() === 'COMMIT' || text.trim() === 'ROLLBACK') {
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  }
+}
+
+describe('OFACReviewRepository', () => {
+  let pool: MockPool;
+  let repository: OFACReviewRepository;
+
+  beforeEach(() => {
+    pool = new MockPool();
+    repository = new OFACReviewRepository(pool as any);
+  });
+
+  it('should create and list queued reviews', async () => {
+    const review = await repository.create({
+      alert_id: 'alert_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      rationale: 'Legal name collision with supporting KYC evidence.',
+    }, 'creator_1');
+
+    const queue = await repository.findQueue();
+
+    expect(review.status).toBe('pending_first_approval');
+    expect(queue).toHaveLength(1);
+    expect(queue[0].alert_id).toBe('alert_1');
+  });
+
+  it('should clear after two independent approvals', async () => {
+    const review = await repository.create({
+      alert_id: 'alert_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      rationale: 'Legal name collision with supporting KYC evidence.',
+    }, 'creator_1');
+
+    const first = await repository.approve(review.id, 'officer_1', 'DOB mismatch verified.');
+    const cleared = await repository.approve(review.id, 'officer_2', 'Address and passport mismatch verified.');
+
+    expect(first.status).toBe('pending_second_approval');
+    expect(cleared.status).toBe('cleared');
+    expect(cleared.clearance_rationale).toContain('officer_2');
+  });
+
+  it('should return null when a review cannot be found', async () => {
+    await expect(repository.findById('missing_review')).resolves.toBeNull();
+  });
+
+  it('should reject creator approval and same-user second approval', async () => {
+    const review = await repository.create({
+      alert_id: 'alert_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      rationale: 'Legal name collision with supporting KYC evidence.',
+    }, 'creator_1');
+
+    await expect(repository.approve(review.id, 'creator_1', 'Self approval')).rejects.toThrow('creator cannot approve');
+    await repository.approve(review.id, 'officer_1', 'First independent approval.');
+    await expect(repository.approve(review.id, 'officer_1', 'Second approval')).rejects.toThrow('cannot approve an OFAC review twice');
+  });
+
+  it('should reject missing and already-cleared reviews', async () => {
+    await expect(repository.approve('missing_review', 'officer_1', 'No row')).rejects.toThrow('not found');
+
+    const review = await repository.create({
+      alert_id: 'alert_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      rationale: 'Legal name collision with supporting KYC evidence.',
+    }, 'creator_1');
+    await repository.approve(review.id, 'officer_1', 'First independent approval.');
+    await repository.approve(review.id, 'officer_2', 'Second independent approval.');
+
+    await expect(repository.approve(review.id, 'officer_3', 'Third approval')).rejects.toThrow('already cleared');
+  });
+
+  it('should reset expired reviews before accepting a new first approval', async () => {
+    const expiresAt = new Date(Date.now() + 1000);
+    const review = await repository.create({
+      alert_id: 'alert_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      rationale: 'Legal name collision with supporting KYC evidence.',
+      expires_at: expiresAt,
+    }, 'creator_1');
+
+    await repository.approve(review.id, 'officer_1', 'First independent approval.');
+    const reset = await repository.approve(
+      review.id,
+      'officer_2',
+      'Expired prior approval, starting approval again.',
+      new Date(expiresAt.getTime() + 1000)
+    );
+
+    expect(reset.status).toBe('pending_second_approval');
+    expect(reset.first_approver_id).toBe('officer_2');
+  });
+
+  it('should reset expired pending second approvals into the queue', async () => {
+    const expiresAt = new Date(Date.now() + 1000);
+    const review = await repository.create({
+      alert_id: 'alert_1',
+      investor_id: 'investor_1',
+      matched_name: 'John Smith',
+      rationale: 'Legal name collision with supporting KYC evidence.',
+      expires_at: expiresAt,
+    }, 'creator_1');
+
+    await repository.approve(review.id, 'officer_1', 'First independent approval.');
+    const queue = await repository.findQueue(new Date(expiresAt.getTime() + 1000));
+
+    expect(queue[0].status).toBe('pending_first_approval');
+    expect(queue[0].first_approver_id).toBeUndefined();
+  });
+});

--- a/src/aml/ofacReviewRepository.ts
+++ b/src/aml/ofacReviewRepository.ts
@@ -1,0 +1,217 @@
+import { Pool, PoolClient, QueryResult } from 'pg';
+import { CreateOFACReviewInput, OFACReview } from './types';
+
+export class OFACReviewRepository {
+  constructor(private db: Pool) {}
+
+  async create(input: CreateOFACReviewInput, creatorId: string): Promise<OFACReview> {
+    const query = `
+      INSERT INTO ofac_reviews (
+        id, alert_id, case_id, investor_id, matched_name, list_entry_id,
+        status, created_by, clearance_rationale, expires_at, created_at, updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, 'pending_first_approval', $7, $8, $9, NOW(), NOW())
+      RETURNING *
+    `;
+    const values = [
+      this.generateId(),
+      input.alert_id,
+      input.case_id || null,
+      input.investor_id,
+      input.matched_name,
+      input.list_entry_id || null,
+      creatorId,
+      input.rationale,
+      input.expires_at || this.defaultExpiry(),
+    ];
+
+    const result: QueryResult<OFACReview> = await this.db.query(query, values);
+    return this.mapReview(result.rows[0]);
+  }
+
+  async findQueue(now = new Date()): Promise<OFACReview[]> {
+    await this.reopenExpired(now);
+
+    const query = `
+      SELECT *
+      FROM ofac_reviews
+      WHERE status IN ('pending_first_approval', 'pending_second_approval')
+      ORDER BY created_at ASC
+    `;
+    const result: QueryResult<OFACReview> = await this.db.query(query);
+    return result.rows.map(row => this.mapReview(row));
+  }
+
+  async findById(reviewId: string): Promise<OFACReview | null> {
+    const result: QueryResult<OFACReview> = await this.db.query(
+      'SELECT * FROM ofac_reviews WHERE id = $1',
+      [reviewId]
+    );
+    return result.rows.length > 0 ? this.mapReview(result.rows[0]) : null;
+  }
+
+  async approve(reviewId: string, approverId: string, rationale: string, now = new Date()): Promise<OFACReview> {
+    const client = await this.db.connect();
+
+    try {
+      await client.query('BEGIN');
+      const locked = await client.query('SELECT * FROM ofac_reviews WHERE id = $1 FOR UPDATE', [reviewId]);
+      if (locked.rows.length === 0) {
+        throw new Error(`OFAC review ${reviewId} not found`);
+      }
+
+      let review = this.mapReview(locked.rows[0]);
+      if (review.expires_at.getTime() <= now.getTime() && review.status !== 'cleared') {
+        review = await this.resetExpiredReview(client, review.id, now);
+      }
+
+      if (review.status === 'cleared') {
+        throw new Error(`OFAC review ${reviewId} is already cleared`);
+      }
+      if (review.created_by === approverId) {
+        throw new Error('Review creator cannot approve their own OFAC clearance');
+      }
+      if (review.first_approver_id === approverId) {
+        throw new Error('Same compliance officer cannot approve an OFAC review twice');
+      }
+
+      const updated = review.status === 'pending_first_approval'
+        ? await this.recordFirstApproval(client, reviewId, approverId, rationale, now)
+        : await this.recordSecondApproval(client, review, approverId, rationale, now);
+
+      await client.query('COMMIT');
+      return updated;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async reopenExpired(now = new Date()): Promise<void> {
+    await this.db.query(
+      `
+        UPDATE ofac_reviews
+        SET status = 'pending_first_approval',
+            first_approver_id = NULL,
+            first_approval_rationale = NULL,
+            first_approved_at = NULL,
+            second_approver_id = NULL,
+            second_approval_rationale = NULL,
+            second_approved_at = NULL,
+            cleared_at = NULL,
+            updated_at = NOW()
+        WHERE status = 'pending_second_approval' AND expires_at <= $1
+      `,
+      [now]
+    );
+  }
+
+  private async recordFirstApproval(
+    client: PoolClient,
+    reviewId: string,
+    approverId: string,
+    rationale: string,
+    now: Date
+  ): Promise<OFACReview> {
+    const result = await client.query(
+      `
+        UPDATE ofac_reviews
+        SET status = 'pending_second_approval',
+            first_approver_id = $1,
+            first_approval_rationale = $2,
+            first_approved_at = $3,
+            updated_at = NOW()
+        WHERE id = $4
+        RETURNING *
+      `,
+      [approverId, rationale, now, reviewId]
+    );
+    return this.mapReview(result.rows[0]);
+  }
+
+  private async recordSecondApproval(
+    client: PoolClient,
+    review: OFACReview,
+    approverId: string,
+    rationale: string,
+    now: Date
+  ): Promise<OFACReview> {
+    const clearanceRationale = [
+      review.clearance_rationale,
+      `first approver ${review.first_approver_id}: ${review.first_approval_rationale}`,
+      `second approver ${approverId}: ${rationale}`,
+    ].filter(Boolean).join('\n');
+
+    const result = await client.query(
+      `
+        UPDATE ofac_reviews
+        SET status = 'cleared',
+            second_approver_id = $1,
+            second_approval_rationale = $2,
+            second_approved_at = $3,
+            clearance_rationale = $4,
+            cleared_at = $3,
+            updated_at = NOW()
+        WHERE id = $5
+        RETURNING *
+      `,
+      [approverId, rationale, now, clearanceRationale, review.id]
+    );
+    return this.mapReview(result.rows[0]);
+  }
+
+  private async resetExpiredReview(client: PoolClient, reviewId: string, now: Date): Promise<OFACReview> {
+    const result = await client.query(
+      `
+        UPDATE ofac_reviews
+        SET status = 'pending_first_approval',
+            first_approver_id = NULL,
+            first_approval_rationale = NULL,
+            first_approved_at = NULL,
+            second_approver_id = NULL,
+            second_approval_rationale = NULL,
+            second_approved_at = NULL,
+            cleared_at = NULL,
+            updated_at = NOW()
+        WHERE id = $1 AND expires_at <= $2
+        RETURNING *
+      `,
+      [reviewId, now]
+    );
+    return this.mapReview(result.rows[0]);
+  }
+
+  private mapReview(row: { [key: string]: any }): OFACReview {
+    return {
+      id: row.id,
+      alert_id: row.alert_id,
+      case_id: row.case_id || undefined,
+      investor_id: row.investor_id,
+      matched_name: row.matched_name,
+      list_entry_id: row.list_entry_id || undefined,
+      status: row.status,
+      created_by: row.created_by,
+      created_at: row.created_at,
+      first_approver_id: row.first_approver_id || undefined,
+      first_approval_rationale: row.first_approval_rationale || undefined,
+      first_approved_at: row.first_approved_at || undefined,
+      second_approver_id: row.second_approver_id || undefined,
+      second_approval_rationale: row.second_approval_rationale || undefined,
+      second_approved_at: row.second_approved_at || undefined,
+      clearance_rationale: row.clearance_rationale || undefined,
+      cleared_at: row.cleared_at || undefined,
+      expires_at: row.expires_at,
+      updated_at: row.updated_at,
+    };
+  }
+
+  private defaultExpiry(): Date {
+    return new Date(Date.now() + 24 * 60 * 60 * 1000);
+  }
+
+  private generateId(): string {
+    return `ofac_review_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+}

--- a/src/aml/types.ts
+++ b/src/aml/types.ts
@@ -182,3 +182,42 @@ export interface UpdateCaseInput {
   disposition?: AMLDisposition;
   notes?: string;
 }
+
+export type OFACReviewStatus =
+  | 'pending_first_approval'
+  | 'pending_second_approval'
+  | 'cleared'
+  | 'expired'
+  | 'rejected';
+
+export interface OFACReview {
+  id: string;
+  alert_id: string;
+  case_id?: string;
+  investor_id: string;
+  matched_name: string;
+  list_entry_id?: string;
+  status: OFACReviewStatus;
+  created_by: string;
+  created_at: Date;
+  first_approver_id?: string;
+  first_approval_rationale?: string;
+  first_approved_at?: Date;
+  second_approver_id?: string;
+  second_approval_rationale?: string;
+  second_approved_at?: Date;
+  clearance_rationale?: string;
+  cleared_at?: Date;
+  expires_at: Date;
+  updated_at: Date;
+}
+
+export interface CreateOFACReviewInput {
+  alert_id: string;
+  case_id?: string;
+  investor_id: string;
+  matched_name: string;
+  list_entry_id?: string;
+  rationale: string;
+  expires_at?: Date;
+}

--- a/src/db/migrations/018_create_ofac_reviews.sql
+++ b/src/db/migrations/018_create_ofac_reviews.sql
@@ -1,0 +1,58 @@
+/**
+ * OFAC false-positive review queue.
+ *
+ * Clearance requires two independent compliance approvals. The review row is
+ * mutable only for workflow state; every clearance action is also written to
+ * immutable security audit events by AMLService.
+ */
+
+CREATE TABLE IF NOT EXISTS ofac_reviews (
+  id VARCHAR(255) PRIMARY KEY,
+  alert_id VARCHAR(255) NOT NULL REFERENCES aml_alerts(id),
+  case_id VARCHAR(255) REFERENCES aml_cases(id),
+  investor_id VARCHAR(255) NOT NULL,
+  matched_name VARCHAR(255) NOT NULL,
+  list_entry_id VARCHAR(255),
+  status VARCHAR(40) NOT NULL CHECK (
+    status IN ('pending_first_approval', 'pending_second_approval', 'cleared', 'expired', 'rejected')
+  ) DEFAULT 'pending_first_approval',
+  created_by VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  first_approver_id VARCHAR(255),
+  first_approval_rationale TEXT,
+  first_approved_at TIMESTAMP WITH TIME ZONE,
+  second_approver_id VARCHAR(255),
+  second_approval_rationale TEXT,
+  second_approved_at TIMESTAMP WITH TIME ZONE,
+  clearance_rationale TEXT NOT NULL,
+  cleared_at TIMESTAMP WITH TIME ZONE,
+  expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT ofac_review_creator_not_first_approver
+    CHECK (first_approver_id IS NULL OR first_approver_id <> created_by),
+  CONSTRAINT ofac_review_creator_not_second_approver
+    CHECK (second_approver_id IS NULL OR second_approver_id <> created_by),
+  CONSTRAINT ofac_review_dual_control
+    CHECK (
+      first_approver_id IS NULL OR
+      second_approver_id IS NULL OR
+      first_approver_id <> second_approver_id
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ofac_reviews_open_alert
+  ON ofac_reviews(alert_id)
+  WHERE status IN ('pending_first_approval', 'pending_second_approval');
+
+CREATE INDEX IF NOT EXISTS idx_ofac_reviews_queue
+  ON ofac_reviews(status, created_at ASC)
+  WHERE status IN ('pending_first_approval', 'pending_second_approval');
+
+CREATE INDEX IF NOT EXISTS idx_ofac_reviews_investor_id ON ofac_reviews(investor_id);
+CREATE INDEX IF NOT EXISTS idx_ofac_reviews_expires_at ON ofac_reviews(expires_at);
+CREATE INDEX IF NOT EXISTS idx_ofac_reviews_created_by ON ofac_reviews(created_by);
+CREATE INDEX IF NOT EXISTS idx_ofac_reviews_approvers
+  ON ofac_reviews(first_approver_id, second_approver_id);
+
+COMMENT ON TABLE ofac_reviews IS 'OFAC false-positive reviews requiring two independent compliance clearances';
+COMMENT ON COLUMN ofac_reviews.clearance_rationale IS 'Creator rationale plus final dual-control clearance rationale';

--- a/src/routes/amlRoutes.test.ts
+++ b/src/routes/amlRoutes.test.ts
@@ -9,13 +9,14 @@ import request from 'supertest';
 import express, { Express } from 'express';
 import { createAMLRoutes } from './amlRoutes';
 import { AMLService } from '../aml/amlService';
-import { AMLRule, AMLCase, AMLAlert, SemVer } from '../aml/types';
+import { AMLRule, AMLCase, AMLAlert, OFACReview, SemVer } from '../aml/types';
 
 // Mock AMLService
 class MockAMLService {
   private rules: AMLRule[] = [];
   private cases: AMLCase[] = [];
   private alerts: AMLAlert[] = [];
+  private ofacReviews: OFACReview[] = [];
 
   async getRules(): Promise<AMLRule[]> {
     return this.rules;
@@ -208,6 +209,54 @@ class MockAMLService {
       status: 'dismissed',
     };
     return this.alerts[index];
+  }
+
+  async getOFACReviewQueue(): Promise<OFACReview[]> {
+    return this.ofacReviews.filter(review =>
+      review.status === 'pending_first_approval' || review.status === 'pending_second_approval'
+    );
+  }
+
+  async createOFACReview(input: any, creatorId: string): Promise<OFACReview> {
+    const review: OFACReview = {
+      id: `ofac_${Date.now()}`,
+      ...input,
+      status: 'pending_first_approval',
+      created_by: creatorId,
+      created_at: new Date(),
+      clearance_rationale: input.rationale,
+      expires_at: input.expires_at || new Date(Date.now() + 86400000),
+      updated_at: new Date(),
+    };
+    this.ofacReviews.push(review);
+    return review;
+  }
+
+  async approveOFACReview(reviewId: string, approverId: string, rationale: string): Promise<OFACReview> {
+    const review = this.ofacReviews.find(item => item.id === reviewId);
+    if (!review) {
+      throw new Error('OFAC review not found');
+    }
+    if (review.created_by === approverId) {
+      throw new Error('Review creator cannot approve their own OFAC clearance');
+    }
+    if (review.first_approver_id === approverId) {
+      throw new Error('Same compliance officer cannot approve an OFAC review twice');
+    }
+    if (review.status === 'pending_first_approval') {
+      review.status = 'pending_second_approval';
+      review.first_approver_id = approverId;
+      review.first_approval_rationale = rationale;
+      review.first_approved_at = new Date();
+      return review;
+    }
+
+    review.status = 'cleared';
+    review.second_approver_id = approverId;
+    review.second_approval_rationale = rationale;
+    review.second_approved_at = new Date();
+    review.cleared_at = new Date();
+    return review;
   }
 }
 
@@ -501,6 +550,92 @@ describe('AML Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.status).toBe('dismissed');
+    });
+  });
+
+  describe('OFAC review queue guards', () => {
+    it('should require an authenticated compliance actor', async () => {
+      const response = await request(app).get('/aml/ofac-reviews');
+
+      expect(response.status).toBe(401);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should reject non-compliance roles', async () => {
+      const response = await request(app)
+        .get('/aml/ofac-reviews')
+        .set('x-user-id', 'investor_1')
+        .set('x-user-role', 'investor');
+
+      expect(response.status).toBe(403);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should require CSRF token for review creation', async () => {
+      const response = await request(app)
+        .post('/aml/ofac-reviews')
+        .set('x-user-id', 'officer_1')
+        .set('x-user-role', 'compliance_officer')
+        .send({
+          alert_id: 'alert_1',
+          investor_id: 'investor_1',
+          matched_name: 'John Smith',
+          rationale: 'Verified false positive from identity documents.',
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Valid CSRF token required');
+    });
+  });
+
+  describe('OFAC review queue workflow', () => {
+    const csrf = 'csrf_test_token';
+
+    const complianceRequest = (verb: 'get' | 'post', path: string) =>
+      request(app)[verb](path)
+        .set('x-user-id', 'officer_1')
+        .set('x-user-role', 'compliance_officer')
+        .set('x-csrf-token', csrf)
+        .set('cookie', `csrfToken=${csrf}`);
+
+    it('should create and list OFAC reviews', async () => {
+      const createResponse = await complianceRequest('post', '/aml/ofac-reviews')
+        .send({
+          alert_id: 'alert_1',
+          investor_id: 'investor_1',
+          matched_name: 'John Smith',
+          list_entry_id: 'sdn_123',
+          rationale: 'Verified false positive from identity documents.',
+        });
+
+      expect(createResponse.status).toBe(201);
+      expect(createResponse.body.data.status).toBe('pending_first_approval');
+
+      const listResponse = await request(app)
+        .get('/aml/ofac-reviews')
+        .set('x-user-id', 'officer_1')
+        .set('x-user-role', 'compliance_officer');
+
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.body.data).toHaveLength(1);
+    });
+
+    it('should approve a review and return conflict for creator approval', async () => {
+      const createResponse = await complianceRequest('post', '/aml/ofac-reviews')
+        .send({
+          alert_id: 'alert_1',
+          investor_id: 'investor_1',
+          matched_name: 'John Smith',
+          rationale: 'Verified false positive from identity documents.',
+        });
+
+      const approveResponse = await complianceRequest(
+        'post',
+        `/aml/ofac-reviews/${createResponse.body.data.id}/approve`
+      ).send({ rationale: 'Creator should be blocked from approving.' });
+
+      expect(approveResponse.status).toBe(409);
+      expect(approveResponse.body.error).toContain('creator cannot approve');
     });
   });
 });

--- a/src/routes/amlRoutes.ts
+++ b/src/routes/amlRoutes.ts
@@ -4,7 +4,7 @@
  * REST API endpoints for AML transaction monitoring and case management.
  */
 
-import { Router, Request, Response } from 'express';
+import { NextFunction, Router, Request, RequestHandler, Response } from 'express';
 import { AMLService } from '../aml/amlService';
 import { z } from 'zod';
 
@@ -16,14 +16,14 @@ const createRuleSchema = z.object({
   description: z.string().min(1).max(1000),
   type: z.enum(['velocity', 'structuring', 'geo_mismatch', 'amount_threshold']),
   severity: z.enum(['low', 'medium', 'high', 'critical']),
-  config: z.record(z.unknown()),
+  config: z.record(z.string(), z.unknown()),
 });
 
 const updateRuleSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   description: z.string().min(1).max(1000).optional(),
   enabled: z.boolean().optional(),
-  config: z.record(z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
   change_reason: z.string().min(1).max(500),
 });
 
@@ -49,11 +49,75 @@ const rollbackRuleSchema = z.object({
   }),
 });
 
+const createOFACReviewSchema = z.object({
+  alert_id: z.string().min(1),
+  case_id: z.string().min(1).optional(),
+  investor_id: z.string().min(1),
+  matched_name: z.string().min(1).max(255),
+  list_entry_id: z.string().min(1).max(255).optional(),
+  rationale: z.string().min(10).max(4000),
+  expires_at: z.string().datetime().optional(),
+});
+
+const approveOFACReviewSchema = z.object({
+  rationale: z.string().min(10).max(4000),
+});
+
+export interface AMLRouteOptions {
+  reviewQueueGuards?: RequestHandler[];
+}
+
+function zodDetails(error: z.ZodError): unknown {
+  return error.issues;
+}
+
+function getActor(req: Request): { id?: string; role?: string } {
+  const user = (req as any).user;
+  const securityUser = (req as any).securityContext?.user;
+
+  return {
+    id: user?.id || securityUser?.id || req.header('x-user-id') || undefined,
+    role: user?.role || securityUser?.role || req.header('x-user-role') || undefined,
+  };
+}
+
+function requireReviewQueueRole(req: Request, res: Response, next: NextFunction): void {
+  const actor = getActor(req);
+  const allowedRoles = ['admin', 'compliance', 'compliance_officer'];
+
+  if (!actor.id || !actor.role) {
+    res.status(401).json({ success: false, error: 'Authentication required' });
+    return;
+  }
+
+  if (!allowedRoles.includes(actor.role)) {
+    res.status(403).json({ success: false, error: 'Compliance role required' });
+    return;
+  }
+
+  (req as any).amlActor = actor;
+  next();
+}
+
+function requireCsrfToken(req: Request, res: Response, next: NextFunction): void {
+  const csrfHeader = req.header('x-csrf-token');
+  const csrfCookie = req.header('cookie')?.match(/(?:^|;\s*)csrfToken=([^;]+)/)?.[1];
+
+  if (!csrfHeader || (csrfCookie && csrfHeader !== decodeURIComponent(csrfCookie))) {
+    res.status(403).json({ success: false, error: 'Valid CSRF token required' });
+    return;
+  }
+
+  next();
+}
+
 /**
  * Create AML routes
  */
-export function createAMLRoutes(amlService: AMLService): Router {
+export function createAMLRoutes(amlService: AMLService, options: AMLRouteOptions = {}): Router {
   const router = Router();
+  const reviewQueueGuards = options.reviewQueueGuards || [requireReviewQueueRole];
+  const reviewQueueMutationGuards = [...reviewQueueGuards, requireCsrfToken];
 
   /**
    * GET /aml/rules
@@ -109,7 +173,7 @@ export function createAMLRoutes(amlService: AMLService): Router {
       res.status(201).json({ success: true, data: rule });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        res.status(400).json({ success: false, error: 'Invalid input', details: error.errors });
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
       } else {
         console.error('Error creating AML rule:', error);
         res.status(500).json({ success: false, error: 'Failed to create rule' });
@@ -129,7 +193,7 @@ export function createAMLRoutes(amlService: AMLService): Router {
       res.json({ success: true, data: rule });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        res.status(400).json({ success: false, error: 'Invalid input', details: error.errors });
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
       } else {
         console.error('Error updating AML rule:', error);
         res.status(500).json({ success: false, error: 'Failed to update rule' });
@@ -149,7 +213,7 @@ export function createAMLRoutes(amlService: AMLService): Router {
       res.json({ success: true, data: rule });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        res.status(400).json({ success: false, error: 'Invalid input', details: error.errors });
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
       } else {
         console.error('Error rolling back AML rule:', error);
         res.status(500).json({ success: false, error: 'Failed to rollback rule' });
@@ -229,7 +293,7 @@ export function createAMLRoutes(amlService: AMLService): Router {
       res.status(201).json({ success: true, data: amlCase });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        res.status(400).json({ success: false, error: 'Invalid input', details: error.errors });
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
       } else {
         console.error('Error creating AML case:', error);
         res.status(500).json({ success: false, error: 'Failed to create case' });
@@ -249,7 +313,7 @@ export function createAMLRoutes(amlService: AMLService): Router {
       res.json({ success: true, data: amlCase });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        res.status(400).json({ success: false, error: 'Invalid input', details: error.errors });
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
       } else {
         console.error('Error updating AML case:', error);
         res.status(500).json({ success: false, error: 'Failed to update case' });
@@ -298,6 +362,55 @@ export function createAMLRoutes(amlService: AMLService): Router {
     } catch (error) {
       console.error('Error dismissing alert:', error);
       res.status(500).json({ success: false, error: 'Failed to dismiss alert' });
+    }
+  });
+
+  router.get('/ofac-reviews', ...reviewQueueGuards, async (req: Request, res: Response) => {
+    try {
+      const reviews = await amlService.getOFACReviewQueue();
+      res.json({ success: true, data: reviews });
+    } catch (error) {
+      console.error('Error fetching OFAC review queue:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch OFAC review queue' });
+    }
+  });
+
+  router.post('/ofac-reviews', ...reviewQueueMutationGuards, async (req: Request, res: Response) => {
+    try {
+      const actor = (req as any).amlActor || getActor(req);
+      const validated = createOFACReviewSchema.parse(req.body);
+      const review = await amlService.createOFACReview({
+        ...validated,
+        expires_at: validated.expires_at ? new Date(validated.expires_at) : undefined,
+      }, actor.id);
+
+      res.status(201).json({ success: true, data: review });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
+      } else {
+        console.error('Error creating OFAC review:', error);
+        res.status(500).json({ success: false, error: 'Failed to create OFAC review' });
+      }
+    }
+  });
+
+  router.post('/ofac-reviews/:reviewId/approve', ...reviewQueueMutationGuards, async (req: Request, res: Response) => {
+    try {
+      const actor = (req as any).amlActor || getActor(req);
+      const { reviewId } = req.params;
+      const validated = approveOFACReviewSchema.parse(req.body);
+      const review = await amlService.approveOFACReview(reviewId, actor.id, validated.rationale);
+      res.json({ success: true, data: review });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ success: false, error: 'Invalid input', details: zodDetails(error) });
+      } else if (error instanceof Error && /creator|twice|already cleared/.test(error.message)) {
+        res.status(409).json({ success: false, error: error.message });
+      } else {
+        console.error('Error approving OFAC review:', error);
+        res.status(500).json({ success: false, error: 'Failed to approve OFAC review' });
+      }
     }
   });
 


### PR DESCRIPTION
Closes #491
## Summary
- add an `ofac_reviews` migration and repository-backed review queue for OFAC false-positive name collisions
- extend `AMLService` with create/list/approve workflow requiring two independent compliance approvals and immutable audit events
- add RBAC/CSRF-protected queue endpoints plus docs for security assumptions and expiry behavior

## Tests
- `npx jest src/aml/amlService.test.ts src/aml/ofacReviewRepository.test.ts src/routes/amlRoutes.test.ts --runInBand` (55 passed)
- `npx jest src/aml/ofacReviewRepository.test.ts --runInBand --coverage --coverageThreshold='{}' --collectCoverageFrom=src/aml/ofacReviewRepository.ts` (100% statements/lines/functions, 93.33% branches)
- `npm test -- --runInBand` (partial workspace: 7 suites/107 tests passed, then failed because the initial Git LFS/partial checkout left unrelated repository files missing locally; coverage gate also measured the partial tree)

## Notes
- Same-user double approval is rejected.
- Review creator approval is rejected.
- Expired pending second approvals reset and re-enter the queue for fresh dual control.