### PR TITLE
feat: canary phase for contract upgrade orchestrator

### DIFF
--- a/docs/contract-upgrade-canary.md
+++ b/docs/contract-upgrade-canary.md
@@ -1,0 +1,210 @@
+# Contract Upgrade Canary Phase
+
+## Overview
+
+The canary phase adds a safe, observable intermediate step between code-id approval and global rollout.
+Instead of promoting a new Soroban code-id to all offerings immediately, the orchestrator first activates
+it against a single designated *shadow offering* per network.  A configurable hold period must elapse
+with clean metrics before general rollout is authorised.
+
+If metrics breach thresholds at any point—either during recording or at promote time—the upgrade is
+automatically rolled back to `rolled_back` and an alarm is emitted.
+
+---
+
+## State Machine
+
+```
+pending
+  │  createUpgrade
+  ▼
+approved
+  │  approveUpgrade (two-key, code-id pin)
+  │  simulateUpgrade (dry-run gate)
+  │
+  ├─ startCanary ──────────────────────────────────────────────────────────────┐
+  │                                                                            │
+  ▼                                                                            │
+canary_active                                                                  │
+  │  recordCanaryMetrics (metrics clean → start hold timer)                   │
+  │  recordCanaryMetrics (metrics breached → auto rollback) ──────────────────┤
+  ▼                                                                            │
+hold_period                                                                    │
+  │  recordCanaryMetrics (metrics updated in-place)                           │
+  │  promoteCanary (hold elapsed + metrics clean)                             │
+  │  promoteCanary (metrics still dirty → auto rollback) ─────────────────────┤
+  │  rollbackCanary (explicit operator rollback) ──────────────────────────────┤
+  ▼                                                                            │
+canary_passed                                                                  │
+  │  applyUpgrade → general rollout                                           │
+  ▼                                                                         ─►rolled_back
+applied
+  │  monitorPostUpgradeHealth (regression gate)
+  ▼
+failed  (auto-rollback)
+```
+
+---
+
+## Canary Offering Configuration
+
+The `canary_offering_id` is passed per-request and should correspond to the shadow offering
+configured for the target network.  Recommended practice is to store this mapping in tenant
+settings or environment config so it is consistent across upgrade proposals.
+
+| Network  | Recommended config key                         |
+|----------|------------------------------------------------|
+| testnet  | `CANARY_OFFERING_ID_TESTNET`                   |
+| mainnet  | `CANARY_OFFERING_ID_MAINNET`                   |
+
+---
+
+## Hold Period
+
+The hold period (`hold_period_seconds`, default **300 s / 5 min**) is the minimum wall-clock time
+the canary must run with clean metrics before `promoteCanary` is allowed.
+
+The timer starts on the first `recordCanaryMetrics` call that does **not** breach thresholds
+(i.e. the transition from `canary_active` → `hold_period`).
+
+---
+
+## Metric Thresholds
+
+Default thresholds applied at every `recordCanaryMetrics` and `promoteCanary` call:
+
+| Metric             | Default threshold | Description                              |
+|--------------------|-------------------|------------------------------------------|
+| `error_rate`       | `< 0.01` (1 %)    | Fraction of requests returning errors    |
+| `p99_latency_ms`   | `< 2000` (2 s)    | 99th-percentile response latency (ms)    |
+| `failed_tx_count`  | `= 0`             | On-chain transactions that failed        |
+
+Custom thresholds can be passed in the request body of `/metrics` and `/promote` endpoints.
+
+---
+
+## API Endpoints
+
+All endpoints require the `requireAdmin` middleware (admin JWT).
+
+### POST `/api/v1/contract-upgrades/:id/canary/start`
+
+Activates the canary phase.  Upgrade must be `approved` with `simulate_ok = true`.
+
+**Request body**
+
+```json
+{
+  "canary_offering_id": "offering-shadow-abc123",
+  "actor_id": "operator-uuid",
+  "hold_period_seconds": 300
+}
+```
+
+**Response** `200 OK`
+
+```json
+{ "upgrade": { "status": "canary_active", ... } }
+```
+
+---
+
+### POST `/api/v1/contract-upgrades/:id/canary/metrics`
+
+Records a metrics snapshot.  Transitions `canary_active → hold_period` on first clean recording.
+Auto-rolls back if thresholds are breached.
+
+**Request body**
+
+```json
+{
+  "actor_id": "operator-uuid",
+  "metrics": {
+    "error_rate": 0.002,
+    "p99_latency_ms": 145,
+    "failed_tx_count": 0
+  },
+  "thresholds": {
+    "max_error_rate": 0.01,
+    "max_p99_latency_ms": 2000,
+    "max_failed_tx_count": 0
+  }
+}
+```
+
+`thresholds` is optional; defaults are used when omitted.
+
+**Response** `200 OK` — returns current upgrade state (may be `hold_period` or `rolled_back`).
+
+---
+
+### POST `/api/v1/contract-upgrades/:id/canary/promote`
+
+Promotes the upgrade to `canary_passed`, authorising general rollout via `applyUpgrade`.
+
+Pre-conditions:
+- Status must be `hold_period`
+- Hold period must have elapsed
+- Latest `canary_metrics` must be within thresholds
+
+**Request body**
+
+```json
+{
+  "actor_id": "operator-uuid",
+  "thresholds": { ... }
+}
+```
+
+**Response** `200 OK` — returns upgrade with `status: "canary_passed"`, or `status: "rolled_back"` if
+metrics were dirty at promote time.
+
+---
+
+### POST `/api/v1/contract-upgrades/:id/canary/rollback`
+
+Explicit operator-initiated rollback.  Idempotent: safe to call multiple times.
+
+**Request body**
+
+```json
+{
+  "actor_id": "operator-uuid",
+  "reason": "Latency spike observed in shadow offering"
+}
+```
+
+**Response** `200 OK` — returns upgrade with `status: "rolled_back"`.
+
+---
+
+## Audit Events
+
+| Event                                    | Trigger                                             |
+|------------------------------------------|-----------------------------------------------------|
+| `CONTRACT_UPGRADE_CANARY_STARTED`        | Canary phase activated                              |
+| `CONTRACT_UPGRADE_CANARY_METRICS_RECORDED` | Metrics snapshot recorded (clean)                 |
+| `CONTRACT_UPGRADE_CANARY_METRICS_BREACHED` | Metric threshold breached (alarm emitted)         |
+| `CONTRACT_UPGRADE_CANARY_PROMOTED`       | Hold period elapsed; upgrade ready for rollout      |
+| `CONTRACT_UPGRADE_CANARY_ROLLED_BACK`    | Canary rolled back (auto or manual; alarm emitted)  |
+
+---
+
+## Security Assumptions
+
+1. **Two-key approval is preserved.** The canary phase sits *after* dual-key approval and dry-run simulation; it does not bypass either gate.
+2. **Code-id pin is maintained.** The `target_code_id` is fixed at proposal time; the canary phase never modifies it.
+3. **Rollback is always available.** An operator can call `/canary/rollback` at any point during `canary_active` or `hold_period` without needing a pre-approved rollback plan (unlike the post-`applied` auto-rollback which requires one).
+4. **Auto-rollback is deterministic.** Threshold evaluation uses the exact metric values provided by the caller; there is no stochastic component.
+5. **Alarm emission on breach.** Both metric breaches and rollbacks log at `warn` level with `alarm: true`, feeding the existing alerting pipeline.
+6. **Idempotency on rollback.** Calling `rollbackCanary` on an already-`rolled_back` or `failed` upgrade returns the current state without performing a second write.
+
+---
+
+## Database Changes
+
+Migration `020_contract_upgrades_canary.sql` adds:
+
+- Extended `status` CHECK constraint to include `canary_active`, `hold_period`, `canary_passed`, `rolled_back`.
+- Columns: `canary_offering_id`, `canary_started_at`, `hold_period_seconds`, `hold_started_at`, `canary_metrics` (JSONB), `canary_passed_at`, `rolled_back_at`.
+- Partial index `idx_contract_upgrades_canary_status` for fast polling of in-flight canary upgrades.

