### PR TITLE
feat: retention labels with legal-hold override

### DIFF
--- a/docs/ledger-retention-legal-hold.md
+++ b/docs/ledger-retention-legal-hold.md
@@ -1,0 +1,44 @@
+# Ledger-export retention labels and legal hold (#565)
+
+Per-period retention labels prevent audit/ledger purge of periods under legal hold,
+even after `AUDIT_RETENTION_DAYS` expires.
+
+## Schema
+
+Migration: `src/db/migrations/018_create_retention_labels.sql`
+
+| Column | Purpose |
+|--------|---------|
+| `period_id` | UTC `YYYY-MM` key matching `to_char(audit_logs.created_at AT TIME ZONE 'UTC', 'YYYY-MM')` |
+| `legal_hold` | When `true`, purge skips matching rows |
+| `pending_action` | Dual-control queue: `add` or `remove` |
+
+## Dual-control API (admin)
+
+All routes require an admin JWT. Propose and approve **must** be different admins.
+
+- `POST /api/v1/admin/retention-labels/:periodId/legal-hold/propose`
+- `POST /api/v1/admin/retention-labels/:periodId/legal-hold/approve`
+- `POST /api/v1/admin/retention-labels/:periodId/legal-hold/propose-release`
+- `POST /api/v1/admin/retention-labels/:periodId/legal-hold/approve-release`
+- `GET /api/v1/admin/retention-labels/:periodId`
+- `GET /api/v1/admin/retention-labels/active`
+
+## Purge behavior
+
+`AuditPurgeService` / `AuditLogRepository.purgeBefore`:
+
+1. Count expired rows whose period has `legal_hold = true` → metric `purge.skipped_hold` (sanitized as `purge_skipped_hold`).
+2. Delete only expired rows **not** under an active hold.
+
+### Hold removed → next cycle only
+
+Approving a release clears `legal_hold` but does **not** run a purge. Eligible rows are
+deleted on the **next** scheduled (or manual) `runPurge()` cycle.
+
+## Security notes
+
+- Two-key rule: approver identity must differ from proposer.
+- Period IDs are strictly validated as `YYYY-MM`.
+- Legal-hold mutations are written to `audit_logs`.
+- Metrics labels are sanitized; no PII is attached to `purge.skipped_hold`.

