### PR TITLE
feat: Apple private-relay email handling

### DIFF
--- a/src/auth/social/providerVerifiers.test.ts
+++ b/src/auth/social/providerVerifiers.test.ts
@@ -660,6 +660,59 @@ describe('JwksSocialTokenVerifier', () => {
     });
   });
 
+  describe('Apple private relay handling', () => {
+    it('passes through isPrivateRelay=true when is_private_email is true in the token', async () => {
+      const jwk = publicKeyJwk('k1');
+      global.fetch = jest.fn().mockResolvedValue(mockJwksResponse([jwk]) as any);
+
+      const verifier = new JwksSocialTokenVerifier([appleConfig]);
+      const token = signToken(
+        validPayload({
+          iss: 'https://appleid.apple.com',
+          aud: 'apple-client-id',
+          email: 'relay@privaterelay.appleid.com',
+          is_private_email: true,
+        }),
+      );
+      const result = await verifier.verify('apple', token);
+      expect(result.isPrivateRelay).toBe(true);
+    });
+
+    it('passes through isPrivateRelay=false when is_private_email is absent', async () => {
+      const jwk = publicKeyJwk('k1');
+      global.fetch = jest.fn().mockResolvedValue(mockJwksResponse([jwk]) as any);
+
+      const verifier = new JwksSocialTokenVerifier([appleConfig]);
+      const token = signToken(
+        validPayload({
+          iss: 'https://appleid.apple.com',
+          aud: 'apple-client-id',
+          email: 'real@example.com',
+          // is_private_email intentionally omitted
+        }),
+      );
+      const result = await verifier.verify('apple', token);
+      expect(result.isPrivateRelay).toBe(false);
+    });
+
+    it('passes through isPrivateRelay=true when is_private_email is the string "true"', async () => {
+      const jwk = publicKeyJwk('k1');
+      global.fetch = jest.fn().mockResolvedValue(mockJwksResponse([jwk]) as any);
+
+      const verifier = new JwksSocialTokenVerifier([appleConfig]);
+      const token = signToken(
+        validPayload({
+          iss: 'https://appleid.apple.com',
+          aud: 'apple-client-id',
+          email: 'relay@privaterelay.appleid.com',
+          is_private_email: 'true',
+        }),
+      );
+      const result = await verifier.verify('apple', token);
+      expect(result.isPrivateRelay).toBe(true);
+    });
+  });
+
   describe('default verifier from env', () => {
     it('createDefaultSocialTokenVerifierFromEnv returns a verifier', () => {
       const originalGoogle = process.env.GOOGLE_OAUTH_CLIENT_ID;

--- a/src/auth/social/providerVerifiers.ts
+++ b/src/auth/social/providerVerifiers.ts
@@ -21,6 +21,9 @@ interface JwtPayload {
   email_verified?: boolean | string;
   exp?: number;
   nbf?: number;
+  /** @notice Apple "Hide My Email" / private-relay indicator.
+   *          When `true`, the email is a transient forwarding address. */
+  is_private_email?: boolean | string;
 }
 
 interface ProviderConfig {
@@ -61,6 +64,10 @@ function decodeJwtPart<T>(part: string): T {
 }
 
 function normalizeEmailVerified(value: boolean | string | undefined): boolean {
+  return value === true || value === 'true';
+}
+
+function normalizePrivateRelay(value: boolean | string | undefined): boolean {
   return value === true || value === 'true';
 }
 
@@ -163,6 +170,7 @@ export class JwksSocialTokenVerifier implements SocialTokenVerifier {
       subject: payload.sub,
       email: payload.email.toLowerCase().trim(),
       emailVerified: normalizeEmailVerified(payload.email_verified),
+      isPrivateRelay: normalizePrivateRelay(payload.is_private_email),
       issuer: payload.iss,
       audience,
     };

--- a/src/auth/social/socialAuthService.test.ts
+++ b/src/auth/social/socialAuthService.test.ts
@@ -75,6 +75,7 @@ class FakeIdentities implements SocialIdentityRepository {
     providerSubject: string;
     providerEmail: string;
     emailVerified: boolean;
+    isPrivateRelay?: boolean;
   }): Promise<SocialIdentityRecord> {
     const identity: SocialIdentityRecord = {
       id: `identity-${this.identities.size + 1}`,
@@ -83,6 +84,7 @@ class FakeIdentities implements SocialIdentityRepository {
       providerSubject: input.providerSubject,
       providerEmail: input.providerEmail,
       emailVerified: input.emailVerified,
+      isPrivateRelay: input.isPrivateRelay ?? false,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -90,11 +92,14 @@ class FakeIdentities implements SocialIdentityRepository {
     return identity;
   }
 
-  async updateIdentityEmail(id: string, providerEmail: string): Promise<void> {
+  async updateIdentityEmail(id: string, providerEmail: string, isPrivateRelay?: boolean): Promise<void> {
     const identity = this.identities.get(id);
     if (identity) {
       identity.providerEmail = providerEmail;
       identity.emailVerified = true;
+      if (isPrivateRelay !== undefined) {
+        identity.isPrivateRelay = isPrivateRelay;
+      }
       identity.updatedAt = new Date();
     }
   }
@@ -529,5 +534,150 @@ describe('SocialAuthService', () => {
     const { createHash } = await import('node:crypto');
     const expectedHash = createHash('sha256').update(result.refreshToken).digest('hex');
     expect(sessions.sessions[0].tokenHash).toBe(expectedHash);
+  });
+
+  // ── Apple private-relay ("Hide My Email") tests ─────────────────────────
+
+  it('skips email collision check for Apple private-relay login with no identity', async () => {
+    const { users, verifier, service } = fixture();
+    // An existing password account happens to have the same email as the
+    // private-relay address.  Without the relay guard this would throw
+    // EMAIL_ACCOUNT_REQUIRES_LINK; with it the service skips the check.
+    users.add({
+      id: 'user-1',
+      email: 'privaterelay@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+    verifier.claims = {
+      ...verifier.claims,
+      provider: 'apple',
+      email: 'privaterelay@example.com',
+      isPrivateRelay: true,
+    };
+
+    await expect(service.loginWithProvider('apple', 'token')).rejects.toMatchObject({
+      code: 'SOCIAL_IDENTITY_NOT_LINKED',
+    });
+  });
+
+  it('reinstalled Apple user logs in via stable sub and gets updated relay email', async () => {
+    const { users, identities, verifier, service } = fixture();
+    // First install: user links Apple with an initial private-relay email.
+    users.add({
+      id: 'user-1',
+      email: 'real@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+    verifier.claims = {
+      ...verifier.claims,
+      provider: 'apple',
+      subject: 'apple-sub-stable-001',
+      email: 'first-relay@privaterelay.appleid.com',
+      isPrivateRelay: true,
+    };
+
+    await service.linkProvider({
+      userId: 'user-1',
+      provider: 'apple',
+      idToken: 'token',
+      currentPassword: 'Password123!',
+    });
+
+    // Re-install: Apple generates a new relay email but the sub stays the same.
+    verifier.claims = {
+      ...verifier.claims,
+      email: 'second-relay@privaterelay.appleid.com',
+      isPrivateRelay: true,
+    };
+
+    const result = await service.loginWithProvider('apple', 'token');
+
+    expect(result.user.id).toBe('user-1');
+
+    const stored = await identities.findByUserAndProvider('user-1', 'apple');
+    expect(stored?.providerEmail).toBe('second-relay@privaterelay.appleid.com');
+    expect(stored?.isPrivateRelay).toBe(true);
+  });
+
+  it('skips email collision check when linking an Apple private-relay identity', async () => {
+    const { users, verifier, service } = fixture();
+    // user-1 owns this email in password-account form.
+    users.add({
+      id: 'user-1',
+      email: 'collision@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+    // user-2 tries to link the private-relay address that happens to
+    // match user-1's email.  The relay guard must skip the collision check.
+    users.add({
+      id: 'user-2',
+      email: 'other@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password456!'),
+    });
+    verifier.claims = {
+      ...verifier.claims,
+      provider: 'apple',
+      email: 'collision@example.com',
+      isPrivateRelay: true,
+    };
+
+    const result = await service.linkProvider({
+      userId: 'user-2',
+      provider: 'apple',
+      idToken: 'token',
+      currentPassword: 'Password456!',
+    });
+
+    expect(result.linked).toBe(true);
+    expect(result.identity.isPrivateRelay).toBe(true);
+    expect(result.identity.providerEmail).toBe('collision@example.com');
+  });
+
+  it('preserves isPrivateRelay flag on re-link when email changes', async () => {
+    const { users, identities, verifier, service } = fixture();
+    users.add({
+      id: 'user-1',
+      email: 'real@example.com',
+      role: 'investor',
+      passwordHash: hashPassword('Password123!'),
+    });
+
+    // First link with private-relay email
+    verifier.claims = {
+      ...verifier.claims,
+      provider: 'apple',
+      subject: 'apple-sub-stable-002',
+      email: 'first-relay@privaterelay.appleid.com',
+      isPrivateRelay: true,
+    };
+
+    await service.linkProvider({
+      userId: 'user-1',
+      provider: 'apple',
+      idToken: 'token',
+      currentPassword: 'Password123!',
+    });
+
+    // Re-link with a different private-relay email
+    verifier.claims = {
+      ...verifier.claims,
+      email: 'second-relay@privaterelay.appleid.com',
+      isPrivateRelay: true,
+    };
+
+    const result = await service.linkProvider({
+      userId: 'user-1',
+      provider: 'apple',
+      idToken: 'token',
+      currentPassword: 'Password123!',
+    });
+
+    expect(result.linked).toBe(true);
+    expect(result.identity.providerEmail).toBe('second-relay@privaterelay.appleid.com');
+    expect(result.identity.isPrivateRelay).toBe(true);
   });
 });

--- a/src/auth/social/socialAuthService.ts
+++ b/src/auth/social/socialAuthService.ts
@@ -130,12 +130,16 @@ export class SocialAuthService {
     );
 
     if (!identity) {
-      const emailUser = await this.userRepository.findByEmail(claims.email);
-      if (emailUser) {
-        throw new SocialAuthError(
-          'EMAIL_ACCOUNT_REQUIRES_LINK',
-          'A password account with this email exists. Sign in and link the provider first.',
-        );
+      // Apple private-relay emails are transient and cannot be used for
+      // account matching.  Skip the email-collision check entirely.
+      if (!claims.isPrivateRelay) {
+        const emailUser = await this.userRepository.findByEmail(claims.email);
+        if (emailUser) {
+          throw new SocialAuthError(
+            'EMAIL_ACCOUNT_REQUIRES_LINK',
+            'A password account with this email exists. Sign in and link the provider first.',
+          );
+        }
       }
       throw new SocialAuthError('SOCIAL_IDENTITY_NOT_LINKED', 'Social identity is not linked.');
     }
@@ -146,7 +150,7 @@ export class SocialAuthService {
     }
 
     if (identity.providerEmail !== claims.email) {
-      await this.identityRepository.updateIdentityEmail(identity.id, claims.email);
+      await this.identityRepository.updateIdentityEmail(identity.id, claims.email, claims.isPrivateRelay);
     }
 
     return this.issueSession(user);
@@ -198,12 +202,17 @@ export class SocialAuthService {
         );
       }
       if (existingUserProvider.providerEmail !== claims.email) {
-        await this.identityRepository.updateIdentityEmail(existingUserProvider.id, claims.email);
+        await this.identityRepository.updateIdentityEmail(
+          existingUserProvider.id,
+          claims.email,
+          claims.isPrivateRelay,
+        );
       }
       return { linked: true, identity: existingUserProvider };
     }
 
-    if (user.email !== claims.email) {
+    // Apple private-relay emails are transient — skip email-collision check.
+    if (!claims.isPrivateRelay && user.email !== claims.email) {
       const emailUser = await this.userRepository.findByEmail(claims.email);
       if (emailUser && emailUser.id !== input.userId) {
         throw new SocialAuthError(
@@ -219,6 +228,7 @@ export class SocialAuthService {
       providerSubject: claims.subject,
       providerEmail: claims.email,
       emailVerified: claims.emailVerified,
+      isPrivateRelay: claims.isPrivateRelay,
     });
 
     return { linked: true, identity };

--- a/src/auth/social/types.ts
+++ b/src/auth/social/types.ts
@@ -9,6 +9,10 @@ export interface SocialProviderClaims {
   emailVerified: boolean;
   issuer: string;
   audience: string;
+  /** @notice Apple "Hide My Email" private-relay flag. When `true`, the email
+   *          is a transient forwarding address that may change on reinstall.
+   *          Account lookup must key on `subject` (sub), not email. */
+  isPrivateRelay?: boolean;
 }
 
 export interface SocialTokenVerifier {
@@ -22,6 +26,9 @@ export interface SocialIdentityRecord {
   providerSubject: string;
   providerEmail: string;
   emailVerified: boolean;
+  /** @notice When `true`, the stored email is an Apple private-relay address
+   *          and should only be used as a transient contact. */
+  isPrivateRelay: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -41,8 +48,13 @@ export interface SocialIdentityRepository {
     providerSubject: string;
     providerEmail: string;
     emailVerified: boolean;
+    isPrivateRelay?: boolean;
   }): Promise<SocialIdentityRecord>;
-  updateIdentityEmail(id: string, providerEmail: string): Promise<void>;
+  updateIdentityEmail(
+    id: string,
+    providerEmail: string,
+    isPrivateRelay?: boolean,
+  ): Promise<void>;
   deleteByUserAndProvider(userId: string, provider: SocialAuthProvider): Promise<boolean>;
 }
 

--- a/src/db/migrations/023_add_private_relay_to_social_identities.sql
+++ b/src/db/migrations/023_add_private_relay_to_social_identities.sql
@@ -1,0 +1,16 @@
+-- Migration: Add private-relay flag to social identities
+-- Description: Marks Apple "Hide My Email" addresses as transient so that
+--              account lookups never key on the private-relay email.  New
+--              relay emails from re-installs update the stored email without
+--              affecting the stable (provider, provider_subject) identity.
+--
+-- Security context: LOW — additive-only schema change; no existing data is
+--                   modified or moved.
+
+ALTER TABLE social_identities
+  ADD COLUMN IF NOT EXISTS is_private_relay BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN social_identities.is_private_relay IS
+  'Apple "Hide My Email" flag. When TRUE the provider_email is a transient '
+  'forwarding address that may change on app re-installation. Account lookup '
+  'must key on provider_subject, not email.';

--- a/src/db/repositories/socialIdentityRepository.ts
+++ b/src/db/repositories/socialIdentityRepository.ts
@@ -12,6 +12,7 @@ interface SocialIdentityRow {
   provider_subject: string;
   provider_email: string;
   email_verified: boolean;
+  is_private_relay: boolean;
   created_at: Date;
   updated_at: Date;
 }
@@ -57,6 +58,7 @@ export class SocialIdentityRepository implements ISocialIdentityRepository {
     providerSubject: string;
     providerEmail: string;
     emailVerified: boolean;
+    isPrivateRelay?: boolean;
   }): Promise<SocialIdentityRecord> {
     const result: QueryResult<SocialIdentityRow> = await this.db.query(
       `
@@ -66,10 +68,11 @@ export class SocialIdentityRepository implements ISocialIdentityRepository {
           provider_subject,
           provider_email,
           email_verified,
+          is_private_relay,
           created_at,
           updated_at
         )
-        VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+        VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
         RETURNING *
       `,
       [
@@ -78,20 +81,32 @@ export class SocialIdentityRepository implements ISocialIdentityRepository {
         input.providerSubject,
         input.providerEmail,
         input.emailVerified,
+        input.isPrivateRelay ?? false,
       ],
     );
     return this.mapRow(result.rows[0]);
   }
 
-  async updateIdentityEmail(id: string, providerEmail: string): Promise<void> {
-    await this.db.query(
-      `
-        UPDATE social_identities
-        SET provider_email = $1, email_verified = TRUE, updated_at = NOW()
-        WHERE id = $2
-      `,
-      [providerEmail, id],
-    );
+  async updateIdentityEmail(id: string, providerEmail: string, isPrivateRelay?: boolean): Promise<void> {
+    if (isPrivateRelay !== undefined) {
+      await this.db.query(
+        `
+          UPDATE social_identities
+          SET provider_email = $1, email_verified = TRUE, is_private_relay = $2, updated_at = NOW()
+          WHERE id = $3
+        `,
+        [providerEmail, isPrivateRelay, id],
+      );
+    } else {
+      await this.db.query(
+        `
+          UPDATE social_identities
+          SET provider_email = $1, email_verified = TRUE, updated_at = NOW()
+          WHERE id = $2
+        `,
+        [providerEmail, id],
+      );
+    }
   }
 
   async deleteByUserAndProvider(userId: string, provider: SocialAuthProvider): Promise<boolean> {
@@ -113,6 +128,7 @@ export class SocialIdentityRepository implements ISocialIdentityRepository {
       providerSubject: row.provider_subject,
       providerEmail: row.provider_email,
       emailVerified: row.email_verified,
+      isPrivateRelay: row.is_private_relay,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };


### PR DESCRIPTION
## Summary

This PR adds support for Apple's "Hide My Email" (private relay) addresses in social authentication. Apple's private relay generates a different forwarding email per app installation, but preserves the stable `sub` (subject) claim. Account lookup now keys on `sub` instead of email for private-relay identities, and the relay flag is stored in the DB schema.

## Related Issue

Closes #571

## Changes

### Apple Private-Relay Detection
- **`providerVerifiers.ts`** — extracts `is_private_email` claim from Apple ID tokens
- **`types.ts`** — adds `isPrivateRelay` field to claims, identity records, and repository interfaces

### Smart Email-Collision Skipping
- **`socialAuthService.ts`** (`loginWithProvider`) — skips the email-collision check (`EMAIL_ACCOUNT_REQUIRES_LINK`) when the token is flagged as a private relay, because the relay address is transient and cannot be used for account matching
- **`socialAuthService.ts`** (`linkProvider`) — same guard for the link flow
- Both paths pass through the `isPrivateRelay` flag when creating or updating identities

### Database Schema
- **`socialIdentityRepository.ts`** — persists `is_private_relay` on create/update
- **Migration `023_add_private_relay_to_social_identities.sql`** — adds `is_private_relay BOOLEAN NOT NULL DEFAULT FALSE` column

### Test Coverage (7 new tests)
- Private-relay login skips email collision (returns `SOCIAL_IDENTITY_NOT_LINKED`, not `EMAIL_ACCOUNT_REQUIRES_LINK`)
- Re-install scenario: same `sub`, new relay email → login succeeds with updated email + relay flag preserved
- Private-relay link skips email collision when relay email happens to match another user's email
- Re-link with changed private relay email preserves `isPrivateRelay` flag
- Token `is_private_email: true` / `"true"` / absent → correct `isPrivateRelay` value

## Verification Results

```
Test Suites: 2 passed, 2 total
Tests:       71 passed, 71 total
```

No linter errors. Zero regressions.

## Security Notes

- The `is_private_relay` flag is purely additive — it never weakens existing checks for non-relay logins
- Email-collision guard is skipped only when `claims.isPrivateRelay === true`, which is set exclusively from the verified Apple ID token's `is_private_email` field
- Account lookup continues to key on `(provider, provider_subject)` via the existing `constantTimeLookup` wrapper, preserving timing-attack mitigation