### PR TITLE
test: add backlog threshold boundary test for scheduler catch-up

### DIFF
--- a/src/services/distributionScheduler.test.ts
+++ b/src/services/distributionScheduler.test.ts
@@ -457,6 +457,25 @@ describe('DistributionScheduler', () => {
         })) as any
       );
 
+      it('does not trigger red-alert when backlog equals the threshold', async () => {
+  revenueReportRepo.findApprovedWithoutDistribution.mockResolvedValueOnce(
+    Array.from({ length: 10 }, (_, i) => ({
+      id: `r-${i}`,
+      offering_id: 'off-1',
+    })) as any
+  );
+
+  const s = new DistributionScheduler(engine, revenueReportRepo, {
+    catchupMax: 10,
+    catchupBacklogAlertThreshold: 10,
+  });
+
+  const result = await s.catchUpMissedWindows();
+
+  expect(result.totalMissed).toBe(10);
+  expect(result.backlogExceededCeiling).toBe(false);
+});
+
       const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
       const s = new DistributionScheduler(engine, revenueReportRepo, {
         catchupMax: 5,


### PR DESCRIPTION
## Summary
- add boundary test for catch-up backlog alert threshold
- verify no red-alert is emitted when backlog equals the configured threshold
- improve test coverage for scheduler catch-up mode

Closes #662