--- a/src/db/migrations/018_create_retention_labels.sql
+++ b/src/db/migrations/018_create_retention_labels.sql
@@ -1,0 +1,37 @@
+-- Migration: ledger-export retention labels with legal-hold override (#565)
+-- Periods under an active legal hold must not be purged even after retention expiry.
+
+CREATE TABLE IF NOT EXISTS retention_labels (
+  period_id VARCHAR(16) PRIMARY KEY,
+  legal_hold BOOLEAN NOT NULL DEFAULT FALSE,
+  reason TEXT,
+  pending_action VARCHAR(16) NULL
+    CHECK (pending_action IS NULL OR pending_action IN ('add', 'remove')),
+  pending_proposed_by UUID NULL,
+  pending_proposed_at TIMESTAMP WITH TIME ZONE NULL,
+  activated_by UUID NULL,
+  activated_at TIMESTAMP WITH TIME ZONE NULL,
+  released_by UUID NULL,
+  released_at TIMESTAMP WITH TIME ZONE NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT retention_labels_period_id_format
+    CHECK (period_id ~ '^[0-9]{4}-[0-9]{2}$')
+);
+
+CREATE INDEX IF NOT EXISTS idx_retention_labels_legal_hold
+  ON retention_labels (legal_hold)
+  WHERE legal_hold = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_retention_labels_pending_action
+  ON retention_labels (pending_action)
+  WHERE pending_action IS NOT NULL;
+
+COMMENT ON TABLE retention_labels IS
+  'Per-period retention labels for ledger/audit exports. Active legal_hold blocks purge.';
+COMMENT ON COLUMN retention_labels.period_id IS
+  'UTC calendar period key YYYY-MM derived from audit_logs.created_at for purge matching.';
+COMMENT ON COLUMN retention_labels.legal_hold IS
+  'When true, purge must skip audit rows belonging to this period.';
+COMMENT ON COLUMN retention_labels.pending_action IS
+  'Dual-control queue: add = propose hold, remove = propose release. Requires second admin.';

--- a/src/db/repositories/auditLogRepository.ts
+++ b/src/db/repositories/auditLogRepository.ts
@@ -141,17 +141,48 @@ export class AuditLogRepository {
   }
 
   /**
-   * Purge audit logs created before a specific date
-   * @param cutoffDate The cutoff date
-   * @returns Number of rows deleted
+   * Purge audit logs created before a specific date.
+   *
+   * Rows whose UTC `YYYY-MM` period has an active legal hold in
+   * `retention_labels` are skipped and counted separately.
    */
-  async purgeBefore(cutoffDate: Date): Promise<number> {
-    const query = `
-      DELETE FROM audit_logs
-      WHERE created_at < $1
-    `;
-    const result = await this.db.query(query, [cutoffDate]);
-    return result.rowCount ?? 0;
+  async purgeBefore(cutoffDate: Date): Promise<{
+    deletedCount: number;
+    skippedHoldCount: number;
+  }> {
+    const skippedResult = await this.db.query<{ count: string | number }>(
+      `
+      SELECT COUNT(*)::int AS count
+      FROM audit_logs a
+      WHERE a.created_at < $1
+        AND EXISTS (
+          SELECT 1
+          FROM retention_labels rl
+          WHERE rl.legal_hold = TRUE
+            AND rl.period_id = to_char((a.created_at AT TIME ZONE 'UTC'), 'YYYY-MM')
+        )
+      `,
+      [cutoffDate],
+    );
+
+    const deleteResult = await this.db.query(
+      `
+      DELETE FROM audit_logs a
+      WHERE a.created_at < $1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM retention_labels rl
+          WHERE rl.legal_hold = TRUE
+            AND rl.period_id = to_char((a.created_at AT TIME ZONE 'UTC'), 'YYYY-MM')
+        )
+      `,
+      [cutoffDate],
+    );
+
+    return {
+      deletedCount: deleteResult.rowCount ?? 0,
+      skippedHoldCount: Number(skippedResult.rows[0]?.count ?? 0),
+    };
   }
 
   /**

--- a/src/db/repositories/retentionLabelRepository.ts
+++ b/src/db/repositories/retentionLabelRepository.ts
@@ -1,0 +1,151 @@
+import { Pool, QueryResult } from 'pg';
+
+export type RetentionPendingAction = 'add' | 'remove';
+
+/**
+ * Per-period retention label row used for ledger-export legal holds.
+ */
+export interface RetentionLabel {
+  period_id: string;
+  legal_hold: boolean;
+  reason: string | null;
+  pending_action: RetentionPendingAction | null;
+  pending_proposed_by: string | null;
+  pending_proposed_at: Date | null;
+  activated_by: string | null;
+  activated_at: Date | null;
+  released_by: string | null;
+  released_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export class RetentionLabelRepository {
+  constructor(private readonly db: Pool) {}
+
+  async findByPeriodId(periodId: string): Promise<RetentionLabel | null> {
+    const result: QueryResult = await this.db.query(
+      `SELECT * FROM retention_labels WHERE period_id = $1`,
+      [periodId],
+    );
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.mapRow(result.rows[0]);
+  }
+
+  async listActiveHolds(): Promise<RetentionLabel[]> {
+    const result: QueryResult = await this.db.query(
+      `SELECT * FROM retention_labels
+       WHERE legal_hold = TRUE
+       ORDER BY period_id ASC`,
+    );
+    return result.rows.map((row) => this.mapRow(row));
+  }
+
+  async upsertProposeAdd(input: {
+    periodId: string;
+    actorId: string;
+    reason?: string | null;
+  }): Promise<RetentionLabel> {
+    const result: QueryResult = await this.db.query(
+      `INSERT INTO retention_labels (
+         period_id, legal_hold, reason, pending_action, pending_proposed_by, pending_proposed_at
+       ) VALUES ($1, FALSE, $2, 'add', $3, NOW())
+       ON CONFLICT (period_id) DO UPDATE SET
+         reason = COALESCE(EXCLUDED.reason, retention_labels.reason),
+         pending_action = 'add',
+         pending_proposed_by = EXCLUDED.pending_proposed_by,
+         pending_proposed_at = NOW(),
+         updated_at = NOW()
+       RETURNING *`,
+      [input.periodId, input.reason ?? null, input.actorId],
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async approveAdd(input: {
+    periodId: string;
+    actorId: string;
+  }): Promise<RetentionLabel> {
+    const result: QueryResult = await this.db.query(
+      `UPDATE retention_labels
+       SET legal_hold = TRUE,
+           pending_action = NULL,
+           pending_proposed_by = NULL,
+           pending_proposed_at = NULL,
+           activated_by = $2,
+           activated_at = NOW(),
+           updated_at = NOW()
+       WHERE period_id = $1
+       RETURNING *`,
+      [input.periodId, input.actorId],
+    );
+    if (result.rows.length === 0) {
+      throw new Error(`Retention label not found for period ${input.periodId}`);
+    }
+    return this.mapRow(result.rows[0]);
+  }
+
+  async proposeRemove(input: {
+    periodId: string;
+    actorId: string;
+  }): Promise<RetentionLabel> {
+    const result: QueryResult = await this.db.query(
+      `UPDATE retention_labels
+       SET pending_action = 'remove',
+           pending_proposed_by = $2,
+           pending_proposed_at = NOW(),
+           updated_at = NOW()
+       WHERE period_id = $1
+       RETURNING *`,
+      [input.periodId, input.actorId],
+    );
+    if (result.rows.length === 0) {
+      throw new Error(`Retention label not found for period ${input.periodId}`);
+    }
+    return this.mapRow(result.rows[0]);
+  }
+
+  async approveRemove(input: {
+    periodId: string;
+    actorId: string;
+  }): Promise<RetentionLabel> {
+    const result: QueryResult = await this.db.query(
+      `UPDATE retention_labels
+       SET legal_hold = FALSE,
+           pending_action = NULL,
+           pending_proposed_by = NULL,
+           pending_proposed_at = NULL,
+           released_by = $2,
+           released_at = NOW(),
+           updated_at = NOW()
+       WHERE period_id = $1
+       RETURNING *`,
+      [input.periodId, input.actorId],
+    );
+    if (result.rows.length === 0) {
+      throw new Error(`Retention label not found for period ${input.periodId}`);
+    }
+    return this.mapRow(result.rows[0]);
+  }
+
+  private mapRow(row: Record<string, unknown>): RetentionLabel {
+    return {
+      period_id: String(row.period_id),
+      legal_hold: Boolean(row.legal_hold),
+      reason: (row.reason as string | null) ?? null,
+      pending_action: (row.pending_action as RetentionPendingAction | null) ?? null,
+      pending_proposed_by: (row.pending_proposed_by as string | null) ?? null,
+      pending_proposed_at: row.pending_proposed_at
+        ? new Date(row.pending_proposed_at as string | Date)
+        : null,
+      activated_by: (row.activated_by as string | null) ?? null,
+      activated_at: row.activated_at ? new Date(row.activated_at as string | Date) : null,
+      released_by: (row.released_by as string | null) ?? null,
+      released_at: row.released_at ? new Date(row.released_at as string | Date) : null,
+      created_at: new Date(row.created_at as string | Date),
+      updated_at: new Date(row.updated_at as string | Date),
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ import { TenantSettingsRepository } from "./db/repositories/tenantSettingsReposi
 import { ContractUpgradeOrchestratorService } from "./services/contractUpgradeOrchestratorService";
 import { createContractUpgradeRouter } from "./routes/contractUpgradeRoutes";
 import { AuditPurgeService } from "./services/auditPurgeService";
+import { RetentionLabelRepository } from "./db/repositories/retentionLabelRepository";
+import { RetentionLabelService } from "./services/retentionLabelService";
 import { PayoutDriftRepository } from "./db/repositories/payoutDriftRepository";
 import { PayoutDriftDetector } from "./services/payoutDriftDetector";
 import { MetricsCollector } from "./lib/metrics";
@@ -666,6 +668,10 @@ export function createApp(dependencies: AppDependencies = {}): express.Express {
 
   // Initialize repositories for admin and audit routes
   const auditLogRepo = new AuditLogRepository(pool);
+  const retentionLabelService = new RetentionLabelService(
+    new RetentionLabelRepository(pool),
+    auditLogRepo,
+  );
   const tenantSettingsRepo = new TenantSettingsRepository(pool);
   const contractUpgradeService = env.STELLAR_SERVER_SECRET
     ? new ContractUpgradeOrchestratorService(
@@ -677,7 +683,7 @@ export function createApp(dependencies: AppDependencies = {}): express.Express {
     : null;
 
   // Mount admin router
-  apiRouter.use("/admin", createAdminRouter(auditLogRepo));
+  apiRouter.use("/admin", createAdminRouter(auditLogRepo, retentionLabelService));
   apiRouter.use("/admin", createAdminKycRiskTierRouter(pool, amlAuditRepo));
 
   if (contractUpgradeService) {

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -99,8 +99,9 @@ describe('Audit Log Retention and Export', () => {
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - 90);
 
-      const deletedCount = await auditLogRepo.purgeBefore(cutoffDate);
-      expect(deletedCount).toBe(1);
+      const deleted = await auditLogRepo.purgeBefore(cutoffDate);
+      expect(deleted.deletedCount).toBe(1);
+      expect(deleted.skippedHoldCount).toBe(0);
 
       const remaining = await pool.query('SELECT * FROM audit_logs');
       expect(remaining.rows.length).toBe(1);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,10 +1,18 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { Keypair } from '@stellar/stellar-sdk';
 import { AuditLogRepository } from '../db/repositories/auditLogRepository';
-import { requireAdmin } from '../middleware/auth';
+import { requireAdmin, AuthenticatedRequest } from '../middleware/auth';
 import { env } from '../config/env';
+import {
+  RetentionLabelError,
+  RetentionLabelService,
+} from '../services/retentionLabelService';
+import { Errors } from '../lib/errors';
 
-export function createAdminRouter(auditLogRepo: AuditLogRepository): Router {
+export function createAdminRouter(
+  auditLogRepo: AuditLogRepository,
+  retentionLabelService?: RetentionLabelService,
+): Router {
   const router = Router();
 
   // Secure all routes in this router with requireAdmin
@@ -67,5 +75,129 @@ export function createAdminRouter(auditLogRepo: AuditLogRepository): Router {
     }
   });
 
+  if (retentionLabelService) {
+    router.get(
+      '/retention-labels/active',
+      async (_req: Request, res: Response, next: NextFunction) => {
+        try {
+          const labels = await retentionLabelService.listActiveHolds();
+          res.status(200).json({ labels });
+        } catch (error) {
+          next(error);
+        }
+      },
+    );
+
+    router.get(
+      '/retention-labels/:periodId',
+      async (req: Request, res: Response, next: NextFunction) => {
+        try {
+          const label = await retentionLabelService.get(req.params.periodId);
+          if (!label) {
+            next(Errors.notFound('Retention label not found'));
+            return;
+          }
+          res.status(200).json({ label });
+        } catch (error) {
+          next(mapRetentionError(error));
+        }
+      },
+    );
+
+    router.post(
+      '/retention-labels/:periodId/legal-hold/propose',
+      async (req: Request, res: Response, next: NextFunction) => {
+        try {
+          const actorId = requireActorId(req);
+          const label = await retentionLabelService.proposeLegalHold({
+            periodId: req.params.periodId,
+            actorId,
+            reason: typeof req.body?.reason === 'string' ? req.body.reason : undefined,
+          });
+          res.status(202).json({ label });
+        } catch (error) {
+          next(mapRetentionError(error));
+        }
+      },
+    );
+
+    router.post(
+      '/retention-labels/:periodId/legal-hold/approve',
+      async (req: Request, res: Response, next: NextFunction) => {
+        try {
+          const actorId = requireActorId(req);
+          const label = await retentionLabelService.approveLegalHold({
+            periodId: req.params.periodId,
+            actorId,
+          });
+          res.status(200).json({ label });
+        } catch (error) {
+          next(mapRetentionError(error));
+        }
+      },
+    );
+
+    router.post(
+      '/retention-labels/:periodId/legal-hold/propose-release',
+      async (req: Request, res: Response, next: NextFunction) => {
+        try {
+          const actorId = requireActorId(req);
+          const label = await retentionLabelService.proposeLegalHoldRelease({
+            periodId: req.params.periodId,
+            actorId,
+          });
+          res.status(202).json({ label });
+        } catch (error) {
+          next(mapRetentionError(error));
+        }
+      },
+    );
+
+    router.post(
+      '/retention-labels/:periodId/legal-hold/approve-release',
+      async (req: Request, res: Response, next: NextFunction) => {
+        try {
+          const actorId = requireActorId(req);
+          const label = await retentionLabelService.approveLegalHoldRelease({
+            periodId: req.params.periodId,
+            actorId,
+          });
+          res.status(200).json({ label });
+        } catch (error) {
+          next(mapRetentionError(error));
+        }
+      },
+    );
+  }
+
   return router;
+}
+
+function requireActorId(req: Request): string {
+  const user = (req as AuthenticatedRequest).user;
+  const actorId = user?.id || user?.sub;
+  if (!actorId || typeof actorId !== 'string') {
+    throw Errors.unauthorized('Authenticated admin identity required');
+  }
+  return actorId;
+}
+
+function mapRetentionError(error: unknown): unknown {
+  if (!(error instanceof RetentionLabelError)) {
+    return error;
+  }
+  switch (error.code) {
+    case 'INVALID_PERIOD':
+      return Errors.badRequest(error.message);
+    case 'DUAL_CONTROL':
+    case 'ALREADY_ACTIVE':
+    case 'NOT_ACTIVE':
+    case 'PENDING_REQUIRED':
+    case 'WRONG_PENDING':
+      return Errors.conflict(error.message);
+    case 'NOT_FOUND':
+      return Errors.notFound(error.message);
+    default:
+      return error;
+  }
 }

--- a/src/services/auditPurgeService.test.ts
+++ b/src/services/auditPurgeService.test.ts
@@ -1,0 +1,64 @@
+import { AuditLogRepository } from '../db/repositories/auditLogRepository';
+import { AuditPurgeService } from './auditPurgeService';
+import { MetricsCollector } from '../lib/metrics';
+import { env } from '../config/env';
+
+describe('AuditPurgeService legal-hold skip', () => {
+  it('skips held periods, emits purge.skipped_hold, and only purges after release on a later cycle', async () => {
+    const auditLogRepo = {
+      purgeBefore: jest
+        .fn()
+        // Cycle 1: hold active → skip rows, delete none
+        .mockResolvedValueOnce({ deletedCount: 0, skippedHoldCount: 3 })
+        // Cycle 2 (after release): rows re-enter purge
+        .mockResolvedValueOnce({ deletedCount: 3, skippedHoldCount: 0 }),
+    } as unknown as AuditLogRepository;
+
+    const metrics = new MetricsCollector({ enabled: true });
+    const service = new AuditPurgeService(auditLogRepo, metrics);
+    env.AUDIT_RETENTION_DAYS = 90;
+
+    const first = await service.runPurge();
+    expect(first).toEqual({ deletedCount: 0, skippedHoldCount: 3 });
+
+    const second = await service.runPurge();
+    expect(second).toEqual({ deletedCount: 3, skippedHoldCount: 0 });
+
+    expect(auditLogRepo.purgeBefore).toHaveBeenCalledTimes(2);
+
+    const snapshot = await metrics.getSnapshot();
+    const skipped = snapshot.custom.find((m) => m.name === 'purge_skipped_hold');
+    expect(skipped?.value).toBe(3);
+
+    const purged = snapshot.custom.find(
+      (m) => m.name === 'audit_logs_purged_total' && m.labels?.status === 'success',
+    );
+    expect(purged?.value).toBe(3);
+  });
+});
+
+describe('AuditLogRepository.purgeBefore SQL contract', () => {
+  it('counts skipped holds and deletes only non-held expired rows', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ count: 2 }] })
+      .mockResolvedValueOnce({ rowCount: 5 });
+
+    const repo = new AuditLogRepository({ query } as any);
+    const cutoff = new Date('2020-01-01T00:00:00.000Z');
+    const result = await repo.purgeBefore(cutoff);
+
+    expect(result).toEqual({ deletedCount: 5, skippedHoldCount: 2 });
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('retention_labels'),
+      [cutoff],
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('DELETE FROM audit_logs'),
+      [cutoff],
+    );
+    expect(String(query.mock.calls[1][0])).toContain('legal_hold = TRUE');
+  });
+});

--- a/src/services/auditPurgeService.ts
+++ b/src/services/auditPurgeService.ts
@@ -4,7 +4,8 @@ import { globalLogger } from '../lib/logger';
 import { env } from '../config/env';
 
 /**
- * Service to manage the scheduled purging of audit logs based on retention policy
+ * Service to manage the scheduled purging of audit logs based on retention policy.
+ * Active legal-hold labels cause matching periods to be skipped (see retention_labels).
  */
 export class AuditPurgeService {
   private intervalId?: NodeJS.Timeout;
@@ -53,9 +54,11 @@ export class AuditPurgeService {
   }
 
   /**
-   * Executes a single purge cycle
+   * Executes a single purge cycle.
+   * Legal-hold periods are never deleted here; they only become eligible after
+   * a dual-controlled release and on a subsequent cycle.
    */
-  async runPurge(): Promise<void> {
+  async runPurge(): Promise<{ deletedCount: number; skippedHoldCount: number }> {
     const startTime = Date.now();
     try {
       const cutoffDate = new Date();
@@ -63,16 +66,28 @@ export class AuditPurgeService {
 
       globalLogger.info('Running audit log purge', { cutoffDate: cutoffDate.toISOString() });
 
-      const deletedCount = await this.auditLogRepo.purgeBefore(cutoffDate);
+      const { deletedCount, skippedHoldCount } = await this.auditLogRepo.purgeBefore(cutoffDate);
       
       const duration = Date.now() - startTime;
       
-      globalLogger.info('Audit log purge complete', { deletedCount, durationMs: duration });
+      globalLogger.info('Audit log purge complete', {
+        deletedCount,
+        skippedHoldCount,
+        durationMs: duration,
+      });
 
       if (this.metricsCollector) {
         this.metricsCollector.incrementCounter('audit_logs_purged_total', { status: 'success' }, deletedCount);
+        this.metricsCollector.incrementCounter(
+          'purge.skipped_hold',
+          { status: 'success' },
+          skippedHoldCount,
+          'Audit/ledger rows skipped because their period is under legal hold',
+        );
         this.metricsCollector.recordHistogram('audit_purge_duration_ms', duration, { status: 'success' });
       }
+
+      return { deletedCount, skippedHoldCount };
     } catch (error) {
       const duration = Date.now() - startTime;
       if (this.metricsCollector) {

--- a/src/services/retentionLabelService.test.ts
+++ b/src/services/retentionLabelService.test.ts
@@ -1,0 +1,123 @@
+import { RetentionLabelRepository } from '../db/repositories/retentionLabelRepository';
+import {
+  RetentionLabelError,
+  RetentionLabelService,
+} from '../services/retentionLabelService';
+
+describe('RetentionLabelService dual-control legal hold', () => {
+  const labels = {
+    findByPeriodId: jest.fn(),
+    listActiveHolds: jest.fn(),
+    upsertProposeAdd: jest.fn(),
+    approveAdd: jest.fn(),
+    proposeRemove: jest.fn(),
+    approveRemove: jest.fn(),
+  } as unknown as jest.Mocked<RetentionLabelRepository>;
+
+  const auditLogRepo = {
+    createAuditLog: jest.fn().mockResolvedValue({}),
+  };
+
+  const service = new RetentionLabelService(labels, auditLogRepo as any);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects invalid period ids', async () => {
+    await expect(
+      service.proposeLegalHold({ periodId: '2026-13', actorId: 'admin-a' }),
+    ).rejects.toMatchObject({ code: 'INVALID_PERIOD' });
+  });
+
+  it('requires a second distinct admin to activate a hold', async () => {
+    labels.findByPeriodId.mockResolvedValue({
+      period_id: '2024-01',
+      legal_hold: false,
+      reason: 'litigation',
+      pending_action: 'add',
+      pending_proposed_by: 'admin-a',
+      pending_proposed_at: new Date(),
+      activated_by: null,
+      activated_at: null,
+      released_by: null,
+      released_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    await expect(
+      service.approveLegalHold({ periodId: '2024-01', actorId: 'admin-a' }),
+    ).rejects.toBeInstanceOf(RetentionLabelError);
+
+    labels.approveAdd.mockResolvedValue({
+      period_id: '2024-01',
+      legal_hold: true,
+      reason: 'litigation',
+      pending_action: null,
+      pending_proposed_by: null,
+      pending_proposed_at: null,
+      activated_by: 'admin-b',
+      activated_at: new Date(),
+      released_by: null,
+      released_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    const activated = await service.approveLegalHold({
+      periodId: '2024-01',
+      actorId: 'admin-b',
+    });
+    expect(activated.legal_hold).toBe(true);
+    expect(labels.approveAdd).toHaveBeenCalledWith({
+      periodId: '2024-01',
+      actorId: 'admin-b',
+    });
+  });
+
+  it('requires dual-control to release a hold and does not purge immediately', async () => {
+    labels.findByPeriodId.mockResolvedValue({
+      period_id: '2024-01',
+      legal_hold: true,
+      reason: 'litigation',
+      pending_action: 'remove',
+      pending_proposed_by: 'admin-a',
+      pending_proposed_at: new Date(),
+      activated_by: 'admin-b',
+      activated_at: new Date(),
+      released_by: null,
+      released_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    labels.approveRemove.mockResolvedValue({
+      period_id: '2024-01',
+      legal_hold: false,
+      reason: 'litigation',
+      pending_action: null,
+      pending_proposed_by: null,
+      pending_proposed_at: null,
+      activated_by: 'admin-b',
+      activated_at: new Date(),
+      released_by: 'admin-c',
+      released_at: new Date(),
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    const released = await service.approveLegalHoldRelease({
+      periodId: '2024-01',
+      actorId: 'admin-c',
+    });
+
+    expect(released.legal_hold).toBe(false);
+    expect(auditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'RETENTION_LEGAL_HOLD_RELEASED',
+        details: expect.stringContaining('next purge cycle'),
+      }),
+    );
+  });
+});

--- a/src/services/retentionLabelService.ts
+++ b/src/services/retentionLabelService.ts
@@ -1,0 +1,198 @@
+import { AuditLogRepository } from '../db/repositories/auditLogRepository';
+import {
+  RetentionLabel,
+  RetentionLabelRepository,
+} from '../db/repositories/retentionLabelRepository';
+import { globalLogger } from '../lib/logger';
+
+const PERIOD_ID_RE = /^[0-9]{4}-(0[1-9]|1[0-2])$/;
+
+export class RetentionLabelError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | 'INVALID_PERIOD'
+      | 'ALREADY_ACTIVE'
+      | 'NOT_ACTIVE'
+      | 'PENDING_REQUIRED'
+      | 'WRONG_PENDING'
+      | 'DUAL_CONTROL'
+      | 'NOT_FOUND',
+  ) {
+    super(message);
+    this.name = 'RetentionLabelError';
+  }
+}
+
+/**
+ * Dual-controlled legal-hold labels for ledger/audit periods.
+ *
+ * Security assumptions:
+ * - Propose and approve must be distinct admin identities (two-key rule).
+ * - A released hold does not trigger an immediate purge; held rows re-enter
+ *   eligibility only on the next scheduled purge cycle.
+ */
+export class RetentionLabelService {
+  constructor(
+    private readonly labels: RetentionLabelRepository,
+    private readonly auditLogRepo?: AuditLogRepository,
+  ) {}
+
+  async get(periodId: string): Promise<RetentionLabel | null> {
+    this.assertPeriodId(periodId);
+    return this.labels.findByPeriodId(periodId);
+  }
+
+  async listActiveHolds(): Promise<RetentionLabel[]> {
+    return this.labels.listActiveHolds();
+  }
+
+  async proposeLegalHold(input: {
+    periodId: string;
+    actorId: string;
+    reason?: string;
+  }): Promise<RetentionLabel> {
+    this.assertPeriodId(input.periodId);
+    const existing = await this.labels.findByPeriodId(input.periodId);
+    if (existing?.legal_hold) {
+      throw new RetentionLabelError(
+        `Period ${input.periodId} already has an active legal hold`,
+        'ALREADY_ACTIVE',
+      );
+    }
+
+    const label = await this.labels.upsertProposeAdd({
+      periodId: input.periodId,
+      actorId: input.actorId,
+      reason: input.reason,
+    });
+
+    await this.audit('RETENTION_LEGAL_HOLD_PROPOSED', input.actorId, input.periodId, {
+      reason: input.reason ?? null,
+    });
+
+    return label;
+  }
+
+  async approveLegalHold(input: {
+    periodId: string;
+    actorId: string;
+  }): Promise<RetentionLabel> {
+    this.assertPeriodId(input.periodId);
+    const existing = await this.labels.findByPeriodId(input.periodId);
+    if (!existing) {
+      throw new RetentionLabelError(`No retention label for period ${input.periodId}`, 'NOT_FOUND');
+    }
+    if (existing.pending_action !== 'add') {
+      throw new RetentionLabelError(
+        `Period ${input.periodId} has no pending legal-hold add to approve`,
+        'WRONG_PENDING',
+      );
+    }
+    if (!existing.pending_proposed_by) {
+      throw new RetentionLabelError(
+        `Period ${input.periodId} is missing propose metadata`,
+        'PENDING_REQUIRED',
+      );
+    }
+    if (existing.pending_proposed_by === input.actorId) {
+      throw new RetentionLabelError(
+        'Approver must differ from proposer (dual-control)',
+        'DUAL_CONTROL',
+      );
+    }
+
+    const label = await this.labels.approveAdd(input);
+    await this.audit('RETENTION_LEGAL_HOLD_ACTIVATED', input.actorId, input.periodId, {
+      proposed_by: existing.pending_proposed_by,
+    });
+    return label;
+  }
+
+  async proposeLegalHoldRelease(input: {
+    periodId: string;
+    actorId: string;
+  }): Promise<RetentionLabel> {
+    this.assertPeriodId(input.periodId);
+    const existing = await this.labels.findByPeriodId(input.periodId);
+    if (!existing) {
+      throw new RetentionLabelError(`No retention label for period ${input.periodId}`, 'NOT_FOUND');
+    }
+    if (!existing.legal_hold) {
+      throw new RetentionLabelError(
+        `Period ${input.periodId} does not have an active legal hold`,
+        'NOT_ACTIVE',
+      );
+    }
+
+    const label = await this.labels.proposeRemove(input);
+    await this.audit('RETENTION_LEGAL_HOLD_RELEASE_PROPOSED', input.actorId, input.periodId, {});
+    return label;
+  }
+
+  async approveLegalHoldRelease(input: {
+    periodId: string;
+    actorId: string;
+  }): Promise<RetentionLabel> {
+    this.assertPeriodId(input.periodId);
+    const existing = await this.labels.findByPeriodId(input.periodId);
+    if (!existing) {
+      throw new RetentionLabelError(`No retention label for period ${input.periodId}`, 'NOT_FOUND');
+    }
+    if (existing.pending_action !== 'remove') {
+      throw new RetentionLabelError(
+        `Period ${input.periodId} has no pending legal-hold release to approve`,
+        'WRONG_PENDING',
+      );
+    }
+    if (!existing.pending_proposed_by) {
+      throw new RetentionLabelError(
+        `Period ${input.periodId} is missing propose metadata`,
+        'PENDING_REQUIRED',
+      );
+    }
+    if (existing.pending_proposed_by === input.actorId) {
+      throw new RetentionLabelError(
+        'Approver must differ from proposer (dual-control)',
+        'DUAL_CONTROL',
+      );
+    }
+
+    const label = await this.labels.approveRemove(input);
+    await this.audit('RETENTION_LEGAL_HOLD_RELEASED', input.actorId, input.periodId, {
+      proposed_by: existing.pending_proposed_by,
+      note: 'Rows re-enter purge eligibility on the next purge cycle only',
+    });
+    globalLogger.info('Legal hold released; purge eligibility deferred to next cycle', {
+      periodId: input.periodId,
+      actorId: input.actorId,
+    });
+    return label;
+  }
+
+  private assertPeriodId(periodId: string): void {
+    if (!PERIOD_ID_RE.test(periodId)) {
+      throw new RetentionLabelError(
+        `Invalid period_id '${periodId}'; expected YYYY-MM`,
+        'INVALID_PERIOD',
+      );
+    }
+  }
+
+  private async audit(
+    action: string,
+    actorId: string,
+    periodId: string,
+    details: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.auditLogRepo) {
+      return;
+    }
+    await this.auditLogRepo.createAuditLog({
+      user_id: actorId,
+      action,
+      resource: `retention_label:${periodId}`,
+      details: JSON.stringify(details),
+    });
+  }
+}


### PR DESCRIPTION
Add dual-controlled period holds that skip purge and emit purge.skipped_hold. Closes #565