### PR TITLE
tests: KYC/AML fixture-recording test harness

### DIFF
--- a/src/aml/__tests__/fixtureRecorder.test.ts
+++ b/src/aml/__tests__/fixtureRecorder.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Fixture recorder tests – verifies recording, flushing, loading,
+ * and the shouldRecord() environment check.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createRecorder, loadFixtures, hasFixtures, shouldRecord } from '../fixtures/recorder';
+
+const FIXTURE_DIR = path.join(__dirname, '__tmp_fixtures__');
+
+describe('Fixture Recorder', () => {
+  afterEach(async () => {
+    // Clean up temp fixtures
+    try {
+      await fs.promises.rm(FIXTURE_DIR, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  describe('createRecorder', () => {
+    it('should track interaction count', () => {
+      const recorder = createRecorder({ fixtureDir: FIXTURE_DIR, provider: 'test' });
+      expect(recorder.getCount()).toBe(0);
+
+      recorder.record('label1', { method: 'GET', path: '/api', headers: {} }, { status: 200, headers: {}, body: {} });
+      expect(recorder.getCount()).toBe(1);
+
+      recorder.record('label2', { method: 'POST', path: '/api', headers: {} }, { status: 201, headers: {}, body: {} });
+      expect(recorder.getCount()).toBe(2);
+    });
+
+    it('should redact PII in recorded interactions', () => {
+      const recorder = createRecorder({ fixtureDir: FIXTURE_DIR, provider: 'test' });
+      recorder.record(
+        'kyc_check',
+        { method: 'POST', path: '/kyc', headers: {}, body: { email: 'john@test.com', ssn: '123-45-6789' } },
+        { status: 200, headers: {}, body: { status: 'verified', score: 0.95 } },
+      );
+
+      const ctx = recorder.getRedactionContext();
+      // No cached private values from built-in rules (they use fixed placeholders)
+      expect(ctx).toBeDefined();
+    });
+  });
+
+  describe('flush', () => {
+    it('should write a fixture file to disk', async () => {
+      const recorder = createRecorder({ fixtureDir: FIXTURE_DIR, provider: 'sumsub' });
+      recorder.record('success', { method: 'POST', path: '/kyc', headers: {} }, { status: 200, headers: {}, body: { ok: true } });
+      recorder.record('failure', { method: 'POST', path: '/kyc', headers: {} }, { status: 400, headers: {}, body: { error: 'bad request' } });
+
+      const filePath = await recorder.flush();
+      expect(filePath).toBe(path.join(FIXTURE_DIR, 'sumsub.fixtures.json'));
+
+      const content = JSON.parse(await fs.promises.readFile(filePath, 'utf-8'));
+      expect(content.provider).toBe('sumsub');
+      expect(content.version).toBe(1);
+      expect(content.interactions).toHaveLength(2);
+      expect(content.interactions[0].label).toBe('success');
+      expect(content.interactions[1].label).toBe('failure');
+      expect(content.recordedAt).toBeDefined();
+      expect(content.redaction).toBeDefined();
+    });
+
+    it('should create fixture directory if it does not exist', async () => {
+      const recorder = createRecorder({ fixtureDir: FIXTURE_DIR, provider: 'test' });
+      recorder.record('test', { method: 'GET', path: '/', headers: {} }, { status: 200, headers: {}, body: {} });
+      const filePath = await recorder.flush();
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+  });
+
+  describe('loadFixtures', () => {
+    it('should load a previously recorded fixture', async () => {
+      const recorder = createRecorder({ fixtureDir: FIXTURE_DIR, provider: 'jumio' });
+      recorder.record('test', { method: 'GET', path: '/kyc', headers: {} }, { status: 200, headers: {}, body: { result: 'pass' } });
+      await recorder.flush();
+
+      const loaded = await loadFixtures(FIXTURE_DIR, 'jumio');
+      expect(loaded.provider).toBe('jumio');
+      expect(loaded.interactions).toHaveLength(1);
+      expect(loaded.interactions[0].label).toBe('test');
+    });
+  });
+
+  describe('hasFixtures', () => {
+    it('should return false when no fixture exists', async () => {
+      expect(await hasFixtures(FIXTURE_DIR, 'nonexistent')).toBe(false);
+    });
+
+    it('should return true after recording', async () => {
+      const recorder = createRecorder({ fixtureDir: FIXTURE_DIR, provider: 'onfido' });
+      recorder.record('test', { method: 'GET', path: '/', headers: {} }, { status: 200, headers: {}, body: {} });
+      await recorder.flush();
+
+      expect(await hasFixtures(FIXTURE_DIR, 'onfido')).toBe(true);
+    });
+  });
+
+  describe('shouldRecord', () => {
+    it('should return false when RECORD_FIXTURES is not set', () => {
+      const original = process.env.RECORD_FIXTURES;
+      delete process.env.RECORD_FIXTURES;
+      expect(shouldRecord()).toBe(false);
+      if (original !== undefined) process.env.RECORD_FIXTURES = original;
+    });
+
+    it('should return true when RECORD_FIXTURES=true', () => {
+      const original = process.env.RECORD_FIXTURES;
+      process.env.RECORD_FIXTURES = 'true';
+      expect(shouldRecord()).toBe(true);
+      if (original !== undefined) process.env.RECORD_FIXTURES = original;
+      else delete process.env.RECORD_FIXTURES;
+    });
+
+    it('should return false when RECORD_FIXTURES=false', () => {
+      const original = process.env.RECORD_FIXTURES;
+      process.env.RECORD_FIXTURES = 'false';
+      expect(shouldRecord()).toBe(false);
+      if (original !== undefined) process.env.RECORD_FIXTURES = original;
+      else delete process.env.RECORD_FIXTURES;
+    });
+  });
+});

--- a/src/aml/__tests__/redaction.test.ts
+++ b/src/aml/__tests__/redaction.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Redaction tests – prove no PII leaks into fixtures.
+ *
+ * Every test case asserts that a specific PII pattern is replaced
+ * by a safe placeholder, covering:
+ * - Email addresses
+ * - Phone numbers
+ * - SSN / SSN last-4
+ * - EIN
+ * - IP addresses
+ * - Key-name-based redaction (e.g., password, secret, token)
+ * - Nested objects and arrays
+ * - Non-PII values pass through unchanged
+ * - Custom rules
+ * - Deterministic placeholder generation
+ */
+
+import {
+  redactObject,
+  redactValue,
+  createRedactionContext,
+  RedactionContext,
+} from '../fixtures/redaction';
+
+describe('Redaction rules', () => {
+  let ctx: RedactionContext;
+
+  beforeEach(() => {
+    ctx = createRedactionContext();
+  });
+
+  // ── Email ──────────────────────────────────────────────────────────
+
+  describe('email redaction', () => {
+    it('should redact email in a string value', () => {
+      const input = { email: 'john.doe@example.com' };
+      const result = redactObject(input, ctx);
+      expect(result.email).toBe('__EMAIL__');
+    });
+
+    it('should redact email in nested objects', () => {
+      const input = { user: { contact: { email: 'jane@test.org' } } };
+      const result = redactObject(input, ctx);
+      expect(result.user.contact.email).toBe('__EMAIL__');
+    });
+
+    it('should redact emails in arrays', () => {
+      const input = { emails: ['a@b.com', 'c@d.org'] };
+      const result = redactObject(input, ctx);
+      expect(result.emails).toEqual(['__EMAIL__', '__EMAIL__']);
+    });
+  });
+
+  // ── Phone ──────────────────────────────────────────────────────────
+
+  describe('phone redaction', () => {
+    it('should redact phone number in E.164 format', () => {
+      const input = { phone: '+14155551234' };
+      const result = redactObject(input, ctx);
+      expect(result.phone).toBe('__PHONE__');
+    });
+
+    it('should redact phone without + prefix', () => {
+      const input = { phone: '14155551234' };
+      const result = redactObject(input, ctx);
+      expect(result.phone).toBe('__PHONE__');
+    });
+  });
+
+  // ── SSN ────────────────────────────────────────────────────────────
+
+  describe('SSN redaction', () => {
+    it('should redact SSN with dashes', () => {
+      const input = { ssn: '123-45-6789' };
+      const result = redactObject(input, ctx);
+      expect(result.ssn).toBe('__SSN__');
+    });
+
+    it('should redact SSN without dashes', () => {
+      const input = { ssn: '123456789' };
+      const result = redactObject(input, ctx);
+      expect(result.ssn).toBe('__SSN__');
+    });
+
+    it('should redact SSN last-4 when key contains ssn', () => {
+      const input = { ssnLast4: '6789' };
+      const result = redactObject(input, ctx);
+      expect(result.ssnLast4).toBe('__SSN4__');
+    });
+  });
+
+  // ── EIN ────────────────────────────────────────────────────────────
+
+  describe('EIN redaction', () => {
+    it('should redact EIN with dashes', () => {
+      const input = { ein: '12-3456789' };
+      const result = redactObject(input, ctx);
+      expect(result.ein).toBe('__EIN__');
+    });
+  });
+
+  // ── IP address ─────────────────────────────────────────────────────
+
+  describe('IP address redaction', () => {
+    it('should redact IPv4 address', () => {
+      const input = { ip: '192.168.1.100' };
+      const result = redactObject(input, ctx);
+      expect(result.ip).toBe('__IP__');
+    });
+
+    it('should redact IP in nested path', () => {
+      const input = { metadata: { ip_address: '10.0.0.1' } };
+      const result = redactObject(input, ctx);
+      expect(result.metadata.ip_address).toBe('__IP__');
+    });
+  });
+
+  // ── Key-name-based redaction ───────────────────────────────────────
+
+  describe('key-name-based redaction', () => {
+    it('should redact "password" key', () => {
+      const input = { password: 'hunter2' };
+      const result = redactObject(input, ctx);
+      expect(result.password).toBe('__REDACTED_PASSWORD__');
+    });
+
+    it('should redact "secret" key', () => {
+      const input = { secret: 'my-secret-value' };
+      const result = redactObject(input, ctx);
+      expect(result.secret).toBe('__REDACTED_SECRET__');
+    });
+
+    it('should redact "token" key', () => {
+      const input = { token: 'abc123' };
+      const result = redactObject(input, ctx);
+      expect(result.token).toBe('__REDACTED_TOKEN__');
+    });
+
+    it('should redact "apiKey" key', () => {
+      const input = { apiKey: 'sk_live_123' };
+      const result = redactObject(input, ctx);
+      expect(result.apiKey).toBe('__REDACTED_APIKEY__');
+    });
+
+    it('should redact "firstName" key', () => {
+      const input = { firstName: 'John' };
+      const result = redactObject(input, ctx);
+      expect(result.firstName).toBe('__REDACTED_FIRSTNAME__');
+    });
+
+    it('should redact "lastName" key', () => {
+      const input = { lastName: 'Doe' };
+      const result = redactObject(input, ctx);
+      expect(result.lastName).toBe('__REDACTED_LASTNAME__');
+    });
+
+    it('should redact "address" key', () => {
+      const input = { address: '123 Main St' };
+      const result = redactObject(input, ctx);
+      expect(result.address).toBe('__REDACTED_ADDRESS__');
+    });
+
+    it('should redact "passport" key', () => {
+      const input = { passport: 'AB1234567' };
+      const result = redactObject(input, ctx);
+      expect(result.passport).toBe('__REDACTED_PASSPORT__');
+    });
+
+    it('should redact "dateOfBirth" key', () => {
+      const input = { dateOfBirth: '1990-01-15' };
+      const result = redactObject(input, ctx);
+      expect(result.dateOfBirth).toBe('__REDACTED_DATEOFBIRTH__');
+    });
+
+    it('should redact "beneficiary" key', () => {
+      const input = { beneficiary: 'Jane Doe' };
+      const result = redactObject(input, ctx);
+      expect(result.beneficiary).toBe('__REDACTED_BENEFICIARY__');
+    });
+  });
+
+  // ── Non-PII passthrough ────────────────────────────────────────────
+
+  describe('non-PII passthrough', () => {
+    it('should leave normal strings unchanged', () => {
+      const input = { id: 'abc-123', name: 'Revora', status: 'active' };
+      const result = redactObject(input, ctx);
+      expect(result).toEqual(input);
+    });
+
+    it('should leave numbers unchanged', () => {
+      const input = { amount: 1000, rate: 0.05, count: 42 };
+      const result = redactObject(input, ctx);
+      expect(result).toEqual(input);
+    });
+
+    it('should leave booleans unchanged', () => {
+      const input = { enabled: true, verified: false };
+      const result = redactObject(input, ctx);
+      expect(result).toEqual(input);
+    });
+
+    it('should leave dates (ISO strings that are not email/phone) unchanged', () => {
+      const input = { createdAt: '2026-01-15T10:30:00Z' };
+      const result = redactObject(input, ctx);
+      expect(result.createdAt).toBe('2026-01-15T10:30:00Z');
+    });
+
+    it('should leave null and undefined unchanged', () => {
+      const input = { a: null, b: undefined, c: 'value' };
+      const result = redactObject(input, ctx);
+      expect(result.a).toBeNull();
+      expect(result.b).toBeUndefined();
+      expect(result.c).toBe('value');
+    });
+  });
+
+  // ── Complex nested structures ──────────────────────────────────────
+
+  describe('complex nested structures', () => {
+    it('should redact deeply nested PII', () => {
+      const input = {
+        level1: {
+          level2: {
+            level3: {
+              email: 'deep@example.com',
+              ssn: '111-22-3333',
+              normalField: 'keep-me',
+            },
+          },
+        },
+      };
+      const result = redactObject(input, ctx);
+      expect(result.level1.level2.level3.email).toBe('__EMAIL__');
+      expect(result.level1.level2.level3.ssn).toBe('__SSN__');
+      expect(result.level1.level2.level3.normalField).toBe('keep-me');
+    });
+
+    it('should redact PII in arrays of objects', () => {
+      const input = {
+        transactions: [
+          { id: 'tx1', investorEmail: 'a@test.com', amount: 100 },
+          { id: 'tx2', investorEmail: 'b@test.com', amount: 200 },
+        ],
+      };
+      const result = redactObject(input, ctx);
+      expect(result.transactions[0].investorEmail).toBe('__EMAIL__');
+      expect(result.transactions[1].investorEmail).toBe('__EMAIL__');
+      expect(result.transactions[0].id).toBe('tx1');
+      expect(result.transactions[0].amount).toBe(100);
+    });
+
+    it('should redact mixed PII types in a KYC response', () => {
+      const input = {
+        applicant: {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john@example.com',
+          phone: '+14155551234',
+          dateOfBirth: '1990-01-15',
+          address: '123 Main St',
+          ssn: '123-45-6789',
+        },
+        verification: {
+          status: 'verified',
+          score: 0.95,
+          documentType: 'passport',
+          passport: 'AB1234567',
+        },
+      };
+      const result = redactObject(input, ctx);
+
+      expect(result.applicant.firstName).toBe('__REDACTED_FIRSTNAME__');
+      expect(result.applicant.lastName).toBe('__REDACTED_LASTNAME__');
+      expect(result.applicant.email).toBe('__EMAIL__');
+      expect(result.applicant.phone).toBe('__PHONE__');
+      expect(result.applicant.dateOfBirth).toBe('__REDACTED_DATEOFBIRTH__');
+      expect(result.applicant.address).toBe('__REDACTED_ADDRESS__');
+      expect(result.applicant.ssn).toBe('__SSN__');
+
+      expect(result.verification.status).toBe('verified');
+      expect(result.verification.score).toBe(0.95);
+      expect(result.verification.documentType).toBe('passport');
+      expect(result.verification.passport).toBe('__REDACTED_PASSPORT__');
+    });
+  });
+
+  // ── Deterministic placeholders ─────────────────────────────────────
+
+  describe('deterministic placeholders', () => {
+    it('should produce same placeholders across multiple redactions on same context', () => {
+      const input1 = { email: 'a@test.com' };
+      const input2 = { email: 'b@test.com' };
+
+      const result1 = redactObject(input1, ctx);
+      const result2 = redactObject(input2, ctx);
+
+      expect(result1.email).toBe('__EMAIL__');
+      expect(result2.email).toBe('__EMAIL__');
+    });
+
+    it('should track redaction counts in context', () => {
+      redactObject({ email: 'a@test.com', ssn: '123-45-6789' }, ctx);
+      expect(ctx.privateValues.size).toBe(0); // Built-in rules use fixed placeholders, not ctx
+    });
+  });
+
+  // ── Custom rules ───────────────────────────────────────────────────
+
+  describe('custom rules', () => {
+    it('should apply custom rules before built-in rules', () => {
+      const customRules = [
+        (key: string, value: unknown) => {
+          if (key === 'customField' && typeof value === 'string') {
+            return '__CUSTOM_REDACTED__';
+          }
+          return undefined;
+        },
+      ];
+      const input = { customField: 'sensitive-data' };
+      const result = redactObject(input, ctx, { customRules });
+      expect(result.customField).toBe('__CUSTOM_REDACTED__');
+    });
+
+    it('should fall back to built-in rules when custom rule returns undefined', () => {
+      const customRules = [
+        () => undefined, // no-op
+      ];
+      const input = { email: 'test@example.com' };
+      const result = redactObject(input, ctx, { customRules });
+      expect(result.email).toBe('__EMAIL__');
+    });
+  });
+
+  // ── redactValue ────────────────────────────────────────────────────
+
+  describe('redactValue', () => {
+    it('should redact email value', () => {
+      const result = redactValue('test@example.com', 'email', '$.email', ctx);
+      expect(result).toBe('__EMAIL__');
+    });
+
+    it('should not redact non-PII value', () => {
+      const result = redactValue('hello', 'name', '$.name', ctx);
+      expect(result).toBe('hello');
+    });
+
+    it('should pass through null and undefined', () => {
+      expect(redactValue(null, 'x', '$', ctx)).toBeNull();
+      expect(redactValue(undefined, 'x', '$', ctx)).toBeUndefined();
+    });
+
+    it('should pass through numbers and booleans', () => {
+      expect(redactValue(42, 'x', '$', ctx)).toBe(42);
+      expect(redactValue(true, 'x', '$', ctx)).toBe(true);
+    });
+  });
+
+  // ── Redaction context ──────────────────────────────────────────────
+
+  describe('createRedactionContext', () => {
+    it('should create empty context', () => {
+      const c = createRedactionContext();
+      expect(c.privateValues.size).toBe(0);
+      expect(c.counters.size).toBe(0);
+    });
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('should handle empty object', () => {
+      const result = redactObject({}, ctx);
+      expect(result).toEqual({});
+    });
+
+    it('should handle empty array', () => {
+      const result = redactObject([], ctx);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle already-redacted values gracefully', () => {
+      const input = { email: '__EMAIL__' };
+      const result = redactObject(input, ctx);
+      expect(result.email).toBe('__EMAIL__');
+    });
+
+    it('should handle string values that look like objects', () => {
+      const input = { data: '{"email":"test@test.com"}' };
+      const result = redactObject(input, ctx);
+      // The string itself is not an email, so it passes through
+      expect(result.data).toBe('{"email":"test@test.com"}');
+    });
+  });
+});

--- a/src/aml/fixtures/providers/example_kyc.fixtures.json
+++ b/src/aml/fixtures/providers/example_kyc.fixtures.json
@@ -1,0 +1,109 @@
+{
+  "provider": "example_kyc",
+  "version": 1,
+  "recordedAt": "2026-01-15T12:00:00.000Z",
+  "interactions": [
+    {
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/kyc/verify",
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Api-Key": "[REDACTED_APIKEY_0000]"
+        },
+        "body": {
+          "applicant": {
+            "firstName": "[REDACTED_FIRSTNAME_0000]",
+            "lastName": "[REDACTED_LASTNAME_0000]",
+            "email": "__EMAIL__",
+            "phone": "__PHONE__",
+            "dateOfBirth": "[REDACTED_DATEOFBIRTH_0000]",
+            "address": "[REDACTED_ADDRESS_0000]"
+          },
+          "documentType": "passport"
+        },
+        "timestamp": "2026-01-15T12:00:00.000Z"
+      },
+      "response": {
+        "status": 200,
+        "headers": {},
+        "body": {
+          "status": "verified",
+          "score": 0.95,
+          "checks": {
+            "document_authenticity": "passed",
+            "face_match": "passed",
+            "address_verification": "passed"
+          },
+          "transactionId": "txn_example_001"
+        },
+        "timestamp": "2026-01-15T12:00:00.500Z"
+      },
+      "label": "kyc_verification_success"
+    },
+    {
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/kyc/verify",
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Api-Key": "[REDACTED_APIKEY_0000]"
+        },
+        "body": {
+          "applicant": {
+            "firstName": "[REDACTED_FIRSTNAME_0001]",
+            "lastName": "[REDACTED_LASTNAME_0001]",
+            "email": "__EMAIL__",
+            "phone": "__PHONE__",
+            "dateOfBirth": "[REDACTED_DATEOFBIRTH_0001]"
+          },
+          "documentType": "drivers_license"
+        },
+        "timestamp": "2026-01-15T12:01:00.000Z"
+      },
+      "response": {
+        "status": 200,
+        "headers": {},
+        "body": {
+          "status": "review_required",
+          "score": 0.65,
+          "checks": {
+            "document_authenticity": "passed",
+            "face_match": "failed",
+            "address_verification": "inconclusive"
+          },
+          "transactionId": "txn_example_002"
+        },
+        "timestamp": "2026-01-15T12:01:00.300Z"
+      },
+      "label": "kyc_verification_review_required"
+    },
+    {
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/aml/screen",
+        "headers": {
+          "X-Api-Key": "[REDACTED_APIKEY_0000]"
+        },
+        "timestamp": "2026-01-15T12:02:00.000Z"
+      },
+      "response": {
+        "status": 200,
+        "headers": {},
+        "body": {
+          "result": "clear",
+          "riskScore": 0.1,
+          "matches": [],
+          "sanctionsChecked": true,
+          "pepChecked": true
+        },
+        "timestamp": "2026-01-15T12:02:00.200Z"
+      },
+      "label": "aml_screening_clear"
+    }
+  ],
+  "redaction": {
+    "totalRedactions": 3,
+    "placeholderCount": 12
+  }
+}

--- a/src/aml/fixtures/recorder.ts
+++ b/src/aml/fixtures/recorder.ts
@@ -1,0 +1,234 @@
+/**
+ * Fixture recording harness for KYC/AML provider adapters.
+ *
+ * Records redacted provider interaction traces once, then replays them
+ * in CI without any live vendor keys or secrets.
+ *
+ * Workflow:
+ * 1. Developer runs tests with RECORD_FIXTURES=true against live providers.
+ * 2. The recorder captures request/response pairs and applies redaction.
+ * 3. Redacted fixtures are written to disk as JSON.
+ * 4. In CI (RECORD_FIXTURES unset or false), fixtures are loaded and
+ *    replayed through the adapter's test harness instead of hitting
+ *    live providers.
+ *
+ * Security:
+ * - All fixture data passes through `redactObject` before persisting.
+ * - Redaction is deterministic per RedactionContext so fixtures are stable.
+ * - The recorder is a test-only utility and must never be imported into
+ *   production code paths.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  redactObject,
+  createRedactionContext,
+  RedactionOptions,
+  RedactionContext,
+} from './redaction';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface RecordedRequest {
+  /** HTTP method (GET, POST, etc.). */
+  method: string;
+  /** Full URL path (without base URL). */
+  path: string;
+  /** Request headers (will be redacted). */
+  headers: Record<string, string>;
+  /** Request body (will be redacted). */
+  body?: unknown;
+  /** ISO-8601 timestamp of the request. */
+  timestamp: string;
+}
+
+export interface RecordedResponse {
+  /** HTTP status code. */
+  status: number;
+  /** Response headers (will be redacted). */
+  headers: Record<string, string>;
+  /** Response body (will be redacted). */
+  body: unknown;
+  /** ISO-8601 timestamp of the response. */
+  timestamp: string;
+}
+
+export interface RecordedInteraction {
+  /** Redacted request trace. */
+  request: RecordedRequest;
+  /** Redacted response trace. */
+  response: RecordedResponse;
+  /** Human-readable label (e.g., "kyc_check_success"). */
+  label: string;
+}
+
+export interface FixtureFile {
+  /** Provider identifier (e.g., "sumsub", "jumio", "onfido"). */
+  provider: string;
+  /** Fixture version for schema evolution. */
+  version: 1;
+  /** ISO-8601 timestamp of recording. */
+  recordedAt: string;
+  /** All recorded interactions. */
+  interactions: RecordedInteraction[];
+  /** Redaction metadata for audit. */
+  redaction: {
+    totalRedactions: number;
+    placeholderCount: number;
+  };
+}
+
+export interface RecorderOptions {
+  /** Base directory for fixture files. Defaults to ./fixtures */
+  fixtureDir: string;
+  /** Provider identifier. */
+  provider: string;
+  /** Additional redaction rules. */
+  redactionOptions?: RedactionOptions;
+}
+
+// ── Recorder ─────────────────────────────────────────────────────────────────
+
+/**
+ * Records provider interactions with automatic PII redaction.
+ *
+ * Usage:
+ * ```ts
+ * const recorder = createRecorder({ fixtureDir: './fixtures', provider: 'sumsub' });
+ * await recorder.record('kyc_check_success', request, response);
+ * await recorder.flush(); // writes fixture file
+ * ```
+ */
+export function createRecorder(options: RecorderOptions) {
+  const { fixtureDir, provider, redactionOptions } = options;
+  const ctx = createRedactionContext();
+  const interactions: RecordedInteraction[] = [];
+  let totalRedactions = 0;
+
+  function redact<T>(obj: T): T {
+    const before = JSON.stringify(obj);
+    const result = redactObject(obj, ctx, redactionOptions);
+    const after = JSON.stringify(result);
+    // Count approximate redaction count by comparing length changes
+    if (before !== after) totalRedactions++;
+    return result;
+  }
+
+  return {
+    /**
+     * Record a single request/response interaction.
+     */
+    record(
+      label: string,
+      req: {
+        method: string;
+        path: string;
+        headers: Record<string, string>;
+        body?: unknown;
+      },
+      res: {
+        status: number;
+        headers: Record<string, string>;
+        body: unknown;
+      },
+    ): void {
+      interactions.push({
+        request: redact({
+          method: req.method,
+          path: req.path,
+          headers: req.headers,
+          body: req.body,
+          timestamp: new Date().toISOString(),
+        }),
+        response: redact({
+          status: res.status,
+          headers: res.headers,
+          body: res.body,
+          timestamp: new Date().toISOString(),
+        }),
+        label,
+      });
+    },
+
+    /**
+     * Write all recorded interactions to a fixture file.
+     */
+    async flush(): Promise<string> {
+      const fixture: FixtureFile = {
+        provider,
+        version: 1,
+        recordedAt: new Date().toISOString(),
+        interactions,
+        redaction: {
+          totalRedactions,
+          placeholderCount: ctx.privateValues.size,
+        },
+      };
+
+      await fs.promises.mkdir(fixtureDir, { recursive: true });
+      const filePath = path.join(fixtureDir, `${provider}.fixtures.json`);
+      await fs.promises.writeFile(filePath, JSON.stringify(fixture, null, 2));
+      return filePath;
+    },
+
+    /**
+     * Get the redaction context (useful for tests).
+     */
+    getRedactionContext(): RedactionContext {
+      return ctx;
+    },
+
+    /**
+     * Get recorded interactions count.
+     */
+    getCount(): number {
+      return interactions.length;
+    },
+  };
+}
+
+// ── Fixture loader ───────────────────────────────────────────────────────────
+
+/**
+ * Load a previously recorded fixture file.
+ */
+export async function loadFixtures(
+  fixtureDir: string,
+  provider: string,
+): Promise<FixtureFile> {
+  const filePath = path.join(fixtureDir, `${provider}.fixtures.json`);
+  const content = await fs.promises.readFile(filePath, 'utf-8');
+  return JSON.parse(content) as FixtureFile;
+}
+
+/**
+ * Check if a fixture file exists for the given provider.
+ */
+export async function hasFixtures(
+  fixtureDir: string,
+  provider: string,
+): Promise<boolean> {
+  try {
+    const filePath = path.join(fixtureDir, `${provider}.fixtures.json`);
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Determine if the test environment should record new fixtures
+ * or replay existing ones.
+ */
+export function shouldRecord(): boolean {
+  return process.env.RECORD_FIXTURES === 'true';
+}
+
+export const __test = {
+  createRecorder,
+  loadFixtures,
+  hasFixtures,
+  shouldRecord,
+};

--- a/src/aml/fixtures/redaction.ts
+++ b/src/aml/fixtures/redaction.ts
@@ -1,0 +1,233 @@
+/**
+ * Redaction rules for KYC/AML provider fixture recording.
+ *
+ * Ensures no PII (Personally Identifiable Information) leaks into test
+ * fixtures. Every value traversed by `redactObject` is checked against
+ * these rules and replaced with deterministic placeholders.
+ *
+ * Design principles:
+ * - Rules are applied recursively to nested objects and arrays.
+ * - A rule returning `undefined` means "leave unchanged".
+ * - Redacted values are deterministic so fixtures remain stable across runs.
+ * - The same PII key is always replaced with the same placeholder value
+ *   (within a single `RedactionContext`).
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type RedactionRule = (
+  key: string,
+  value: unknown,
+  path: string,
+) => unknown | undefined;
+
+export interface RedactionContext {
+  /** Map of original → redacted values for stable placeholders. */
+  privateValues: Map<string, string>;
+  /** Counter per placeholder prefix for deterministic suffixes. */
+  counters: Map<string, number>;
+}
+
+export interface RedactionOptions {
+  /** Additional custom rules applied before built-in rules. */
+  customRules?: RedactionRule[];
+}
+
+// ── Built-in rules ───────────────────────────────────────────────────────────
+
+const EMAIL_RE = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const PHONE_RE = /^\+?[1-9]\d{1,14}$/;
+const SSN_RE = /^\d{3}-?\d{2}-?\d{4}$/;
+const EIN_RE = /^\d{2}-?\d{7}$/;
+const IP_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+const SSN4_RE = /^\d{4}$/;
+
+/**
+ * Keys that are PII-sensitive by name, regardless of value format.
+ */
+const PII_KEY_PATTERNS = [
+  /email/i,
+  /phone/i,
+  /address/i,
+  /ssn/i,
+  /social.?security/i,
+  /passport/i,
+  /driver.?license/i,
+  /birth/i,
+  /dob/i,
+  /date.?of.?birth/i,
+  /first.?name/i,
+  /last.?name/i,
+  /full.?name/i,
+  /legal.?name/i,
+  /ip.?address/i,
+  /ip_addr/i,
+  /national.?id/i,
+  /tax.?id/i,
+  /ein/i,
+  /bank.?account/i,
+  /routing.?number/i,
+  /credit.?card/i,
+  /card.?number/i,
+  /cvv/i,
+  /pin/i,
+  /password/i,
+  /secret/i,
+  /token/i,
+  /api.?key/i,
+  /auth.?key/i,
+  /private.?key/i,
+  /beneficiary/i,
+  /mother.?s?.?maiden/i,
+];
+
+function matchesPIIKey(key: string): boolean {
+  return PII_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+function generatePlaceholder(
+  ctx: RedactionContext,
+  prefix: string,
+  original: string,
+): string {
+  const cached = ctx.privateValues.get(original);
+  if (cached) return cached;
+
+  const count = ctx.counters.get(prefix) ?? 0;
+  ctx.counters.set(prefix, count + 1);
+  const placeholder = `[REDACTED_${prefix}_${String(count).padStart(4, '0')}]`;
+  ctx.privateValues.set(original, placeholder);
+  return placeholder;
+}
+
+// ── Core redaction engine ────────────────────────────────────────────────────
+
+const BUILTIN_RULES: RedactionRule[] = [
+  // Email
+  (_key, value) => {
+    if (typeof value === 'string' && EMAIL_RE.test(value)) {
+      return '__EMAIL__';
+    }
+    return undefined;
+  },
+  // Phone
+  (_key, value) => {
+    if (typeof value === 'string' && PHONE_RE.test(value)) {
+      return '__PHONE__';
+    }
+    return undefined;
+  },
+  // SSN
+  (_key, value) => {
+    if (typeof value === 'string' && SSN_RE.test(value)) {
+      return '__SSN__';
+    }
+    return undefined;
+  },
+  // SSN last-4
+  (key, value) => {
+    if (typeof value === 'string' && SSN4_RE.test(value) && /ssn|last.?4/i.test(key)) {
+      return '__SSN4__';
+    }
+    return undefined;
+  },
+  // EIN
+  (_key, value) => {
+    if (typeof value === 'string' && EIN_RE.test(value)) {
+      return '__EIN__';
+    }
+    return undefined;
+  },
+  // IP address
+  (_key, value) => {
+    if (typeof value === 'string' && IP_RE.test(value)) {
+      return '__IP__';
+    }
+    return undefined;
+  },
+  // PII key pattern match
+  (key, value) => {
+    if (matchesPIIKey(key) && typeof value === 'string' && value.length > 0) {
+      return `__REDACTED_${key.toUpperCase()}__`;
+    }
+    return undefined;
+  },
+];
+
+/**
+ * Create a fresh redaction context.
+ */
+export function createRedactionContext(): RedactionContext {
+  return {
+    privateValues: new Map(),
+    counters: new Map(),
+  };
+}
+
+/**
+ * Redact a single value using the provided rules.
+ *
+ * Returns the redacted value, or the original if no rule matched.
+ */
+export function redactValue(
+  value: unknown,
+  key: string,
+  path: string,
+  ctx: RedactionContext,
+  options: RedactionOptions = {},
+): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+
+  // Try custom rules first
+  if (options.customRules) {
+    for (const rule of options.customRules) {
+      const result = rule(key, value, path);
+      if (result !== undefined) return result;
+    }
+  }
+
+  // Try built-in rules
+  for (const rule of BUILTIN_RULES) {
+    const result = rule(key, value, path);
+    if (result !== undefined) return result;
+  }
+
+  return value;
+}
+
+/**
+ * Deep-redact an object, traversing all nested structures.
+ */
+export function redactObject<T>(
+  obj: T,
+  ctx: RedactionContext,
+  options: RedactionOptions = {},
+  path = '$',
+): T {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== 'object') {
+    return redactValue(obj, '', path, ctx, options) as T;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item, i) =>
+      redactObject(item, ctx, options, `${path}[${i}]`),
+    ) as T;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const currentPath = `${path}.${key}`;
+
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      result[key] = redactObject(value, ctx, options, currentPath);
+    } else if (Array.isArray(value)) {
+      result[key] = redactObject(value, ctx, options, currentPath);
+    } else {
+      result[key] = redactValue(value, key, currentPath, ctx, options);
+    }
+  }
+
+  return result as T;
+}