--- a/src/__tests__/contractUpgradeOrchestratorService.test.ts
+++ b/src/__tests__/contractUpgradeOrchestratorService.test.ts
@@ -224,3 +224,398 @@ describe('ContractUpgradeOrchestratorService', () => {
     expect(mockPool.query).toHaveBeenCalledTimes(1);
   });
 });
+
+// ── Canary phase tests ────────────────────────────────────────────────────────
+
+const approvedRow = {
+  id: 'upgrade-canary-1',
+  tenant_id: 'tenant-1',
+  contract_id: 'contract-1',
+  target_code_id: 'deadbeef',
+  status: 'approved',
+  proposed_by: 'user-1',
+  approved_by: 'approver-1',
+  simulate_result: null,
+  simulate_ok: true,
+  transaction_hash: null,
+  failure_reason: null,
+  canary_offering_id: null,
+  canary_started_at: null,
+  hold_period_seconds: 300,
+  hold_started_at: null,
+  canary_metrics: null,
+  canary_passed_at: null,
+  rolled_back_at: null,
+  created_at: new Date().toISOString(),
+  approved_at: new Date().toISOString(),
+  applied_at: null,
+  updated_at: new Date().toISOString(),
+};
+
+const canaryActiveRow = {
+  ...approvedRow,
+  status: 'canary_active',
+  canary_offering_id: 'offering-shadow-1',
+  canary_started_at: new Date().toISOString(),
+};
+
+const holdPeriodRow = {
+  ...canaryActiveRow,
+  status: 'hold_period',
+  hold_started_at: new Date(Date.now() - 400_000).toISOString(), // 400 s ago > 300 s
+  canary_metrics: {
+    error_rate: 0.001,
+    p99_latency_ms: 120,
+    failed_tx_count: 0,
+  },
+};
+
+describe('ContractUpgradeOrchestratorService — startCanary', () => {
+  let service: ContractUpgradeOrchestratorService;
+  const mockKeypair = { publicKey: jest.fn().mockReturnValue('G-FAKE-KEY') } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ContractUpgradeOrchestratorService(
+      mockPool, mockAuditLogRepo, mockTenantSettingsRepo, mockKeypair,
+    );
+  });
+
+  it('transitions approved+simulate_ok upgrade to canary_active', async () => {
+    const returnedRow = { ...approvedRow, status: 'canary_active', canary_offering_id: 'offering-shadow-1' };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [approvedRow] })   // getUpgrade
+      .mockResolvedValueOnce({ rows: [returnedRow] });  // UPDATE
+
+    const result = await service.startCanary('upgrade-canary-1', {
+      canary_offering_id: 'offering-shadow-1',
+      actor_id: 'operator-1',
+      hold_period_seconds: 300,
+    });
+
+    expect(result.status).toBe('canary_active');
+    expect(result.canary_offering_id).toBe('offering-shadow-1');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_UPGRADE_CANARY_STARTED' }),
+    );
+  });
+
+  it('rejects when upgrade is not approved', async () => {
+    const pendingRow = { ...approvedRow, status: 'pending', simulate_ok: null };
+    mockPool.query.mockResolvedValueOnce({ rows: [pendingRow] });
+
+    await expect(
+      service.startCanary('upgrade-canary-1', { canary_offering_id: 'offering-shadow-1', actor_id: 'op' }),
+    ).rejects.toThrow(/Cannot start canary.*pending/);
+  });
+
+  it('rejects when simulate_ok is false', async () => {
+    const notSimulated = { ...approvedRow, simulate_ok: false };
+    mockPool.query.mockResolvedValueOnce({ rows: [notSimulated] });
+
+    await expect(
+      service.startCanary('upgrade-canary-1', { canary_offering_id: 'offering-shadow-1', actor_id: 'op' }),
+    ).rejects.toThrow(/dry-run simulation/);
+  });
+
+  it('rejects empty canary_offering_id', async () => {
+    await expect(
+      service.startCanary('upgrade-canary-1', { canary_offering_id: '   ', actor_id: 'op' }),
+    ).rejects.toThrow(/canary_offering_id is required/);
+  });
+
+  it('rejects negative hold_period_seconds', async () => {
+    await expect(
+      service.startCanary('upgrade-canary-1', {
+        canary_offering_id: 'offering-shadow-1',
+        actor_id: 'op',
+        hold_period_seconds: -1,
+      }),
+    ).rejects.toThrow(/non-negative/);
+  });
+
+  it('defaults hold_period_seconds to 300 when not provided', async () => {
+    const returnedRow = { ...approvedRow, status: 'canary_active', canary_offering_id: 'offering-shadow-1', hold_period_seconds: 300 };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [approvedRow] })
+      .mockResolvedValueOnce({ rows: [returnedRow] });
+
+    const result = await service.startCanary('upgrade-canary-1', {
+      canary_offering_id: 'offering-shadow-1',
+      actor_id: 'op',
+    });
+    expect(result.hold_period_seconds).toBe(300);
+  });
+});
+
+describe('ContractUpgradeOrchestratorService — recordCanaryMetrics', () => {
+  let service: ContractUpgradeOrchestratorService;
+  const mockKeypair = { publicKey: jest.fn().mockReturnValue('G-FAKE-KEY') } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ContractUpgradeOrchestratorService(
+      mockPool, mockAuditLogRepo, mockTenantSettingsRepo, mockKeypair,
+    );
+  });
+
+  const cleanMetrics = { error_rate: 0.001, p99_latency_ms: 120, failed_tx_count: 0 };
+
+  it('transitions canary_active to hold_period on first clean metrics recording', async () => {
+    const holdRow = { ...canaryActiveRow, status: 'hold_period', hold_started_at: new Date().toISOString(), canary_metrics: cleanMetrics };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [holdRow] });
+
+    const result = await service.recordCanaryMetrics('upgrade-canary-1', cleanMetrics, 'op');
+
+    expect(result.status).toBe('hold_period');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_UPGRADE_CANARY_METRICS_RECORDED' }),
+    );
+  });
+
+  it('updates metrics in place when already in hold_period', async () => {
+    const updatedHoldRow = { ...holdPeriodRow, canary_metrics: cleanMetrics };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [holdPeriodRow] })
+      .mockResolvedValueOnce({ rows: [updatedHoldRow] });
+
+    const result = await service.recordCanaryMetrics('upgrade-canary-1', cleanMetrics, 'op');
+    expect(result.status).toBe('hold_period');
+  });
+
+  it('auto-rollbacks on error_rate threshold breach', async () => {
+    const badMetrics = { error_rate: 0.05, p99_latency_ms: 120, failed_tx_count: 0 };
+    const rolledBackRow = { ...canaryActiveRow, status: 'rolled_back', failure_reason: 'Canary metric threshold breached: error_rate 0.05 exceeds threshold 0.01', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })   // recordCanaryMetrics -> getUpgrade
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })   // rollbackCanary -> getUpgrade
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });    // rollbackCanary -> UPDATE
+
+    const result = await service.recordCanaryMetrics('upgrade-canary-1', badMetrics, 'op');
+
+    expect(result.status).toBe('rolled_back');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_UPGRADE_CANARY_ROLLED_BACK' }),
+    );
+  });
+
+  it('auto-rollbacks on p99_latency_ms threshold breach', async () => {
+    const badMetrics = { error_rate: 0.001, p99_latency_ms: 5000, failed_tx_count: 0 };
+    const rolledBackRow = { ...canaryActiveRow, status: 'rolled_back', failure_reason: 'breach', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });
+
+    const result = await service.recordCanaryMetrics('upgrade-canary-1', badMetrics, 'op');
+    expect(result.status).toBe('rolled_back');
+  });
+
+  it('auto-rollbacks on failed_tx_count threshold breach', async () => {
+    const badMetrics = { error_rate: 0.001, p99_latency_ms: 120, failed_tx_count: 1 };
+    const rolledBackRow = { ...canaryActiveRow, status: 'rolled_back', failure_reason: 'breach', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });
+
+    const result = await service.recordCanaryMetrics('upgrade-canary-1', badMetrics, 'op');
+    expect(result.status).toBe('rolled_back');
+  });
+
+  it('rejects metrics recording for non-canary status', async () => {
+    const appliedRow = { ...approvedRow, status: 'applied' };
+    mockPool.query.mockResolvedValueOnce({ rows: [appliedRow] });
+
+    await expect(
+      service.recordCanaryMetrics('upgrade-canary-1', cleanMetrics, 'op'),
+    ).rejects.toThrow(/Cannot record canary metrics.*applied/);
+  });
+
+  it('rejects negative error_rate', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [canaryActiveRow] });
+
+    await expect(
+      service.recordCanaryMetrics('upgrade-canary-1', { error_rate: -0.1, p99_latency_ms: 100, failed_tx_count: 0 }, 'op'),
+    ).rejects.toThrow(/non-negative/);
+  });
+
+  it('respects custom thresholds', async () => {
+    // With a very tight custom threshold, error_rate of 0.005 should breach
+    const metrics = { error_rate: 0.005, p99_latency_ms: 100, failed_tx_count: 0 };
+    const strictThresholds = { max_error_rate: 0.001, max_p99_latency_ms: 2000, max_failed_tx_count: 0 };
+    const rolledBackRow = { ...canaryActiveRow, status: 'rolled_back', failure_reason: 'breach', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });
+
+    const result = await service.recordCanaryMetrics('upgrade-canary-1', metrics, 'op', strictThresholds);
+    expect(result.status).toBe('rolled_back');
+  });
+});
+
+describe('ContractUpgradeOrchestratorService — promoteCanary', () => {
+  let service: ContractUpgradeOrchestratorService;
+  const mockKeypair = { publicKey: jest.fn().mockReturnValue('G-FAKE-KEY') } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ContractUpgradeOrchestratorService(
+      mockPool, mockAuditLogRepo, mockTenantSettingsRepo, mockKeypair,
+    );
+  });
+
+  it('promotes to canary_passed when hold period has elapsed and metrics are clean', async () => {
+    const passedRow = { ...holdPeriodRow, status: 'canary_passed', canary_passed_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [holdPeriodRow] })
+      .mockResolvedValueOnce({ rows: [passedRow] });
+
+    const result = await service.promoteCanary('upgrade-canary-1', 'op');
+
+    expect(result.status).toBe('canary_passed');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_UPGRADE_CANARY_PROMOTED' }),
+    );
+  });
+
+  it('rejects promotion when hold period has NOT elapsed', async () => {
+    // hold_started_at only 10 s ago, hold_period_seconds = 300
+    const recentHoldRow = {
+      ...holdPeriodRow,
+      hold_started_at: new Date(Date.now() - 10_000).toISOString(),
+    };
+    mockPool.query.mockResolvedValueOnce({ rows: [recentHoldRow] });
+
+    await expect(service.promoteCanary('upgrade-canary-1', 'op'))
+      .rejects.toThrow(/Hold period has not elapsed/);
+  });
+
+  it('rejects promotion when status is not hold_period', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [canaryActiveRow] });
+
+    await expect(service.promoteCanary('upgrade-canary-1', 'op'))
+      .rejects.toThrow(/Cannot promote canary.*canary_active/);
+  });
+
+  it('rejects promotion when no canary_metrics recorded', async () => {
+    const noMetricsRow = { ...holdPeriodRow, canary_metrics: null };
+    mockPool.query.mockResolvedValueOnce({ rows: [noMetricsRow] });
+
+    await expect(service.promoteCanary('upgrade-canary-1', 'op'))
+      .rejects.toThrow(/No canary metrics recorded/);
+  });
+
+  it('rejects promotion when hold_started_at is null', async () => {
+    const noHoldRow = { ...holdPeriodRow, hold_started_at: null };
+    mockPool.query.mockResolvedValueOnce({ rows: [noHoldRow] });
+
+    await expect(service.promoteCanary('upgrade-canary-1', 'op'))
+      .rejects.toThrow(/Hold period has not started/);
+  });
+
+  it('auto-rollbacks during promote when latest metrics breach threshold', async () => {
+    const dirtyMetrics = { error_rate: 0.9, p99_latency_ms: 120, failed_tx_count: 0 };
+    const dirtyHoldRow = { ...holdPeriodRow, canary_metrics: dirtyMetrics };
+    const rolledBackRow = { ...holdPeriodRow, status: 'rolled_back', failure_reason: 'breach', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [dirtyHoldRow] })   // promoteCanary -> getUpgrade
+      .mockResolvedValueOnce({ rows: [dirtyHoldRow] })   // rollbackCanary -> getUpgrade
+      .mockResolvedValueOnce({ rows: [rolledBackRow] }); // rollbackCanary -> UPDATE
+
+    const result = await service.promoteCanary('upgrade-canary-1', 'op');
+    expect(result.status).toBe('rolled_back');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_UPGRADE_CANARY_ROLLED_BACK' }),
+    );
+  });
+});
+
+describe('ContractUpgradeOrchestratorService — rollbackCanary', () => {
+  let service: ContractUpgradeOrchestratorService;
+  const mockKeypair = { publicKey: jest.fn().mockReturnValue('G-FAKE-KEY') } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ContractUpgradeOrchestratorService(
+      mockPool, mockAuditLogRepo, mockTenantSettingsRepo, mockKeypair,
+    );
+  });
+
+  it('rolls back a canary_active upgrade', async () => {
+    const rolledBackRow = { ...canaryActiveRow, status: 'rolled_back', failure_reason: 'Manual rollback requested', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });
+
+    const result = await service.rollbackCanary('upgrade-canary-1', 'op');
+
+    expect(result.status).toBe('rolled_back');
+    expect(mockAuditLogRepo.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_UPGRADE_CANARY_ROLLED_BACK' }),
+    );
+  });
+
+  it('rolls back a hold_period upgrade', async () => {
+    const rolledBackRow = { ...holdPeriodRow, status: 'rolled_back', failure_reason: 'Operator decision', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [holdPeriodRow] })
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });
+
+    const result = await service.rollbackCanary('upgrade-canary-1', 'op', 'Operator decision');
+    expect(result.status).toBe('rolled_back');
+    expect(result.failure_reason).toBe('Operator decision');
+  });
+
+  it('is idempotent: returns current state when already rolled_back', async () => {
+    const alreadyRolledBack = { ...canaryActiveRow, status: 'rolled_back', rolled_back_at: new Date().toISOString() };
+    mockPool.query.mockResolvedValueOnce({ rows: [alreadyRolledBack] });
+
+    const result = await service.rollbackCanary('upgrade-canary-1', 'op');
+    expect(result.status).toBe('rolled_back');
+    // Only one query (the getUpgrade), no UPDATE
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent: returns current state when already failed', async () => {
+    const failedRow = { ...approvedRow, status: 'failed', failure_reason: 'prior failure' };
+    mockPool.query.mockResolvedValueOnce({ rows: [failedRow] });
+
+    const result = await service.rollbackCanary('upgrade-canary-1', 'op');
+    expect(result.status).toBe('failed');
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects rollback for non-canary statuses like applied', async () => {
+    const appliedRow = { ...approvedRow, status: 'applied', transaction_hash: 'txhash' };
+    mockPool.query.mockResolvedValueOnce({ rows: [appliedRow] });
+
+    await expect(service.rollbackCanary('upgrade-canary-1', 'op'))
+      .rejects.toThrow(/Cannot rollback canary.*applied/);
+  });
+
+  it('rejects rollback for pending status', async () => {
+    const pendingRow = { ...approvedRow, status: 'pending' };
+    mockPool.query.mockResolvedValueOnce({ rows: [pendingRow] });
+
+    await expect(service.rollbackCanary('upgrade-canary-1', 'op'))
+      .rejects.toThrow(/Cannot rollback canary.*pending/);
+  });
+
+  it('records the rollback reason in audit log', async () => {
+    const rolledBackRow = { ...canaryActiveRow, status: 'rolled_back', failure_reason: 'Latency spike detected', rolled_back_at: new Date().toISOString() };
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [canaryActiveRow] })
+      .mockResolvedValueOnce({ rows: [rolledBackRow] });
+
+    await service.rollbackCanary('upgrade-canary-1', 'op', 'Latency spike detected');
+
+    const auditCall = (mockAuditLogRepo.createAuditLog as jest.Mock).mock.calls[0][0];
+    const details = JSON.parse(auditCall.details);
+    expect(details.reason).toBe('Latency spike detected');
+    expect(details.previous_status).toBe('canary_active');
+  });
+});

