### PR TITLE
feat: audit-log verifier CLI

### DIFF
--- a/docs/audit-log-hash-chain.md
+++ b/docs/audit-log-hash-chain.md
@@ -49,6 +49,42 @@ npm run verify-audit-integrity
 - Exit `0` — chain valid
 - Exit `1` — tamper detected or runtime error
 
+### Standalone Receipt Verifier CLI (Auditors)
+
+Auditors can verify an exported audit log excerpt against a published cryptographic receipt without running the application server or accessing the database:
+
+```bash
+npx ts-node scripts/verify-audit-receipt.ts --receipt <path-or-url-to-receipt> --excerpt <path-or-url-to-excerpt>
+```
+
+Or positional format:
+
+```bash
+npx ts-node scripts/verify-audit-receipt.ts <receipt.json> <excerpt.json-or-jsonl>
+```
+
+#### Verification Receipt Schema (`AuditReceipt`)
+
+```json
+{
+  "version": "revora-audit-receipt-v1",
+  "published_at": "2026-01-15T10:15:00.000Z",
+  "start_prev_hash": "bee58147dc813f93e3b43277b5da53c1a1620f2258f953b75a25fe5774f999be",
+  "expected_head_hash": "75da7a8205ab1cb890612851d7ae5ca2da6a390cca5df14754b75597ff8d1f7e",
+  "total_rows": 3,
+  "start_id": "00000000-0000-4000-8000-000000000001",
+  "end_id": "00000000-0000-4000-8000-000000000003",
+  "signature": "ed25519:abcdef1234567890"
+}
+```
+
+#### Exit Codes & Output Format
+
+- `0` — Pass: Step-by-step derivation trace confirms integrity of all log entries against the published receipt.
+- `1` — Fail: Tamper detected, missing entries (truncated excerpt), broken chain link, or missing receipt anchor. Emits actionable recovery recommendation details.
+
+Pass `--json` to output machine-readable JSON reports.
+
 ### Programmatic
 
 ```typescript

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,19 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/scripts'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
+    'scripts/**/*.ts',
     '!src/**/*.test.ts',
     '!src/**/*.d.ts',
     '!src/__tests__/**/*',
+    '!scripts/**/*.test.ts',
+    '!scripts/fixtures/**/*',
+    '!scripts/check-postmortem.ts',
+    '!scripts/indexer-replay.ts',
+    '!scripts/rbac-policy-diff.ts',
   ],
   coverageThreshold: {
     global: {

--- a/scripts/fixtures/audit/generate.ts
+++ b/scripts/fixtures/audit/generate.ts
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  AUDIT_LOG_GENESIS_HASH,
+  computeAuditRowHash,
+} from '../../../src/security/auditHashChain';
+
+const dir = __dirname;
+
+const row1Base = {
+  id: '00000000-0000-4000-8000-000000000001',
+  user_id: 'usr_101',
+  action: 'user.login',
+  resource: 'auth',
+  details: 'User logged in successfully',
+  ip_address: '192.168.1.1',
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0)',
+  created_at: new Date('2026-01-15T10:00:00.000Z'),
+  prev_hash: AUDIT_LOG_GENESIS_HASH,
+};
+const row1 = { ...row1Base, row_hash: computeAuditRowHash(row1Base) };
+
+const row2Base = {
+  id: '00000000-0000-4000-8000-000000000002',
+  user_id: 'usr_101',
+  action: 'offering.invest',
+  resource: 'offering_99',
+  details: 'Investment of 1000 USD',
+  ip_address: '192.168.1.1',
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0)',
+  created_at: new Date('2026-01-15T10:05:00.000Z'),
+  prev_hash: row1.row_hash,
+};
+const row2 = { ...row2Base, row_hash: computeAuditRowHash(row2Base) };
+
+const row3Base = {
+  id: '00000000-0000-4000-8000-000000000003',
+  user_id: 'usr_102',
+  action: 'kyc.verify',
+  resource: 'kyc_102',
+  details: 'Tier 2 verified',
+  ip_address: '10.0.0.5',
+  user_agent: 'RevoraApp/1.0',
+  created_at: new Date('2026-01-15T10:10:00.000Z'),
+  prev_hash: row2.row_hash,
+};
+const row3 = { ...row3Base, row_hash: computeAuditRowHash(row3Base) };
+
+const validExcerpt = [row1, row2, row3];
+
+const validReceipt = {
+  version: 'revora-audit-receipt-v1',
+  published_at: '2026-01-15T10:15:00.000Z',
+  start_prev_hash: AUDIT_LOG_GENESIS_HASH,
+  expected_head_hash: row3.row_hash,
+  total_rows: 3,
+  start_id: row1.id,
+  end_id: row3.id,
+  signature: 'ed25519:abcdef1234567890',
+};
+
+const truncatedExcerpt = [row1, row2]; // missing row3
+
+const tamperedExcerpt = [
+  row1,
+  {
+    ...row2,
+    details: 'Investment of 999999 USD (FORGED)', // modified payload
+  },
+  row3,
+];
+
+fs.mkdirSync(dir, { recursive: true });
+fs.writeFileSync(path.join(dir, 'valid-receipt.json'), JSON.stringify(validReceipt, null, 2));
+fs.writeFileSync(path.join(dir, 'valid-excerpt.json'), JSON.stringify(validExcerpt, null, 2));
+fs.writeFileSync(path.join(dir, 'truncated-excerpt.json'), JSON.stringify(truncatedExcerpt, null, 2));
+fs.writeFileSync(path.join(dir, 'tampered-excerpt.json'), JSON.stringify(tamperedExcerpt, null, 2));
+
+console.log('Fixtures generated successfully in', dir);

--- a/scripts/fixtures/audit/tampered-excerpt.json
+++ b/scripts/fixtures/audit/tampered-excerpt.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "user_id": "usr_101",
+    "action": "user.login",
+    "resource": "auth",
+    "details": "User logged in successfully",
+    "ip_address": "192.168.1.1",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0)",
+    "created_at": "2026-01-15T10:00:00.000Z",
+    "prev_hash": "bee58147dc813f93e3b43277b5da53c1a1620f2258f953b75a25fe5774f999be",
+    "row_hash": "a3e229a68b3c83900e4336016e82497741df9e61d15dbeece37d21d20b7208ba"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000000002",
+    "user_id": "usr_101",
+    "action": "offering.invest",
+    "resource": "offering_99",
+    "details": "Investment of 999999 USD (FORGED)",
+    "ip_address": "192.168.1.1",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0)",
+    "created_at": "2026-01-15T10:05:00.000Z",
+    "prev_hash": "a3e229a68b3c83900e4336016e82497741df9e61d15dbeece37d21d20b7208ba",
+    "row_hash": "195c4364aed08e4ed3a82422eef7910b96fdbdf1947c751728751517241d93d8"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000000003",
+    "user_id": "usr_102",
+    "action": "kyc.verify",
+    "resource": "kyc_102",
+    "details": "Tier 2 verified",
+    "ip_address": "10.0.0.5",
+    "user_agent": "RevoraApp/1.0",
+    "created_at": "2026-01-15T10:10:00.000Z",
+    "prev_hash": "195c4364aed08e4ed3a82422eef7910b96fdbdf1947c751728751517241d93d8",
+    "row_hash": "75da7a8205ab1cb890612851d7ae5ca2da6a390cca5df14754b75597ff8d1f7e"
+  }
+]

--- a/scripts/fixtures/audit/truncated-excerpt.json
+++ b/scripts/fixtures/audit/truncated-excerpt.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "user_id": "usr_101",
+    "action": "user.login",
+    "resource": "auth",
+    "details": "User logged in successfully",
+    "ip_address": "192.168.1.1",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0)",
+    "created_at": "2026-01-15T10:00:00.000Z",
+    "prev_hash": "bee58147dc813f93e3b43277b5da53c1a1620f2258f953b75a25fe5774f999be",
+    "row_hash": "a3e229a68b3c83900e4336016e82497741df9e61d15dbeece37d21d20b7208ba"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000000002",
+    "user_id": "usr_101",
+    "action": "offering.invest",
+    "resource": "offering_99",
+    "details": "Investment of 1000 USD",
+    "ip_address": "192.168.1.1",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0)",
+    "created_at": "2026-01-15T10:05:00.000Z",
+    "prev_hash": "a3e229a68b3c83900e4336016e82497741df9e61d15dbeece37d21d20b7208ba",
+    "row_hash": "195c4364aed08e4ed3a82422eef7910b96fdbdf1947c751728751517241d93d8"
+  }
+]

--- a/scripts/fixtures/audit/valid-excerpt.json
+++ b/scripts/fixtures/audit/valid-excerpt.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "user_id": "usr_101",
+    "action": "user.login",
+    "resource": "auth",
+    "details": "User logged in successfully",
+    "ip_address": "192.168.1.1",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0)",
+    "created_at": "2026-01-15T10:00:00.000Z",
+    "prev_hash": "bee58147dc813f93e3b43277b5da53c1a1620f2258f953b75a25fe5774f999be",
+    "row_hash": "a3e229a68b3c83900e4336016e82497741df9e61d15dbeece37d21d20b7208ba"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000000002",
+    "user_id": "usr_101",
+    "action": "offering.invest",
+    "resource": "offering_99",
+    "details": "Investment of 1000 USD",
+    "ip_address": "192.168.1.1",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0)",
+    "created_at": "2026-01-15T10:05:00.000Z",
+    "prev_hash": "a3e229a68b3c83900e4336016e82497741df9e61d15dbeece37d21d20b7208ba",
+    "row_hash": "195c4364aed08e4ed3a82422eef7910b96fdbdf1947c751728751517241d93d8"
+  },
+  {
+    "id": "00000000-0000-4000-8000-000000000003",
+    "user_id": "usr_102",
+    "action": "kyc.verify",
+    "resource": "kyc_102",
+    "details": "Tier 2 verified",
+    "ip_address": "10.0.0.5",
+    "user_agent": "RevoraApp/1.0",
+    "created_at": "2026-01-15T10:10:00.000Z",
+    "prev_hash": "195c4364aed08e4ed3a82422eef7910b96fdbdf1947c751728751517241d93d8",
+    "row_hash": "75da7a8205ab1cb890612851d7ae5ca2da6a390cca5df14754b75597ff8d1f7e"
+  }
+]

--- a/scripts/fixtures/audit/valid-receipt.json
+++ b/scripts/fixtures/audit/valid-receipt.json
@@ -1,0 +1,10 @@
+{
+  "version": "revora-audit-receipt-v1",
+  "published_at": "2026-01-15T10:15:00.000Z",
+  "start_prev_hash": "bee58147dc813f93e3b43277b5da53c1a1620f2258f953b75a25fe5774f999be",
+  "expected_head_hash": "75da7a8205ab1cb890612851d7ae5ca2da6a390cca5df14754b75597ff8d1f7e",
+  "total_rows": 3,
+  "start_id": "00000000-0000-4000-8000-000000000001",
+  "end_id": "00000000-0000-4000-8000-000000000003",
+  "signature": "ed25519:abcdef1234567890"
+}

--- a/scripts/verify-audit-receipt.test.ts
+++ b/scripts/verify-audit-receipt.test.ts
@@ -1,0 +1,732 @@
+import fs from 'fs';
+import http from 'http';
+import https from 'https';
+import path from 'path';
+import {
+  AUDIT_LOG_GENESIS_HASH,
+  AuditLogChainRow,
+  computeAuditRowHash,
+} from '../src/security/auditHashChain';
+import {
+  AuditReceipt,
+  formatReport,
+  loadContent,
+  normalizeReceipt,
+  parseCliArgs,
+  parseLogExcerpt,
+  printHelp,
+  runCli,
+  verifyAuditReceipt,
+} from './verify-audit-receipt';
+
+// Mock fs.promises.readFile for loadContent tests
+jest.mock('fs', () => {
+  const actualFs = jest.requireActual('fs');
+  return {
+    ...actualFs,
+    promises: {
+      ...actualFs.promises,
+      readFile: jest.fn(),
+    },
+  };
+});
+
+describe('verify-audit-receipt script', () => {
+  const makeRow = (
+    overrides: Partial<AuditLogChainRow> & Pick<AuditLogChainRow, 'id' | 'action' | 'created_at'>,
+    prevHash: string = AUDIT_LOG_GENESIS_HASH,
+  ): AuditLogChainRow => {
+    const base: Omit<AuditLogChainRow, 'row_hash'> = {
+      id: overrides.id,
+      user_id: overrides.user_id ?? null,
+      action: overrides.action,
+      resource: overrides.resource ?? null,
+      details: overrides.details ?? null,
+      ip_address: overrides.ip_address ?? null,
+      user_agent: overrides.user_agent ?? null,
+      created_at: overrides.created_at,
+      prev_hash: overrides.prev_hash ?? prevHash,
+    };
+    return {
+      ...base,
+      row_hash: overrides.row_hash ?? computeAuditRowHash(base),
+    };
+  };
+
+  const createTestChain = (): AuditLogChainRow[] => {
+    const r1 = makeRow({
+      id: '00000000-0000-4000-8000-000000000001',
+      action: 'login',
+      created_at: new Date('2026-01-15T10:00:00.000Z'),
+    });
+    const r2 = makeRow(
+      {
+        id: '00000000-0000-4000-8000-000000000002',
+        action: 'invest',
+        created_at: new Date('2026-01-15T10:05:00.000Z'),
+      },
+      r1.row_hash,
+    );
+    const r3 = makeRow(
+      {
+        id: '00000000-0000-4000-8000-000000000003',
+        action: 'logout',
+        created_at: new Date('2026-01-15T10:10:00.000Z'),
+      },
+      r2.row_hash,
+    );
+    return [r1, r2, r3];
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('normalizeReceipt', () => {
+    it('normalizes alias fields for receipt parameters', () => {
+      const raw: AuditReceipt = {
+        prev_hash: 'start123',
+        head_hash: 'head456',
+        count: 5,
+      };
+      const normalized = normalizeReceipt(raw);
+      expect(normalized.start_prev_hash).toBe('start123');
+      expect(normalized.expected_head_hash).toBe('head456');
+      expect(normalized.total_rows).toBe(5);
+    });
+
+    it('supports alternative alias field names: initial_prev_hash, final_hash, row_count', () => {
+      const raw: AuditReceipt = {
+        initial_prev_hash: 'init123',
+        final_hash: 'final456',
+        row_count: 10,
+      };
+      const normalized = normalizeReceipt(raw);
+      expect(normalized.start_prev_hash).toBe('init123');
+      expect(normalized.expected_head_hash).toBe('final456');
+      expect(normalized.total_rows).toBe(10);
+    });
+
+    it('supports alternative alias field names: final_row_hash and row_hash', () => {
+      const raw1: AuditReceipt = { final_row_hash: 'frh' };
+      const raw2: AuditReceipt = { row_hash: 'rh' };
+      expect(normalizeReceipt(raw1).expected_head_hash).toBe('frh');
+      expect(normalizeReceipt(raw2).expected_head_hash).toBe('rh');
+    });
+  });
+
+  describe('parseLogExcerpt', () => {
+    it('returns empty array for empty or whitespace content', () => {
+      expect(parseLogExcerpt('')).toEqual([]);
+      expect(parseLogExcerpt('   \n  ')).toEqual([]);
+    });
+
+    it('parses JSON array', () => {
+      const rows = createTestChain();
+      const content = JSON.stringify(rows);
+      const parsed = parseLogExcerpt(content);
+      expect(parsed).toHaveLength(3);
+      expect(parsed[0].id).toBe(rows[0].id);
+      expect(parsed[0].created_at).toBeInstanceOf(Date);
+    });
+
+    it('parses newline-delimited JSON (JSONL)', () => {
+      const rows = createTestChain();
+      const content = rows.map((r) => JSON.stringify(r)).join('\n');
+      const parsed = parseLogExcerpt(content);
+      expect(parsed).toHaveLength(3);
+      expect(parsed[1].action).toBe('invest');
+    });
+
+    it('handles numeric epoch timestamps and null fields', () => {
+      const raw = [
+        {
+          id: 'row-x',
+          action: 'test',
+          created_at: 1768471200000,
+          user_id: null,
+        },
+      ];
+      const parsed = parseLogExcerpt(JSON.stringify(raw));
+      expect(parsed[0].created_at.getTime()).toBe(1768471200000);
+      expect(parsed[0].user_id).toBeNull();
+    });
+
+    it('parses raw entries with non-null string fields', () => {
+      const raw = [
+        {
+          id: 'row-full',
+          user_id: 'usr_99',
+          action: 'act_full',
+          resource: 'res_99',
+          details: 'det_99',
+          ip_address: '1.2.3.4',
+          user_agent: 'agent_99',
+          created_at: '2026-01-15T10:00:00.000Z',
+          prev_hash: 'ph',
+          row_hash: 'rh',
+        },
+      ];
+      const parsed = parseLogExcerpt(JSON.stringify(raw));
+      expect(parsed[0].user_id).toBe('usr_99');
+      expect(parsed[0].resource).toBe('res_99');
+      expect(parsed[0].details).toBe('det_99');
+      expect(parsed[0].ip_address).toBe('1.2.3.4');
+      expect(parsed[0].user_agent).toBe('agent_99');
+    });
+  });
+
+  describe('loadContent', () => {
+    it('reads local file via fs.promises.readFile', async () => {
+      (fs.promises.readFile as jest.Mock).mockResolvedValue('file-data');
+      const res = await loadContent('test.json');
+      expect(res).toBe('file-data');
+    });
+
+    it('fetches content over HTTP', async () => {
+      const mockReq = {
+        on: jest.fn().mockImplementation((event, cb) => {
+          return mockReq;
+        }),
+      };
+      const mockRes = {
+        statusCode: 200,
+        on: jest.fn().mockImplementation((event, cb) => {
+          if (event === 'data') cb('http-data');
+          if (event === 'end') cb();
+        }),
+      };
+
+      jest.spyOn(http, 'get').mockImplementation((url, cb: any) => {
+        cb(mockRes);
+        return mockReq as any;
+      });
+
+      const data = await loadContent('http://example.com/receipt.json');
+      expect(data).toBe('http-data');
+    });
+
+    it('fetches content over HTTPS', async () => {
+      const mockReq = {
+        on: jest.fn().mockImplementation((event, cb) => mockReq),
+      };
+      const mockRes = {
+        statusCode: 200,
+        on: jest.fn().mockImplementation((event, cb) => {
+          if (event === 'data') cb('https-data');
+          if (event === 'end') cb();
+        }),
+      };
+
+      jest.spyOn(https, 'get').mockImplementation((url, cb: any) => {
+        cb(mockRes);
+        return mockReq as any;
+      });
+
+      const data = await loadContent('https://example.com/receipt.json');
+      expect(data).toBe('https-data');
+    });
+
+    it('rejects on HTTP error status', async () => {
+      const mockReq = {
+        on: jest.fn().mockImplementation((event, cb) => mockReq),
+      };
+      const mockRes = {
+        statusCode: 404,
+      };
+
+      jest.spyOn(http, 'get').mockImplementation((url, cb: any) => {
+        cb(mockRes);
+        return mockReq as any;
+      });
+
+      await expect(loadContent('http://example.com/404.json')).rejects.toThrow('HTTP 404');
+    });
+
+    it('rejects on HTTPS error status', async () => {
+      const mockReq = {
+        on: jest.fn().mockImplementation((event, cb) => mockReq),
+      };
+      const mockRes = {
+        statusCode: 404,
+      };
+
+      jest.spyOn(https, 'get').mockImplementation((url, cb: any) => {
+        cb(mockRes);
+        return mockReq as any;
+      });
+
+      await expect(loadContent('https://example.com/404.json')).rejects.toThrow('HTTP 404');
+    });
+
+    it('rejects on request network error', async () => {
+      const mockReq = {
+        on: jest.fn().mockImplementation((event, cb) => {
+          if (event === 'error') cb(new Error('Connection refused'));
+          return mockReq;
+        }),
+      };
+
+      jest.spyOn(http, 'get').mockImplementation(() => mockReq as any);
+
+      await expect(loadContent('http://example.com/error.json')).rejects.toThrow('Connection refused');
+    });
+  });
+
+  describe('verifyAuditReceipt', () => {
+    it('verifies a valid multi-row chain against matching receipt', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = {
+        start_prev_hash: AUDIT_LOG_GENESIS_HASH,
+        expected_head_hash: rows[2].row_hash,
+        total_rows: 3,
+        start_id: rows[0].id,
+        end_id: rows[2].id,
+      };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(true);
+      expect(res.verifiedEntries).toBe(3);
+      expect(res.computedHeadHash).toBe(rows[2].row_hash);
+    });
+
+    it('accepts an empty excerpt when receipt total_rows is 0', () => {
+      const receipt: AuditReceipt = { total_rows: 0 };
+      const res = verifyAuditReceipt(receipt, []);
+      expect(res.valid).toBe(true);
+      expect(res.totalEntries).toBe(0);
+    });
+
+    it('returns EMPTY_EXCERPT failure when excerpt is empty but total_rows > 0', () => {
+      const receipt: AuditReceipt = { total_rows: 5 };
+      const res = verifyAuditReceipt(receipt, []);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('EMPTY_EXCERPT');
+      expect(res.actionableRecommendation).toMatch(/matching the receipt period/i);
+    });
+
+    it('returns TRUNCATED_EXCERPT with actionable error when excerpt has fewer rows than expected', () => {
+      const rows = createTestChain().slice(0, 2); // 2 rows instead of 3
+      const receipt: AuditReceipt = {
+        total_rows: 3,
+        start_id: '00000000-0000-4000-8000-000000000001',
+        end_id: '00000000-0000-4000-8000-000000000003',
+      };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('TRUNCATED_EXCERPT');
+      expect(res.message).toContain('Log excerpt is truncated: received 2 entries, but receipt expected 3');
+      expect(res.actionableRecommendation).toContain('Ensure the log export includes all 3 entries without truncation');
+    });
+
+    it('returns ROW_COUNT_MISMATCH when excerpt has more rows than expected', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = { total_rows: 2 };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('ROW_COUNT_MISMATCH');
+    });
+
+    it('returns START_ID_MISMATCH when first row ID does not match start_id', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = { start_id: 'different-id' };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('START_ID_MISMATCH');
+    });
+
+    it('returns END_ID_MISMATCH when last row ID does not match end_id', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = { end_id: 'different-id' };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('END_ID_MISMATCH');
+    });
+
+    it('returns START_HASH_MISMATCH when starting prev_hash does not match receipt', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = { start_prev_hash: 'a'.repeat(64) };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('START_HASH_MISMATCH');
+    });
+
+    it('returns MISSING_HASHES when a row is missing hash fields', () => {
+      const rows = createTestChain();
+      rows[1].row_hash = '';
+
+      const receipt: AuditReceipt = {};
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('MISSING_HASHES');
+    });
+
+    it('returns BROKEN_CHAIN when genesis anchor is broken at row 0', () => {
+      const rows = createTestChain();
+      const brokenRow0Base = { ...rows[0], prev_hash: 'wrong_prev' };
+      rows[0] = { ...brokenRow0Base, row_hash: computeAuditRowHash(brokenRow0Base) };
+
+      const receipt: AuditReceipt = {};
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('BROKEN_CHAIN');
+    });
+
+    it('returns GAP_DETECTED when mid-chain prev_hash link is broken', () => {
+      const rows = createTestChain();
+      rows[2] = { ...rows[2], prev_hash: 'broken_link' };
+
+      const receipt: AuditReceipt = {};
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('GAP_DETECTED');
+      expect(res.message).toMatch(/gap or deleted entry/i);
+    });
+
+    it('returns HASH_MISMATCH when payload was tampered with', () => {
+      const rows = createTestChain();
+      rows[1] = { ...rows[1], action: 'tampered_action' };
+
+      const receipt: AuditReceipt = {};
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('HASH_MISMATCH');
+      expect(res.actionableRecommendation).toMatch(/integrity check failed/i);
+    });
+
+    it('returns HEAD_HASH_MISMATCH when computed head hash differs from receipt expected_head_hash', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = { expected_head_hash: 'f'.repeat(64) };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(false);
+      expect(res.failureType).toBe('HEAD_HASH_MISMATCH');
+    });
+  });
+
+  describe('formatReport', () => {
+    it('formats human-readable report for passing verification', () => {
+      const rows = createTestChain();
+      const res = verifyAuditReceipt({ expected_head_hash: rows[2].row_hash }, rows);
+      const output = formatReport(res, 'receipt.json', 'excerpt.json');
+
+      expect(output).toContain('AUDIT LOG INTEGRITY VERIFICATION REPORT');
+      expect(output).toContain('PASS [VALID INTEGRITY PROOF]');
+      expect(output).toContain('VERIFICATION RESULT: SUCCESS');
+    });
+
+    it('formats human-readable report for failing verification', () => {
+      const res = verifyAuditReceipt({ total_rows: 5 }, []);
+      const output = formatReport(res, 'receipt.json', 'excerpt.json');
+
+      expect(output).toContain('FAIL [TAMPER OR INVALID PROOF]');
+      expect(output).toContain('VERIFICATION RESULT: FAILURE [EMPTY_EXCERPT]');
+      expect(output).toContain('Action Required:');
+    });
+
+    it('suppresses derivation trace when quiet option is true', () => {
+      const rows = createTestChain();
+      const res = verifyAuditReceipt({ expected_head_hash: rows[2].row_hash }, rows);
+      const output = formatReport(res, undefined, undefined, true);
+
+      expect(output).not.toContain('DERIVATION TRACE:');
+    });
+  });
+
+  describe('parseCliArgs and printHelp', () => {
+    it('parses flag options', () => {
+      const opts = parseCliArgs([
+        '--receipt',
+        'r.json',
+        '--entries',
+        'e.json',
+        '--json',
+        '--quiet',
+      ]);
+      expect(opts.receiptPathOrUrl).toBe('r.json');
+      expect(opts.excerptPathOrUrl).toBe('e.json');
+      expect(opts.jsonOutput).toBe(true);
+      expect(opts.quiet).toBe(true);
+    });
+
+    it('parses short flag options -r, -e, -q', () => {
+      const opts = parseCliArgs(['-r', 'r.json', '-e', 'e.json', '-q']);
+      expect(opts.receiptPathOrUrl).toBe('r.json');
+      expect(opts.excerptPathOrUrl).toBe('e.json');
+      expect(opts.quiet).toBe(true);
+    });
+
+    it('parses positional arguments and help flag', () => {
+      const opts = parseCliArgs(['pos-r.json', 'pos-e.json', '-h']);
+      expect(opts.receiptPathOrUrl).toBe('pos-r.json');
+      expect(opts.excerptPathOrUrl).toBe('pos-e.json');
+      expect(opts.help).toBe(true);
+    });
+
+    it('prints help message', () => {
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      printHelp();
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Audit Log Receipt Verifier CLI'));
+    });
+  });
+
+  describe('runCli', () => {
+    it('prints help and exits with 0 when -h is passed', async () => {
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const code = await runCli(['-h']);
+      expect(code).toBe(0);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('prints error and exits with 1 when arguments are missing', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const code = await runCli([]);
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Both receipt and excerpt'));
+    });
+
+    it('exits with 0 when verification succeeds', async () => {
+      const rows = createTestChain();
+      const receipt = { total_rows: 3, expected_head_hash: rows[2].row_hash };
+
+      (fs.promises.readFile as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(receipt))
+        .mockResolvedValueOnce(JSON.stringify(rows));
+
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const code = await runCli(['r.json', 'e.json']);
+
+      expect(code).toBe(0);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('PASS [VALID INTEGRITY PROOF]'));
+    });
+
+    it('outputs JSON when --json flag is passed', async () => {
+      const rows = createTestChain();
+      const receipt = { total_rows: 3, expected_head_hash: rows[2].row_hash };
+
+      (fs.promises.readFile as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(receipt))
+        .mockResolvedValueOnce(JSON.stringify(rows));
+
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const code = await runCli(['r.json', 'e.json', '--json']);
+
+      expect(code).toBe(0);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('"valid": true'));
+    });
+
+    it('exits with 1 when verification fails', async () => {
+      const receipt = { total_rows: 5 };
+
+      (fs.promises.readFile as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(receipt))
+        .mockResolvedValueOnce(JSON.stringify([]));
+
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const code = await runCli(['r.json', 'e.json']);
+
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('FAIL'));
+    });
+
+    it('handles runtime error cleanly (e.g. invalid JSON)', async () => {
+      (fs.promises.readFile as jest.Mock).mockResolvedValue('invalid-json');
+
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const code = await runCli(['r.json', 'e.json']);
+
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('[VERIFIER ERROR]'));
+    });
+
+    it('handles runtime error with --json flag', async () => {
+      (fs.promises.readFile as jest.Mock).mockResolvedValue('invalid-json');
+
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const code = await runCli(['r.json', 'e.json', '--json']);
+
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('"failureType":"RUNTIME_ERROR"'));
+    });
+
+    it('handles non-Error exception objects gracefully in runCli', async () => {
+      (fs.promises.readFile as jest.Mock).mockRejectedValue('String exception error');
+
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const code = await runCli(['r.json', 'e.json']);
+
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('String exception error'));
+    });
+
+    it('verifies start_id and end_id matching when both match', () => {
+      const rows = createTestChain();
+      const receipt: AuditReceipt = {
+        start_id: rows[0].id,
+        end_id: rows[2].id,
+        start_prev_hash: AUDIT_LOG_GENESIS_HASH,
+        expected_head_hash: rows[2].row_hash,
+      };
+
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.valid).toBe(true);
+    });
+
+    it('parses Date object instances in raw entries', () => {
+      const dateObj = new Date('2026-01-15T10:00:00.000Z');
+      const raw = [{ id: '1', created_at: dateObj, action: 'act' }];
+      const parsed = parseLogExcerpt(JSON.stringify(raw));
+      expect(parsed[0].created_at).toEqual(dateObj);
+    });
+
+    it('sorts entries with identical timestamp using id tie-breaker', () => {
+      const sameDate = new Date('2026-01-15T10:00:00.000Z');
+      const rA = makeRow({ id: 'a-id', action: 'actionA', created_at: sameDate });
+      const rB = makeRow({ id: 'b-id', action: 'actionB', created_at: sameDate }, rA.row_hash);
+
+      const res = verifyAuditReceipt(
+        {
+          total_rows: 2,
+          start_prev_hash: AUDIT_LOG_GENESIS_HASH,
+          expected_head_hash: rB.row_hash,
+        },
+        [rB, rA],
+      );
+      expect(res.valid).toBe(true);
+    });
+
+    it('formats report displaying step error details when step.error is present', () => {
+      const rows = createTestChain();
+      rows[1] = { ...rows[1], action: 'tampered' };
+      const res = verifyAuditReceipt({}, rows);
+      const report = formatReport(res);
+      expect(report).toContain('Error:');
+    });
+
+    it('returns TRUNCATED_EXCERPT displaying start_id and end_id when specified on receipt', () => {
+      const rows = createTestChain().slice(0, 1);
+      const receipt: AuditReceipt = {
+        total_rows: 3,
+        start_id: 'id-start',
+        end_id: 'id-end',
+      };
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.actionableRecommendation).toContain('from start_id (id-start) to end_id (id-end)');
+    });
+
+    it('verifies valid chain when expected_head_hash is omitted from receipt', () => {
+      const rows = createTestChain();
+      const res = verifyAuditReceipt({}, rows);
+      expect(res.valid).toBe(true);
+      expect(res.receiptHeadHash).toBe(rows[2].row_hash);
+    });
+
+    it('formats report with empty computedHash step and no actionable recommendation', () => {
+      const res = {
+        valid: false,
+        totalEntries: 1,
+        verifiedEntries: 0,
+        failureType: 'TEST_FAIL' as any,
+        message: 'Test message',
+        derivationTrace: [
+          {
+            index: 0,
+            rowId: 'row-1',
+            timestamp: '2026-01-15T10:00:00.000Z',
+            prevHashMatch: false,
+            computedHash: '',
+            storedHash: 'stored',
+            hashMatch: false,
+          },
+        ],
+        durationMs: 1,
+      };
+
+      const output = formatReport(res);
+      expect(output).toContain('Computed: N/A');
+      expect(output).not.toContain('Action Required:');
+    });
+
+    it('handles http response with undefined statusCode', async () => {
+      const mockReq = { on: jest.fn().mockImplementation(() => mockReq) };
+      const mockRes = {
+        statusCode: undefined,
+        on: jest.fn().mockImplementation((event: string, cb: any) => {
+          if (event === 'data') cb('no-status-data');
+          if (event === 'end') cb();
+        }),
+      };
+
+      jest.spyOn(http, 'get').mockImplementation((url: any, cb: any) => {
+        cb(mockRes);
+        return mockReq as any;
+      });
+
+      const res = await loadContent('http://example.com/nostatus.json');
+      expect(res).toBe('no-status-data');
+    });
+
+    it('handles https response with undefined statusCode', async () => {
+      const mockReq = { on: jest.fn().mockImplementation(() => mockReq) };
+      const mockRes = {
+        statusCode: undefined,
+        on: jest.fn().mockImplementation((event: string, cb: any) => {
+          if (event === 'data') cb('no-status-https-data');
+          if (event === 'end') cb();
+        }),
+      };
+
+      jest.spyOn(https, 'get').mockImplementation((url: any, cb: any) => {
+        cb(mockRes);
+        return mockReq as any;
+      });
+
+      const res = await loadContent('https://example.com/nostatus.json');
+      expect(res).toBe('no-status-https-data');
+    });
+
+    it('returns TRUNCATED_EXCERPT with start_id set and end_id omitted', () => {
+      const rows = createTestChain().slice(0, 1);
+      const receipt: AuditReceipt = { total_rows: 3, start_id: 'start-10' };
+      const res = verifyAuditReceipt(receipt, rows);
+      expect(res.actionableRecommendation).toContain('from start_id (start-10) to end_id (N/A)');
+    });
+
+    it('exits with 1 in runCli when only receipt is provided without excerpt', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const code = await runCli(['-r', 'r.json']);
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Both receipt and excerpt'));
+    });
+
+    it('exits with 1 in runCli when only excerpt is provided without receipt', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const code = await runCli(['-e', 'e.json']);
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Both receipt and excerpt'));
+    });
+
+    it('handles positional args when receipt flag is already set', () => {
+      const opts = parseCliArgs(['--receipt', 'flag-r.json', 'pos.json']);
+      expect(opts.receiptPathOrUrl).toBe('flag-r.json');
+      expect(opts.excerptPathOrUrl).toBe('pos.json');
+    });
+
+    it('handles positional args when excerpt flag is already set', () => {
+      const opts = parseCliArgs(['--excerpt', 'flag-e.json', 'pos-r.json']);
+      expect(opts.receiptPathOrUrl).toBe('pos-r.json');
+      expect(opts.excerptPathOrUrl).toBe('flag-e.json');
+    });
+
+    it('ignores unknown flag arguments in parseCliArgs', () => {
+      const opts = parseCliArgs(['--unknown-flag', '-r', 'r.json', '-e', 'e.json']);
+      expect(opts.receiptPathOrUrl).toBe('r.json');
+      expect(opts.excerptPathOrUrl).toBe('e.json');
+    });
+  });
+});

--- a/scripts/verify-audit-receipt.ts
+++ b/scripts/verify-audit-receipt.ts
@@ -1,0 +1,625 @@
+#!/usr/bin/env node
+/**
+ * Standalone CLI: Audit Log Receipt Verifier
+ *
+ * Verifies an audit log excerpt against a published receipt without requiring
+ * application server execution or PostgreSQL database connection.
+ *
+ * Usage:
+ *   npx ts-node scripts/verify-audit-receipt.ts --receipt <path-or-url> --excerpt <path-or-url>
+ *   npx ts-node scripts/verify-audit-receipt.ts <receipt-path-or-url> <excerpt-path-or-url>
+ *
+ * Exit code 0 on success, 1 on verification failure or runtime error.
+ */
+
+import fs from 'fs';
+import http from 'http';
+import https from 'https';
+import path from 'path';
+import {
+  AUDIT_LOG_GENESIS_HASH,
+  AuditLogChainRow,
+  buildAuditCanonicalPayload,
+  computeAuditRowHash,
+} from '../src/security/auditHashChain';
+
+export interface AuditReceipt {
+  version?: string;
+  published_at?: string;
+  start_prev_hash?: string;
+  expected_head_hash?: string;
+  total_rows?: number;
+  start_id?: string;
+  end_id?: string;
+  signature?: string;
+  metadata?: Record<string, unknown>;
+
+  // Common field aliases for flexibility
+  prev_hash?: string;
+  initial_prev_hash?: string;
+  head_hash?: string;
+  final_hash?: string;
+  final_row_hash?: string;
+  row_hash?: string;
+  count?: number;
+  row_count?: number;
+}
+
+export type ReceiptVerificationFailureType =
+  | 'INVALID_RECEIPT'
+  | 'EMPTY_EXCERPT'
+  | 'TRUNCATED_EXCERPT'
+  | 'ROW_COUNT_MISMATCH'
+  | 'START_HASH_MISMATCH'
+  | 'BROKEN_CHAIN'
+  | 'GAP_DETECTED'
+  | 'HASH_MISMATCH'
+  | 'HEAD_HASH_MISMATCH'
+  | 'START_ID_MISMATCH'
+  | 'END_ID_MISMATCH'
+  | 'MISSING_HASHES';
+
+export interface DerivationStep {
+  index: number;
+  rowId: string;
+  timestamp: string;
+  prevHashMatch: boolean;
+  computedHash: string;
+  storedHash: string;
+  hashMatch: boolean;
+  error?: string;
+}
+
+export interface ReceiptVerificationResult {
+  valid: boolean;
+  failureType?: ReceiptVerificationFailureType;
+  message?: string;
+  actionableRecommendation?: string;
+  totalEntries: number;
+  verifiedEntries: number;
+  expectedEntries?: number;
+  receiptHeadHash?: string;
+  computedHeadHash?: string;
+  derivationTrace: DerivationStep[];
+  durationMs: number;
+}
+
+export interface CliOptions {
+  receiptPathOrUrl?: string;
+  excerptPathOrUrl?: string;
+  jsonOutput?: boolean;
+  quiet?: boolean;
+  help?: boolean;
+}
+
+/**
+ * Fetch content from HTTP/HTTPS URL or read from local filesystem.
+ */
+export async function loadContent(inputPathOrUrl: string): Promise<string> {
+  if (/^https?:\/\//i.test(inputPathOrUrl)) {
+    const client = inputPathOrUrl.toLowerCase().startsWith('https') ? https : http;
+    return new Promise((resolve, reject) => {
+      client
+        .get(inputPathOrUrl, (res) => {
+          const status = res.statusCode || 200;
+          if (status >= 400) {
+            return reject(
+              new Error(`HTTP ${status} fetching ${inputPathOrUrl}`),
+            );
+          }
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => resolve(data));
+        })
+        .on('error', reject);
+    });
+  }
+
+  const resolvedPath = path.resolve(process.cwd(), inputPathOrUrl);
+  return fs.promises.readFile(resolvedPath, 'utf8');
+}
+
+/**
+ * Parse log excerpt content from JSON array or newline-delimited JSON (JSONL).
+ */
+export function parseLogExcerpt(content: string): AuditLogChainRow[] {
+  const trimmed = content.trim();
+  if (!trimmed) return [];
+
+  let rawRows: any[] = [];
+  if (trimmed.startsWith('[')) {
+    rawRows = JSON.parse(trimmed);
+  } else {
+    rawRows = trimmed
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line));
+  }
+
+  return rawRows.map((r) => ({
+    id: String(r.id ?? ''),
+    user_id: r.user_id == null ? null : String(r.user_id),
+    action: String(r.action ?? ''),
+    resource: r.resource == null ? null : String(r.resource),
+    details: r.details == null ? null : String(r.details),
+    ip_address: r.ip_address == null ? null : String(r.ip_address),
+    user_agent: r.user_agent == null ? null : String(r.user_agent),
+    created_at:
+      r.created_at instanceof Date
+        ? r.created_at
+        : new Date(typeof r.created_at === 'number' ? r.created_at : String(r.created_at)),
+    prev_hash: String(r.prev_hash ?? ''),
+    row_hash: String(r.row_hash ?? ''),
+  }));
+}
+
+/**
+ * Normalize receipt options taking alias fields into account.
+ */
+export function normalizeReceipt(rawReceipt: AuditReceipt): AuditReceipt {
+  return {
+    ...rawReceipt,
+    start_prev_hash:
+      rawReceipt.start_prev_hash ??
+      rawReceipt.initial_prev_hash ??
+      rawReceipt.prev_hash,
+    expected_head_hash:
+      rawReceipt.expected_head_hash ??
+      rawReceipt.head_hash ??
+      rawReceipt.final_hash ??
+      rawReceipt.final_row_hash ??
+      rawReceipt.row_hash,
+    total_rows:
+      rawReceipt.total_rows ?? rawReceipt.count ?? rawReceipt.row_count,
+  };
+}
+
+/**
+ * Perform hash chain reconstruction and verify excerpt against receipt.
+ */
+export function verifyAuditReceipt(
+  rawReceipt: AuditReceipt,
+  entries: AuditLogChainRow[],
+): ReceiptVerificationResult {
+  const startTime = Date.now();
+  const receipt = normalizeReceipt(rawReceipt);
+
+  const derivationTrace: DerivationStep[] = [];
+
+  const expectedCount = receipt.total_rows;
+  const expectedHeadHash = receipt.expected_head_hash;
+  const startPrevHash = receipt.start_prev_hash;
+
+  if (entries.length === 0) {
+    if (expectedCount === 0) {
+      return {
+        valid: true,
+        totalEntries: 0,
+        verifiedEntries: 0,
+        expectedEntries: 0,
+        derivationTrace: [],
+        durationMs: Date.now() - startTime,
+      };
+    }
+    return {
+      valid: false,
+      failureType: 'EMPTY_EXCERPT',
+      message: 'Log excerpt contains 0 entries.',
+      actionableRecommendation:
+        'Provide a log excerpt containing audit log entries matching the receipt period.',
+      totalEntries: 0,
+      verifiedEntries: 0,
+      expectedEntries: expectedCount,
+      derivationTrace: [],
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // Sort rows in deterministic chain sequence: created_at ASC, id ASC
+  const sorted = [...entries].sort((a, b) => {
+    const tDiff = a.created_at.getTime() - b.created_at.getTime();
+    if (tDiff !== 0) return tDiff;
+    return a.id.localeCompare(b.id);
+  });
+
+  // Check truncation / count mismatch
+  if (expectedCount !== undefined && sorted.length !== expectedCount) {
+    const startIdStr = receipt.start_id ?? 'N/A';
+    const endIdStr = receipt.end_id ?? 'N/A';
+    if (sorted.length < expectedCount) {
+      return {
+        valid: false,
+        failureType: 'TRUNCATED_EXCERPT',
+        message: `Log excerpt is truncated: received ${sorted.length} entries, but receipt expected ${expectedCount} entries.`,
+        actionableRecommendation: `Ensure the log export includes all ${expectedCount} entries without truncation from start_id (${startIdStr}) to end_id (${endIdStr}).`,
+        totalEntries: sorted.length,
+        verifiedEntries: 0,
+        expectedEntries: expectedCount,
+        receiptHeadHash: expectedHeadHash,
+        derivationTrace: [],
+        durationMs: Date.now() - startTime,
+      };
+    } else {
+      return {
+        valid: false,
+        failureType: 'ROW_COUNT_MISMATCH',
+        message: `Log excerpt count (${sorted.length}) exceeds receipt expected row count (${expectedCount}).`,
+        actionableRecommendation:
+          'Verify that the log excerpt range strictly corresponds to the receipt bounds.',
+        totalEntries: sorted.length,
+        verifiedEntries: 0,
+        expectedEntries: expectedCount,
+        receiptHeadHash: expectedHeadHash,
+        derivationTrace: [],
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  // Check start ID if specified
+  if (receipt.start_id && sorted[0].id !== receipt.start_id) {
+    return {
+      valid: false,
+      failureType: 'START_ID_MISMATCH',
+      message: `First entry ID (${sorted[0].id}) does not match receipt start_id (${receipt.start_id}).`,
+      actionableRecommendation: `Include the starting entry with ID ${receipt.start_id}.`,
+      totalEntries: sorted.length,
+      verifiedEntries: 0,
+      expectedEntries: expectedCount,
+      derivationTrace: [],
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // Check end ID if specified
+  if (receipt.end_id && sorted[sorted.length - 1].id !== receipt.end_id) {
+    return {
+      valid: false,
+      failureType: 'END_ID_MISMATCH',
+      message: `Last entry ID (${sorted[sorted.length - 1].id}) does not match receipt end_id (${receipt.end_id}).`,
+      actionableRecommendation: `Include ending entry with ID ${receipt.end_id}.`,
+      totalEntries: sorted.length,
+      verifiedEntries: 0,
+      expectedEntries: expectedCount,
+      derivationTrace: [],
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // Check start_prev_hash anchor if specified
+  let expectedPrev = startPrevHash ?? AUDIT_LOG_GENESIS_HASH;
+  if (startPrevHash !== undefined && sorted[0].prev_hash !== startPrevHash) {
+    return {
+      valid: false,
+      failureType: 'START_HASH_MISMATCH',
+      message: `First entry prev_hash (${sorted[0].prev_hash}) does not match receipt start_prev_hash (${startPrevHash}).`,
+      actionableRecommendation:
+        'Verify that the excerpt starts at the exact initial prev_hash recorded in the published receipt.',
+      totalEntries: sorted.length,
+      verifiedEntries: 0,
+      expectedEntries: expectedCount,
+      receiptHeadHash: expectedHeadHash,
+      derivationTrace: [],
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  let verifiedEntries = 0;
+
+  for (let index = 0; index < sorted.length; index++) {
+    const row = sorted[index];
+
+    if (!row.prev_hash || !row.row_hash) {
+      const step: DerivationStep = {
+        index,
+        rowId: row.id,
+        timestamp: row.created_at.toISOString(),
+        prevHashMatch: false,
+        computedHash: '',
+        storedHash: row.row_hash,
+        hashMatch: false,
+        error: 'Missing prev_hash or row_hash in excerpt row',
+      };
+      derivationTrace.push(step);
+      return {
+        valid: false,
+        failureType: 'MISSING_HASHES',
+        message: `Row index ${index} (ID: ${row.id}) is missing required prev_hash or row_hash fields.`,
+        actionableRecommendation:
+          'Ensure all excerpt entries include prev_hash and row_hash fields.',
+        totalEntries: sorted.length,
+        verifiedEntries,
+        expectedEntries: expectedCount,
+        receiptHeadHash: expectedHeadHash,
+        derivationTrace,
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    const prevHashMatch = row.prev_hash === expectedPrev;
+    if (!prevHashMatch) {
+      const step: DerivationStep = {
+        index,
+        rowId: row.id,
+        timestamp: row.created_at.toISOString(),
+        prevHashMatch: false,
+        computedHash: '',
+        storedHash: row.row_hash,
+        hashMatch: false,
+        error: `Prev hash mismatch: expected ${expectedPrev}, found ${row.prev_hash}`,
+      };
+      derivationTrace.push(step);
+
+      const isGenesis = index === 0;
+      return {
+        valid: false,
+        failureType: isGenesis ? 'BROKEN_CHAIN' : 'GAP_DETECTED',
+        message: isGenesis
+          ? `Genesis chain anchor broken at entry ${row.id}: prev_hash does not match genesis constant.`
+          : `Chain gap or deleted entry before ${row.id} at index ${index}: prev_hash (${row.prev_hash}) does not match prior row_hash (${expectedPrev}).`,
+        actionableRecommendation:
+          'Check for deleted entries or missing rows in the provided log excerpt sequence.',
+        totalEntries: sorted.length,
+        verifiedEntries,
+        expectedEntries: expectedCount,
+        receiptHeadHash: expectedHeadHash,
+        derivationTrace,
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    const computedHash = computeAuditRowHash(row);
+    const hashMatch = computedHash === row.row_hash;
+
+    const step: DerivationStep = {
+      index,
+      rowId: row.id,
+      timestamp: row.created_at.toISOString(),
+      prevHashMatch: true,
+      computedHash,
+      storedHash: row.row_hash,
+      hashMatch,
+    };
+    derivationTrace.push(step);
+
+    if (!hashMatch) {
+      step.error = `Row payload hash mismatch: computed ${computedHash}, stored ${row.row_hash}`;
+      return {
+        valid: false,
+        failureType: 'HASH_MISMATCH',
+        message: `Tampered audit log entry detected at index ${index} (ID: ${row.id}): canonical payload hash (${computedHash}) does not match stored row_hash (${row.row_hash}).`,
+        actionableRecommendation:
+          'Audit log payload integrity check failed. The row content has been modified after hash generation.',
+        totalEntries: sorted.length,
+        verifiedEntries,
+        expectedEntries: expectedCount,
+        receiptHeadHash: expectedHeadHash,
+        derivationTrace,
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    expectedPrev = row.row_hash;
+    verifiedEntries++;
+  }
+
+  const computedHeadHash = sorted[sorted.length - 1].row_hash;
+
+  if (expectedHeadHash !== undefined && computedHeadHash !== expectedHeadHash) {
+    return {
+      valid: false,
+      failureType: 'HEAD_HASH_MISMATCH',
+      message: `Final excerpt head hash (${computedHeadHash}) does not match receipt expected_head_hash (${expectedHeadHash}).`,
+      actionableRecommendation:
+        'The log excerpt does not reach the published receipt head commitment. Ensure the excerpt is complete up to the receipt commit point.',
+      totalEntries: sorted.length,
+      verifiedEntries,
+      expectedEntries: expectedCount,
+      receiptHeadHash: expectedHeadHash,
+      computedHeadHash,
+      derivationTrace,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  return {
+    valid: true,
+    totalEntries: sorted.length,
+    verifiedEntries,
+    expectedEntries: expectedCount ?? sorted.length,
+    receiptHeadHash: expectedHeadHash ?? computedHeadHash,
+    computedHeadHash,
+    derivationTrace,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+/**
+ * Format verification result as human-readable report.
+ */
+export function formatReport(
+  result: ReceiptVerificationResult,
+  receiptSource?: string,
+  excerptSource?: string,
+  quiet?: boolean,
+): string {
+  const lines: string[] = [];
+  lines.push('============================================================');
+  lines.push('AUDIT LOG INTEGRITY VERIFICATION REPORT');
+  lines.push('============================================================');
+  if (receiptSource) lines.push(`Receipt Source:    ${receiptSource}`);
+  if (excerptSource) lines.push(`Excerpt Source:    ${excerptSource}`);
+  lines.push(
+    `Status:            ${result.valid ? 'PASS [VALID INTEGRITY PROOF]' : 'FAIL [TAMPER OR INVALID PROOF]'}`,
+  );
+  lines.push(`Total Entries:     ${result.totalEntries}`);
+  lines.push(`Verified Entries:  ${result.verifiedEntries}`);
+  lines.push(`Duration:          ${result.durationMs}ms`);
+
+  if (result.receiptHeadHash) {
+    lines.push(`Receipt Head Hash: ${result.receiptHeadHash}`);
+  }
+  if (result.computedHeadHash) {
+    lines.push(`Computed Head Hash:${result.computedHeadHash}`);
+  }
+
+  if (!quiet) {
+    lines.push('------------------------------------------------------------');
+    lines.push('DERIVATION TRACE:');
+    lines.push('------------------------------------------------------------');
+
+    if (result.derivationTrace.length === 0) {
+      lines.push('(No derivation steps executed due to early validation failure)');
+    } else {
+      for (const step of result.derivationTrace) {
+        lines.push(
+          `[Row ${step.index + 1}] ID: ${step.rowId} (${step.timestamp})`,
+        );
+        lines.push(
+          `        Prev Hash Link: ${step.prevHashMatch ? 'OK' : 'BROKEN'}`,
+        );
+        lines.push(
+          `        Payload Hash:   ${step.hashMatch ? 'OK' : 'MISMATCH'} (Computed: ${step.computedHash || 'N/A'})`,
+        );
+        if (step.error) {
+          lines.push(`        Error:          ${step.error}`);
+        }
+      }
+    }
+  }
+
+  lines.push('------------------------------------------------------------');
+
+  if (result.valid) {
+    lines.push('VERIFICATION RESULT: SUCCESS');
+    lines.push(
+      `All ${result.verifiedEntries} audit log entries cryptographically link to published receipt.`,
+    );
+  } else {
+    lines.push(`VERIFICATION RESULT: FAILURE [${result.failureType}]`);
+    lines.push(`Error Details:  ${result.message}`);
+    if (result.actionableRecommendation) {
+      lines.push(`Action Required:${result.actionableRecommendation}`);
+    }
+  }
+
+  lines.push('============================================================');
+  return lines.join('\n');
+}
+
+export function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--receipt' || arg === '-r') {
+      options.receiptPathOrUrl = args[++i];
+    } else if (arg === '--excerpt' || arg === '-e' || arg === '--entries') {
+      options.excerptPathOrUrl = args[++i];
+    } else if (arg === '--json') {
+      options.jsonOutput = true;
+    } else if (arg === '--quiet' || arg === '-q') {
+      options.quiet = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (!arg.startsWith('-')) {
+      positional.push(arg);
+    }
+  }
+
+  if (!options.receiptPathOrUrl && positional.length > 0) {
+    options.receiptPathOrUrl = positional.shift();
+  }
+  if (!options.excerptPathOrUrl && positional.length > 0) {
+    options.excerptPathOrUrl = positional.shift();
+  }
+
+  return options;
+}
+
+export function printHelp(): void {
+  console.log(`
+Audit Log Receipt Verifier CLI
+
+Usage:
+  npx ts-node scripts/verify-audit-receipt.ts --receipt <path-or-url> --excerpt <path-or-url>
+  npx ts-node scripts/verify-audit-receipt.ts <receipt-file-or-url> <excerpt-file-or-url>
+
+Options:
+  -r, --receipt <path-or-url>   Path or HTTP URL to receipt JSON
+  -e, --excerpt <path-or-url>   Path or HTTP URL to log excerpt JSON or JSONL
+  --json                        Print machine-readable JSON report
+  -q, --quiet                   Suppress detailed derivation trace in output
+  -h, --help                    Display this help message
+`);
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const options = parseCliArgs(argv);
+
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  if (!options.receiptPathOrUrl) {
+    console.error('Error: Both receipt and excerpt paths/URLs must be specified.');
+    printHelp();
+    return 1;
+  }
+  if (!options.excerptPathOrUrl) {
+    console.error('Error: Both receipt and excerpt paths/URLs must be specified.');
+    printHelp();
+    return 1;
+  }
+
+  try {
+    const [receiptRaw, excerptRaw] = await Promise.all([
+      loadContent(options.receiptPathOrUrl),
+      loadContent(options.excerptPathOrUrl),
+    ]);
+
+    const receipt: AuditReceipt = JSON.parse(receiptRaw);
+    const entries = parseLogExcerpt(excerptRaw);
+
+    const result = verifyAuditReceipt(receipt, entries);
+
+    if (options.jsonOutput) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(
+        formatReport(
+          result,
+          options.receiptPathOrUrl,
+          options.excerptPathOrUrl,
+          options.quiet,
+        ),
+      );
+    }
+
+    return result.valid ? 0 : 1;
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    if (options.jsonOutput) {
+      console.log(
+        JSON.stringify({
+          valid: false,
+          failureType: 'RUNTIME_ERROR',
+          message: errorMessage,
+        }),
+      );
+    } else {
+      console.error(`\n[VERIFIER ERROR] Failed to execute verification: ${errorMessage}`);
+    }
+    return 1;
+  }
+}
+
+/* istanbul ignore next */
+if (require.main === module) {
+  runCli()
+    .then((code) => process.exit(code))
+    .catch(() => process.exit(1));
+}


### PR DESCRIPTION
Closes #534 

Description
Summary
Auditors need a standalone CLI tool to cryptographically verify audit log excerpts against published receipts without running the application or connecting to the PostgreSQL database.

This PR adds scripts/verify-audit-receipt.ts along with comprehensive unit tests (scripts/verify-audit-receipt.test.ts), golden test fixtures (scripts/fixtures/audit/), and updated documentation.

Key Changes
Standalone Verifier CLI (scripts/verify-audit-receipt.ts):

Ingests published receipts and audit log excerpts from local JSON/JSONL files or HTTP/HTTPS URLs.
Normalizes standard field aliases (expected_head_hash/head_hash/final_hash, start_prev_hash/prev_hash, total_rows/count).
Performs hash-chain reconstruction using canonical payload building from src/security/auditHashChain.ts.
Emits a human-readable pass/fail report with step-by-step derivation trace.
Handles edge cases (e.g. truncated log excerpts, tampered entry payloads, broken genesis/chain links, head hash mismatches) with clear, actionable error recommendations.
Supports --json flag for machine-readable JSON output and -q/--quiet to suppress derivation step trace. Exits with 0 on success and 1 on failure or runtime error.
Golden Test Fixtures (scripts/fixtures/audit/):

valid-receipt.json: Published receipt commitment for a 3-row audit log chain.
valid-excerpt.json: Matching valid log excerpt.
truncated-excerpt.json: Truncated log excerpt missing tail entry.
tampered-excerpt.json: Log excerpt containing modified payload content.
generate.ts: Fixture generation utility.
Test Suite (scripts/verify-audit-receipt.test.ts):

57 unit tests covering valid verification, truncation detection, tampered entry detection, broken chain detection, HTTP/HTTPS fetching, date/timestamp parsing, CLI argument flags, and error formatting.
Test Coverage: 100% Statements, 100% Functions, 100% Lines, >94.5% Branches.
Documentation & Jest Config:

docs/audit-log-hash-chain.md: Updated with standalone receipt verifier usage, receipt schema format, exit code definitions, and execution options.
jest.config.js: Added <rootDir>/scripts to Jest roots.
Verification
Ran CLI on golden fixtures:
Valid: PASS [VALID INTEGRITY PROOF] (3/3 entries verified)
Truncated: FAIL [TRUNCATED_EXCERPT] with actionable export advice.
Tampered: FAIL [HASH_MISMATCH] pinpointing exact tampered entry index and hash mismatch.
Executed npx jest scripts/verify-audit-receipt.test.ts --coverage. All 57 tests passed with clean coverage.