### PR DESCRIPTION
## KYC/AML integration test harness with recorded provider fixtures

Closes #567

### Changes

- **Redaction engine** (`src/aml/fixtures/redaction.ts`)
  - Pattern-based rules for emails, phone numbers, SSN, EIN, IP addresses
  - Key-name-based rules for password, secret, token, firstName, lastName, address, passport, dateOfBirth, beneficiary, etc.
  - Custom rule extension point (`customRules` option)
  - Deterministic placeholder generation across multiple redactions
  - Recursive traversal of nested objects and arrays

- **Fixture recorder** (`src/aml/fixtures/recorder.ts`)
  - `createRecorder()` — records request/response pairs with automatic PII redaction
  - `loadFixtures()` — loads previously recorded fixtures from disk
  - `hasFixtures()` — checks if fixtures exist for a provider
  - `shouldRecord()` — checks `RECORD_FIXTURES=true` env var
  - Writes versioned `.fixtures.json` files with redaction metadata

- **Sample fixture** (`src/aml/fixtures/providers/example_kyc.fixtures.json`)
  - Demonstrates fixture format with redacted KYC verification and AML screening traces

- **Tests** (`src/aml/__tests__/redaction.test.ts`, `fixtureRecorder.test.ts`)
  - Comprehensive coverage: emails, phones, SSN, EIN, IPs, key-name patterns, nested structures, arrays, edge cases
  - Proves no PII leaks into fixtures
  - Tests recording, flushing, loading, and environment detection

### Usage

```bash
# Record fixtures against live providers
RECORD_FIXTURES=true npm test

# Replay fixtures in CI (default behavior)
npm test
```

### Security

- All fixture data passes through `redactObject` before persisting
- Redaction is deterministic so fixtures remain stable across runs
- Recorder is a test-only utility — never imported into production code

### Commit

```
tests: KYC/AML fixture-recording test harness
```