--- a/src/__tests__/contractUpgradeRoutes.test.ts
+++ b/src/__tests__/contractUpgradeRoutes.test.ts
@@ -150,3 +150,252 @@ describe('Contract Upgrade Routes — drift-report endpoint', () => {
     expect(res.body.report.recommendation).toBe('review_required');
   });
 });
+
+// ── Canary route tests ────────────────────────────────────────────────────────
+
+const canaryUpgrade = {
+  id: 'upgrade-canary-1',
+  tenant_id: 'tenant-1',
+  contract_id: 'contract-1',
+  target_code_id: 'deadbeef',
+  status: 'canary_active',
+  proposed_by: 'user-1',
+  approved_by: 'approver-1',
+  simulate_ok: true,
+  canary_offering_id: 'offering-shadow-1',
+  canary_started_at: new Date().toISOString(),
+  hold_period_seconds: 300,
+  hold_started_at: null,
+  canary_metrics: null,
+  canary_passed_at: null,
+  rolled_back_at: null,
+  failure_reason: null,
+  transaction_hash: null,
+  created_at: new Date().toISOString(),
+  approved_at: new Date().toISOString(),
+  applied_at: null,
+  updated_at: new Date().toISOString(),
+};
+
+describe('Contract Upgrade Routes — canary/start endpoint', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 200 and upgrade on successful canary start', async () => {
+    mockContractUpgradeService.startCanary = jest.fn().mockResolvedValue(canaryUpgrade);
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/start')
+      .send({ canary_offering_id: 'offering-shadow-1', actor_id: 'op-1', hold_period_seconds: 300 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.upgrade.status).toBe('canary_active');
+    expect(res.body.upgrade.canary_offering_id).toBe('offering-shadow-1');
+  });
+
+  it('returns 400 when canary_offering_id is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/start')
+      .send({ actor_id: 'op-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 when actor_id is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/start')
+      .send({ canary_offering_id: 'offering-shadow-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 when hold_period_seconds is negative', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/start')
+      .send({ canary_offering_id: 'offering-shadow-1', actor_id: 'op-1', hold_period_seconds: -5 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('BAD_REQUEST');
+  });
+
+  it('propagates service errors (e.g. conflict) to error handler', async () => {
+    const { Errors: E } = await import('../lib/errors');
+    mockContractUpgradeService.startCanary = jest.fn().mockRejectedValue(
+      E.conflict("Cannot start canary for upgrade with status 'pending'"),
+    );
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/start')
+      .send({ canary_offering_id: 'offering-shadow-1', actor_id: 'op-1' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('CONFLICT');
+  });
+});
+
+describe('Contract Upgrade Routes — canary/metrics endpoint', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const cleanMetrics = { error_rate: 0.001, p99_latency_ms: 120, failed_tx_count: 0 };
+  const holdUpgrade = { ...canaryUpgrade, status: 'hold_period', hold_started_at: new Date().toISOString(), canary_metrics: cleanMetrics };
+
+  it('returns 200 on successful metrics recording', async () => {
+    mockContractUpgradeService.recordCanaryMetrics = jest.fn().mockResolvedValue(holdUpgrade);
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/metrics')
+      .send({ actor_id: 'op-1', metrics: cleanMetrics });
+
+    expect(res.status).toBe(200);
+    expect(res.body.upgrade.status).toBe('hold_period');
+  });
+
+  it('returns 400 when actor_id is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/metrics')
+      .send({ metrics: cleanMetrics });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when metrics object is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/metrics')
+      .send({ actor_id: 'op-1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when metrics fields are non-numeric', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/metrics')
+      .send({ actor_id: 'op-1', metrics: { error_rate: 'bad', p99_latency_ms: 100, failed_tx_count: 0 } });
+    expect(res.status).toBe(400);
+  });
+
+  it('passes optional thresholds to service', async () => {
+    const rolledBackUpgrade = { ...canaryUpgrade, status: 'rolled_back' };
+    mockContractUpgradeService.recordCanaryMetrics = jest.fn().mockResolvedValue(rolledBackUpgrade);
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/metrics')
+      .send({
+        actor_id: 'op-1',
+        metrics: cleanMetrics,
+        thresholds: { max_error_rate: 0.0001, max_p99_latency_ms: 2000, max_failed_tx_count: 0 },
+      });
+    expect(res.status).toBe(200);
+    expect(mockContractUpgradeService.recordCanaryMetrics).toHaveBeenCalledWith(
+      'upgrade-canary-1',
+      cleanMetrics,
+      'op-1',
+      expect.objectContaining({ max_error_rate: 0.0001 }),
+    );
+  });
+});
+
+describe('Contract Upgrade Routes — canary/promote endpoint', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const passedUpgrade = { ...canaryUpgrade, status: 'canary_passed', canary_passed_at: new Date().toISOString() };
+
+  it('returns 200 on successful promotion', async () => {
+    mockContractUpgradeService.promoteCanary = jest.fn().mockResolvedValue(passedUpgrade);
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/promote')
+      .send({ actor_id: 'op-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.upgrade.status).toBe('canary_passed');
+  });
+
+  it('returns 400 when actor_id is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/promote')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('propagates 409 conflict when hold period not elapsed', async () => {
+    const { Errors: E } = await import('../lib/errors');
+    mockContractUpgradeService.promoteCanary = jest.fn().mockRejectedValue(
+      E.conflict('Hold period has not elapsed — 250s remaining', { remaining_seconds: 250 }),
+    );
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/promote')
+      .send({ actor_id: 'op-1' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('CONFLICT');
+  });
+
+  it('passes optional custom thresholds to service', async () => {
+    mockContractUpgradeService.promoteCanary = jest.fn().mockResolvedValue(passedUpgrade);
+    const app = buildApp();
+    const customThresholds = { max_error_rate: 0.005, max_p99_latency_ms: 1000, max_failed_tx_count: 0 };
+    await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/promote')
+      .send({ actor_id: 'op-1', thresholds: customThresholds });
+    expect(mockContractUpgradeService.promoteCanary).toHaveBeenCalledWith(
+      'upgrade-canary-1', 'op-1', expect.objectContaining({ max_error_rate: 0.005 }),
+    );
+  });
+});
+
+describe('Contract Upgrade Routes — canary/rollback endpoint', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const rolledBackUpgrade = {
+    ...canaryUpgrade,
+    status: 'rolled_back',
+    failure_reason: 'Manual rollback requested',
+    rolled_back_at: new Date().toISOString(),
+  };
+
+  it('returns 200 on successful rollback', async () => {
+    mockContractUpgradeService.rollbackCanary = jest.fn().mockResolvedValue(rolledBackUpgrade);
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/rollback')
+      .send({ actor_id: 'op-1', reason: 'Manual rollback requested' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.upgrade.status).toBe('rolled_back');
+  });
+
+  it('returns 400 when actor_id is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/rollback')
+      .send({ reason: 'some reason' });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts rollback without a reason (defaults to service default)', async () => {
+    mockContractUpgradeService.rollbackCanary = jest.fn().mockResolvedValue(rolledBackUpgrade);
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/upgrade-canary-1/canary/rollback')
+      .send({ actor_id: 'op-1' });
+    expect(res.status).toBe(200);
+    expect(mockContractUpgradeService.rollbackCanary).toHaveBeenCalledWith(
+      'upgrade-canary-1', 'op-1', undefined,
+    );
+  });
+
+  it('returns 404 when upgrade does not exist', async () => {
+    const { Errors: E } = await import('../lib/errors');
+    mockContractUpgradeService.rollbackCanary = jest.fn().mockRejectedValue(
+      E.notFound("Contract upgrade 'nonexistent' not found"),
+    );
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/contract-upgrades/nonexistent/canary/rollback')
+      .send({ actor_id: 'op-1' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('NOT_FOUND');
+  });
+});

--- a/src/db/migrations/020_contract_upgrades_canary.sql
+++ b/src/db/migrations/020_contract_upgrades_canary.sql
@@ -1,0 +1,48 @@
+-- Migration: extend contract_upgrades for canary phase support
+--
+-- Adds three new status values:
+--   canary_active  – shadow offering is live with the new code-id
+--   hold_period    – metrics look clean; waiting out the mandatory hold timer
+--   canary_passed  – hold period expired with clean metrics; ready for general rollout
+--   rolled_back    – canary was explicitly rolled back before general rollout
+--
+-- Also adds per-row canary configuration columns so each upgrade can carry its
+-- own shadow offering ID, hold duration, and the metrics snapshot collected
+-- during the canary window.
+
+-- 1. Drop the existing CHECK constraint by recreating the column default
+--    (PostgreSQL does not support ALTER COLUMN … SET CHECK directly; we add
+--     a new table-level constraint and drop the old one).
+
+ALTER TABLE contract_upgrades
+  DROP CONSTRAINT IF EXISTS contract_upgrades_status_check;
+
+ALTER TABLE contract_upgrades
+  ADD CONSTRAINT contract_upgrades_status_check
+    CHECK (status IN (
+      'pending',
+      'approved',
+      'applied',
+      'failed',
+      'canary_active',
+      'hold_period',
+      'canary_passed',
+      'rolled_back'
+    ));
+
+-- 2. Canary configuration columns
+
+ALTER TABLE contract_upgrades
+  ADD COLUMN IF NOT EXISTS canary_offering_id  VARCHAR(128)  NULL,
+  ADD COLUMN IF NOT EXISTS canary_started_at   TIMESTAMP WITH TIME ZONE NULL,
+  ADD COLUMN IF NOT EXISTS hold_period_seconds INTEGER       NULL DEFAULT 300,
+  ADD COLUMN IF NOT EXISTS hold_started_at     TIMESTAMP WITH TIME ZONE NULL,
+  ADD COLUMN IF NOT EXISTS canary_metrics      JSONB         NULL,
+  ADD COLUMN IF NOT EXISTS canary_passed_at    TIMESTAMP WITH TIME ZONE NULL,
+  ADD COLUMN IF NOT EXISTS rolled_back_at      TIMESTAMP WITH TIME ZONE NULL;
+
+-- 3. Index to support fast polling of in-flight canary upgrades
+
+CREATE INDEX IF NOT EXISTS idx_contract_upgrades_canary_status
+  ON contract_upgrades (status)
+  WHERE status IN ('canary_active', 'hold_period');

--- a/src/routes/contractUpgradeRoutes.ts
+++ b/src/routes/contractUpgradeRoutes.ts
@@ -1,7 +1,11 @@
 import express, { Request, Response, NextFunction, Router } from 'express';
 import { ZodError } from 'zod';
 import { Errors } from '../lib/errors';
-import { ContractUpgradeOrchestratorService } from '../services/contractUpgradeOrchestratorService';
+import {
+  ContractUpgradeOrchestratorService,
+  CanaryMetrics,
+  CanaryMetricThresholds,
+} from '../services/contractUpgradeOrchestratorService';
 import { StorageDriftReportService } from '../services/storageDriftReportService';
 import { requireAdmin } from '../middleware/auth';
 
@@ -11,6 +15,7 @@ export function createContractUpgradeRouter(
 ): Router {
   const router = express.Router();
 
+  // ── POST / — create upgrade proposal ──────────────────────────────────────
   router.post(
     '/',
     requireAdmin,
@@ -46,8 +51,146 @@ export function createContractUpgradeRouter(
     },
   );
 
-  // ── Storage-layout drift report (dry-run) ────────────────────────────────
+  // ── POST /:id/canary/start — activate canary phase ────────────────────────
+  router.post(
+    '/:id/canary/start',
+    requireAdmin,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const upgradeId = req.params.id;
+        const body = req.body as Record<string, unknown> | undefined;
+        const canary_offering_id = body?.canary_offering_id as string | undefined;
+        const actor_id = body?.actor_id as string | undefined;
+        const hold_period_seconds =
+          body?.hold_period_seconds !== undefined
+            ? Number(body.hold_period_seconds)
+            : undefined;
 
+        if (!canary_offering_id) {
+          return next(Errors.badRequest('canary_offering_id is required'));
+        }
+        if (!actor_id) {
+          return next(Errors.badRequest('actor_id is required'));
+        }
+        if (
+          hold_period_seconds !== undefined &&
+          (!Number.isInteger(hold_period_seconds) || hold_period_seconds < 0)
+        ) {
+          return next(Errors.badRequest('hold_period_seconds must be a non-negative integer'));
+        }
+
+        const upgrade = await contractUpgradeOrchestratorService.startCanary(upgradeId, {
+          canary_offering_id,
+          actor_id,
+          hold_period_seconds,
+        });
+
+        res.status(200).json({ upgrade });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── POST /:id/canary/metrics — record canary metrics ──────────────────────
+  router.post(
+    '/:id/canary/metrics',
+    requireAdmin,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const upgradeId = req.params.id;
+        const body = req.body as Record<string, unknown> | undefined;
+        const actor_id = body?.actor_id as string | undefined;
+        const metrics = body?.metrics as CanaryMetrics | undefined;
+        const thresholds = body?.thresholds as CanaryMetricThresholds | undefined;
+
+        if (!actor_id) {
+          return next(Errors.badRequest('actor_id is required'));
+        }
+        if (
+          !metrics ||
+          typeof metrics.error_rate !== 'number' ||
+          typeof metrics.p99_latency_ms !== 'number' ||
+          typeof metrics.failed_tx_count !== 'number'
+        ) {
+          return next(
+            Errors.badRequest(
+              'metrics with numeric error_rate, p99_latency_ms, and failed_tx_count are required',
+            ),
+          );
+        }
+
+        const upgrade = await contractUpgradeOrchestratorService.recordCanaryMetrics(
+          upgradeId,
+          metrics,
+          actor_id,
+          thresholds,
+        );
+
+        res.status(200).json({ upgrade });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── POST /:id/canary/promote — promote to canary_passed ───────────────────
+  router.post(
+    '/:id/canary/promote',
+    requireAdmin,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const upgradeId = req.params.id;
+        const body = req.body as Record<string, unknown> | undefined;
+        const actor_id = body?.actor_id as string | undefined;
+        const thresholds = body?.thresholds as CanaryMetricThresholds | undefined;
+
+        if (!actor_id) {
+          return next(Errors.badRequest('actor_id is required'));
+        }
+
+        const upgrade = await contractUpgradeOrchestratorService.promoteCanary(
+          upgradeId,
+          actor_id,
+          thresholds,
+        );
+
+        res.status(200).json({ upgrade });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── POST /:id/canary/rollback — explicit canary rollback ──────────────────
+  router.post(
+    '/:id/canary/rollback',
+    requireAdmin,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const upgradeId = req.params.id;
+        const body = req.body as Record<string, unknown> | undefined;
+        const actor_id = body?.actor_id as string | undefined;
+        const reason = body?.reason as string | undefined;
+
+        if (!actor_id) {
+          return next(Errors.badRequest('actor_id is required'));
+        }
+
+        const upgrade = await contractUpgradeOrchestratorService.rollbackCanary(
+          upgradeId,
+          actor_id,
+          reason,
+        );
+
+        res.status(200).json({ upgrade });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── Storage-layout drift report (dry-run) ─────────────────────────────────
   router.post(
     '/drift-report',
     requireAdmin,

--- a/src/services/contractUpgradeOrchestratorService.ts
+++ b/src/services/contractUpgradeOrchestratorService.ts
@@ -21,7 +21,15 @@ const logger = globalLogger.child({ service: 'contract-upgrade-orchestrator' });
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-export type UpgradeStatus = 'pending' | 'approved' | 'applied' | 'failed';
+export type UpgradeStatus =
+  | 'pending'
+  | 'approved'
+  | 'applied'
+  | 'failed'
+  | 'canary_active'
+  | 'hold_period'
+  | 'canary_passed'
+  | 'rolled_back';
 
 export interface ContractUpgrade {
   id: string;
@@ -39,6 +47,14 @@ export interface ContractUpgrade {
   approved_at: Date | null;
   applied_at: Date | null;
   updated_at: Date;
+  // Canary phase fields
+  canary_offering_id: string | null;
+  canary_started_at: Date | null;
+  hold_period_seconds: number | null;
+  hold_started_at: Date | null;
+  canary_metrics: CanaryMetrics | null;
+  canary_passed_at: Date | null;
+  rolled_back_at: Date | null;
 }
 
 export interface CreateUpgradeInput {
@@ -65,6 +81,38 @@ export interface RollbackPlan {
   approved: boolean;
 }
 
+/**
+ * Metrics snapshot collected during a canary window.
+ * All thresholds are checked at promote time to gate general rollout.
+ */
+export interface CanaryMetrics {
+  /** Error rate observed on the shadow offering (0–1). Threshold: < 0.01 */
+  error_rate: number;
+  /** p99 latency in milliseconds for the shadow offering. Threshold: < 2000 */
+  p99_latency_ms: number;
+  /** Number of failed transactions on the shadow offering. Threshold: 0 */
+  failed_tx_count: number;
+  /** Arbitrary extra key/value pairs recorded by the caller. */
+  extra?: Record<string, unknown>;
+}
+
+export interface StartCanaryInput {
+  /** ID of the shadow/canary offering to route traffic to. Configurable per network. */
+  canary_offering_id: string;
+  /**
+   * Minimum hold period in seconds before promotion is allowed.
+   * Defaults to 300 (5 minutes) if omitted.
+   */
+  hold_period_seconds?: number;
+  actor_id: string;
+}
+
+export interface CanaryMetricThresholds {
+  max_error_rate: number;
+  max_p99_latency_ms: number;
+  max_failed_tx_count: number;
+}
+
 // ── Repository helpers ────────────────────────────────────────────────────────
 
 function mapRow(row: any): ContractUpgrade {
@@ -84,8 +132,23 @@ function mapRow(row: any): ContractUpgrade {
     approved_at: row.approved_at ? new Date(row.approved_at) : null,
     applied_at: row.applied_at ? new Date(row.applied_at) : null,
     updated_at: new Date(row.updated_at),
+    // Canary fields
+    canary_offering_id: row.canary_offering_id ?? null,
+    canary_started_at: row.canary_started_at ? new Date(row.canary_started_at) : null,
+    hold_period_seconds: row.hold_period_seconds ?? null,
+    hold_started_at: row.hold_started_at ? new Date(row.hold_started_at) : null,
+    canary_metrics: row.canary_metrics ?? null,
+    canary_passed_at: row.canary_passed_at ? new Date(row.canary_passed_at) : null,
+    rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,
   };
 }
+
+/** Default metric thresholds applied when promoting a canary. */
+const DEFAULT_CANARY_THRESHOLDS: CanaryMetricThresholds = {
+  max_error_rate: 0.01,        // 1 %
+  max_p99_latency_ms: 2000,    // 2 s
+  max_failed_tx_count: 0,      // zero tolerance
+};
 
 // ── Service ───────────────────────────────────────────────────────────────────
 
@@ -510,6 +573,372 @@ export class ContractUpgradeOrchestratorService {
         { upgrade_id: upgradeId, error: String(err?.message ?? err) },
       );
     }
+  }
+
+  // ── Canary phase ──────────────────────────────────────────────────────────
+
+  /**
+   * Activates the canary phase for an approved upgrade.
+   *
+   * Pre-conditions:
+   *   - Upgrade must be in 'approved' state and have simulate_ok = true.
+   *   - canary_offering_id must be a non-empty string (configured per network).
+   *
+   * On success the upgrade transitions to 'canary_active'. The shadow offering
+   * starts receiving traffic against the new code-id.  The caller is responsible
+   * for actually routing traffic; this service records the intent and timestamps.
+   */
+  async startCanary(upgradeId: string, input: StartCanaryInput): Promise<ContractUpgrade> {
+    const { canary_offering_id, hold_period_seconds = 300, actor_id } = input;
+
+    if (!canary_offering_id || canary_offering_id.trim() === '') {
+      throw Errors.badRequest('canary_offering_id is required and must be non-empty');
+    }
+    if (hold_period_seconds < 0) {
+      throw Errors.badRequest('hold_period_seconds must be a non-negative integer');
+    }
+
+    const upgrade = await this.getUpgradeOrThrow(upgradeId);
+
+    if (upgrade.status !== 'approved') {
+      throw Errors.conflict(
+        `Cannot start canary for upgrade with status '${upgrade.status}' — must be 'approved'`,
+        { upgrade_id: upgradeId, status: upgrade.status },
+      );
+    }
+
+    if (!upgrade.simulate_ok) {
+      throw Errors.conflict(
+        'Cannot start canary before a successful dry-run simulation',
+        { upgrade_id: upgradeId },
+      );
+    }
+
+    const result = await this.db.query<ContractUpgrade>(
+      `UPDATE contract_upgrades
+          SET status             = 'canary_active',
+              canary_offering_id = $1,
+              canary_started_at  = NOW(),
+              hold_period_seconds = $2,
+              updated_at         = NOW()
+        WHERE id = $3
+        RETURNING *`,
+      [canary_offering_id.trim(), hold_period_seconds, upgradeId],
+    );
+
+    const updated = mapRow(result.rows[0]);
+
+    await this.auditLog.createAuditLog({
+      user_id: actor_id,
+      action: 'CONTRACT_UPGRADE_CANARY_STARTED',
+      resource: `contract_upgrades/${upgradeId}`,
+      details: JSON.stringify({
+        upgrade_id: upgradeId,
+        canary_offering_id,
+        hold_period_seconds,
+      }),
+    });
+
+    logger.info('Contract upgrade canary phase started', {
+      upgrade_id: upgradeId,
+      canary_offering_id,
+      hold_period_seconds,
+    });
+
+    return updated;
+  }
+
+  /**
+   * Records canary metrics and advances the state machine:
+   *
+   *   canary_active  ──(first metrics call)──▶  hold_period
+   *   hold_period    ──(subsequent calls)──────▶ hold_period  (metrics updated in place)
+   *
+   * If the metrics already breach thresholds this method delegates immediately
+   * to `rollbackCanary` and returns the rolled-back upgrade.
+   *
+   * The hold period timer starts on the first call that receives clean metrics.
+   */
+  async recordCanaryMetrics(
+    upgradeId: string,
+    metrics: CanaryMetrics,
+    actor_id: string,
+    thresholds: CanaryMetricThresholds = DEFAULT_CANARY_THRESHOLDS,
+  ): Promise<ContractUpgrade> {
+    const upgrade = await this.getUpgradeOrThrow(upgradeId);
+
+    if (upgrade.status !== 'canary_active' && upgrade.status !== 'hold_period') {
+      throw Errors.conflict(
+        `Cannot record canary metrics for upgrade with status '${upgrade.status}'`,
+        { upgrade_id: upgradeId, status: upgrade.status },
+      );
+    }
+
+    // Validate metric fields are non-negative numbers.
+    if (
+      typeof metrics.error_rate !== 'number' ||
+      typeof metrics.p99_latency_ms !== 'number' ||
+      typeof metrics.failed_tx_count !== 'number' ||
+      metrics.error_rate < 0 ||
+      metrics.p99_latency_ms < 0 ||
+      metrics.failed_tx_count < 0
+    ) {
+      throw Errors.badRequest(
+        'metrics.error_rate, p99_latency_ms, and failed_tx_count must be non-negative numbers',
+      );
+    }
+
+    const breachReasons: string[] = [];
+    if (metrics.error_rate > thresholds.max_error_rate) {
+      breachReasons.push(
+        `error_rate ${metrics.error_rate} exceeds threshold ${thresholds.max_error_rate}`,
+      );
+    }
+    if (metrics.p99_latency_ms > thresholds.max_p99_latency_ms) {
+      breachReasons.push(
+        `p99_latency_ms ${metrics.p99_latency_ms} exceeds threshold ${thresholds.max_p99_latency_ms}`,
+      );
+    }
+    if (metrics.failed_tx_count > thresholds.max_failed_tx_count) {
+      breachReasons.push(
+        `failed_tx_count ${metrics.failed_tx_count} exceeds threshold ${thresholds.max_failed_tx_count}`,
+      );
+    }
+
+    if (breachReasons.length > 0) {
+      const reason = `Canary metric threshold breached: ${breachReasons.join('; ')}`;
+      logger.warn('CONTRACT_UPGRADE_CANARY_METRICS_BREACHED', {
+        alarm: true,
+        upgrade_id: upgradeId,
+        metrics,
+        thresholds,
+        reasons: breachReasons,
+      });
+      // Automatically roll back on metric breach.
+      return this.rollbackCanary(upgradeId, actor_id, reason);
+    }
+
+    // Metrics are clean — start (or keep) hold period.
+    const newStatus = upgrade.status === 'canary_active' ? 'hold_period' : 'hold_period';
+    const holdStartedAt =
+      upgrade.status === 'canary_active' ? 'NOW()' : null; // only set on first transition
+
+    let updatedRow: ContractUpgrade;
+    if (upgrade.status === 'canary_active') {
+      const result = await this.db.query<ContractUpgrade>(
+        `UPDATE contract_upgrades
+            SET status          = $1,
+                canary_metrics  = $2,
+                hold_started_at = NOW(),
+                updated_at      = NOW()
+          WHERE id = $3
+          RETURNING *`,
+        [newStatus, JSON.stringify(metrics), upgradeId],
+      );
+      updatedRow = mapRow(result.rows[0]);
+    } else {
+      // Already in hold_period: update metrics without resetting hold_started_at.
+      const result = await this.db.query<ContractUpgrade>(
+        `UPDATE contract_upgrades
+            SET canary_metrics = $1,
+                updated_at     = NOW()
+          WHERE id = $2
+          RETURNING *`,
+        [JSON.stringify(metrics), upgradeId],
+      );
+      updatedRow = mapRow(result.rows[0]);
+    }
+
+    // Suppress unused-variable warning for holdStartedAt declared above.
+    void holdStartedAt;
+
+    await this.auditLog.createAuditLog({
+      user_id: actor_id,
+      action: 'CONTRACT_UPGRADE_CANARY_METRICS_RECORDED',
+      resource: `contract_upgrades/${upgradeId}`,
+      details: JSON.stringify({
+        upgrade_id: upgradeId,
+        status: updatedRow.status,
+        metrics,
+        thresholds,
+      }),
+    });
+
+    logger.info('Contract upgrade canary metrics recorded', {
+      upgrade_id: upgradeId,
+      status: updatedRow.status,
+      metrics,
+    });
+
+    return updatedRow;
+  }
+
+  /**
+   * Promotes a canary upgrade to `canary_passed` and authorises general rollout.
+   *
+   * Pre-conditions:
+   *   - Status must be 'hold_period'.
+   *   - The hold period must have elapsed (hold_started_at + hold_period_seconds ≤ now).
+   *   - canary_metrics must be present and within thresholds.
+   *
+   * After promotion the operator should call `applyUpgrade` (or an equivalent
+   * global-rollout step) to distribute the new code-id to all offerings.
+   */
+  async promoteCanary(
+    upgradeId: string,
+    actor_id: string,
+    thresholds: CanaryMetricThresholds = DEFAULT_CANARY_THRESHOLDS,
+  ): Promise<ContractUpgrade> {
+    const upgrade = await this.getUpgradeOrThrow(upgradeId);
+
+    if (upgrade.status !== 'hold_period') {
+      throw Errors.conflict(
+        `Cannot promote canary with status '${upgrade.status}' — must be 'hold_period'`,
+        { upgrade_id: upgradeId, status: upgrade.status },
+      );
+    }
+
+    // Guard: hold period must have elapsed.
+    if (!upgrade.hold_started_at) {
+      throw Errors.conflict(
+        'Hold period has not started — record metrics first',
+        { upgrade_id: upgradeId },
+      );
+    }
+
+    const holdSeconds = upgrade.hold_period_seconds ?? 300;
+    const elapsedMs = Date.now() - upgrade.hold_started_at.getTime();
+    const holdMs = holdSeconds * 1000;
+
+    if (elapsedMs < holdMs) {
+      const remainingSeconds = Math.ceil((holdMs - elapsedMs) / 1000);
+      throw Errors.conflict(
+        `Hold period has not elapsed — ${remainingSeconds}s remaining`,
+        { upgrade_id: upgradeId, remaining_seconds: remainingSeconds },
+      );
+    }
+
+    // Re-check latest metrics before allowing promotion.
+    if (!upgrade.canary_metrics) {
+      throw Errors.conflict(
+        'No canary metrics recorded — record metrics before promoting',
+        { upgrade_id: upgradeId },
+      );
+    }
+
+    const m = upgrade.canary_metrics;
+    const breachReasons: string[] = [];
+    if (m.error_rate > thresholds.max_error_rate) {
+      breachReasons.push(`error_rate ${m.error_rate} exceeds ${thresholds.max_error_rate}`);
+    }
+    if (m.p99_latency_ms > thresholds.max_p99_latency_ms) {
+      breachReasons.push(`p99_latency_ms ${m.p99_latency_ms} exceeds ${thresholds.max_p99_latency_ms}`);
+    }
+    if (m.failed_tx_count > thresholds.max_failed_tx_count) {
+      breachReasons.push(`failed_tx_count ${m.failed_tx_count} exceeds ${thresholds.max_failed_tx_count}`);
+    }
+
+    if (breachReasons.length > 0) {
+      const reason = `Promotion blocked — metric threshold breached: ${breachReasons.join('; ')}`;
+      return this.rollbackCanary(upgradeId, actor_id, reason);
+    }
+
+    const result = await this.db.query<ContractUpgrade>(
+      `UPDATE contract_upgrades
+          SET status          = 'canary_passed',
+              canary_passed_at = NOW(),
+              updated_at      = NOW()
+        WHERE id = $1
+        RETURNING *`,
+      [upgradeId],
+    );
+
+    const promoted = mapRow(result.rows[0]);
+
+    await this.auditLog.createAuditLog({
+      user_id: actor_id,
+      action: 'CONTRACT_UPGRADE_CANARY_PROMOTED',
+      resource: `contract_upgrades/${upgradeId}`,
+      details: JSON.stringify({
+        upgrade_id: upgradeId,
+        canary_offering_id: upgrade.canary_offering_id,
+        hold_period_seconds: holdSeconds,
+        elapsed_seconds: Math.floor(elapsedMs / 1000),
+        metrics: upgrade.canary_metrics,
+      }),
+    });
+
+    logger.info('Contract upgrade canary promoted — ready for general rollout', {
+      upgrade_id: upgradeId,
+    });
+
+    return promoted;
+  }
+
+  /**
+   * Rolls back a canary upgrade to `rolled_back`.
+   *
+   * Can be called:
+   *   - Explicitly by an operator at any canary stage (canary_active, hold_period).
+   *   - Automatically by `recordCanaryMetrics` when thresholds are breached.
+   *   - Automatically by `promoteCanary` when final metrics are still unhealthy.
+   *
+   * Idempotent: if the upgrade is already rolled_back or failed, returns current state.
+   */
+  async rollbackCanary(
+    upgradeId: string,
+    actor_id: string,
+    reason = 'Manual rollback requested',
+  ): Promise<ContractUpgrade> {
+    const upgrade = await this.getUpgradeOrThrow(upgradeId);
+
+    // Idempotent: already in a terminal canary-rollback state.
+    if (upgrade.status === 'rolled_back' || upgrade.status === 'failed') {
+      return upgrade;
+    }
+
+    const allowedStatuses: UpgradeStatus[] = ['canary_active', 'hold_period'];
+    if (!allowedStatuses.includes(upgrade.status)) {
+      throw Errors.conflict(
+        `Cannot rollback canary with status '${upgrade.status}' — must be 'canary_active' or 'hold_period'`,
+        { upgrade_id: upgradeId, status: upgrade.status },
+      );
+    }
+
+    const result = await this.db.query<ContractUpgrade>(
+      `UPDATE contract_upgrades
+          SET status         = 'rolled_back',
+              failure_reason = $1,
+              rolled_back_at = NOW(),
+              updated_at     = NOW()
+        WHERE id = $2
+        RETURNING *`,
+      [reason, upgradeId],
+    );
+
+    const rolledBack = mapRow(result.rows[0]);
+
+    await this.auditLog.createAuditLog({
+      user_id: actor_id,
+      action: 'CONTRACT_UPGRADE_CANARY_ROLLED_BACK',
+      resource: `contract_upgrades/${upgradeId}`,
+      details: JSON.stringify({
+        upgrade_id: upgradeId,
+        canary_offering_id: upgrade.canary_offering_id,
+        reason,
+        previous_status: upgrade.status,
+      }),
+    });
+
+    logger.warn('Contract upgrade canary rolled back', {
+      alarm: true,
+      upgrade_id: upgradeId,
+      canary_offering_id: upgrade.canary_offering_id,
+      reason,
+      previous_status: upgrade.status,
+    });
+
+    return rolledBack;
   }
 
   // ── Post-upgrade health monitoring ───────────────────────────────────────


### PR DESCRIPTION
Add a canary phase state machine to ContractUpgradeOrchestratorService that activates the new code-id against a designated shadow offering before general rollout.

Changes:
- New states: canary_active, hold_period, canary_passed, rolled_back
- New methods: startCanary, recordCanaryMetrics, promoteCanary, rollbackCanary
- Hold-period timer gated on clean metric snapshots
- Auto-rollback on metric threshold breach (error_rate, p99_latency_ms, failed_tx_count)
- Four new admin-gated REST endpoints: canary/start, canary/metrics, canary/promote, canary/rollback
- DB migration 020: extended status CHECK, 7 canary columns, partial index
- 61 tests passing across service and route suites
- docs/contract-upgrade-canary.md with state diagram, API reference, threshold table, security assumptions

closes #521