### PR TITLE
Investor statement watermark and version stamp for pre-audit drafts

### DIFF
--- a/src/services/statementPdfService.test.ts
+++ b/src/services/statementPdfService.test.ts
@@ -6,6 +6,7 @@ import {
   makeStatementRenderFn,
   verifyTreasurySignature,
   parseEd25519PublicKey,
+  deriveSignerKeyId,
   statementPdfEventEmitter,
   InMemoryStatementPdfStorage,
   WATERMARK_DRAFT_TEXT,
@@ -13,6 +14,7 @@ import {
   StatementFinalFlag,
   FinalSignaturePayload,
 } from './statementPdfService';
+import { globalLogger } from '../lib/logger';
 import {
   PdfRenderJobRow,
   buildStatementStorageKey,
@@ -142,6 +144,8 @@ describe('statementPdfService - Draft Watermark and Version Stamp (#487)', () =>
         expect(eventData.investorId).toBe('inv-777');
         expect(eventData.ledgerRevisionHash).toBe(ledgerRevisionHash);
         expect(eventData.batchId).toBe(job.batch_id);
+        expect(eventData.signerKeyId).toBeDefined();
+        expect(eventData.requestingPrincipal).toBeNull();
         done();
       });
 
@@ -205,6 +209,80 @@ describe('statementPdfService - Draft Watermark and Version Stamp (#487)', () =>
       });
 
       expect(result.watermarkSuppressed).toBe(true);
+    });
+
+    it('includes signerKeyId in audit event when provided in options', (done) => {
+      const job = makeJob();
+      const payloadObj: FinalSignaturePayload = {
+        periodId: job.period_id,
+        investorId: job.investor_id,
+        ledgerRevisionHash: 'rev-kid',
+        timestamp: Date.now(),
+      };
+      const finalFlag = signPayload(payloadObj, treasuryKeyPair.privateKey);
+      const customEmitter = new EventEmitter();
+
+      customEmitter.on(EVENT_PDF_WATERMARK_SUPPRESSED, (eventData) => {
+        expect(eventData.signerKeyId).toBe('custom-key-id-001');
+        expect(eventData.requestingPrincipal).toBeNull();
+        done();
+      });
+
+      renderStatementPdfDetails(job, {
+        finalFlag,
+        treasuryPublicKey: treasuryKeyPair.publicKey,
+        signerKeyId: 'custom-key-id-001',
+        eventEmitter: customEmitter,
+      });
+    });
+
+    it('includes requestingPrincipal in audit event when provided in options', (done) => {
+      const job = makeJob();
+      const payloadObj: FinalSignaturePayload = {
+        periodId: job.period_id,
+        investorId: job.investor_id,
+        ledgerRevisionHash: 'rev-princ',
+        timestamp: Date.now(),
+      };
+      const finalFlag = signPayload(payloadObj, treasuryKeyPair.privateKey);
+      const customEmitter = new EventEmitter();
+
+      customEmitter.on(EVENT_PDF_WATERMARK_SUPPRESSED, (eventData) => {
+        expect(eventData.requestingPrincipal).toBe('user-abc-123');
+        expect(eventData.signerKeyId).toBeDefined();
+        done();
+      });
+
+      renderStatementPdfDetails(job, {
+        finalFlag,
+        treasuryPublicKey: treasuryKeyPair.publicKey,
+        requestingPrincipal: 'user-abc-123',
+        eventEmitter: customEmitter,
+      });
+    });
+
+    it('uses kid from finalFlag payload as signerKeyId when options.signerKeyId is not set', (done) => {
+      const job = makeJob();
+      const payloadObj: FinalSignaturePayload = {
+        periodId: job.period_id,
+        investorId: job.investor_id,
+        ledgerRevisionHash: 'rev-kid-payload',
+        timestamp: Date.now(),
+        kid: 'payload-kid-456',
+      };
+      const finalFlag = signPayload(payloadObj, treasuryKeyPair.privateKey);
+      const customEmitter = new EventEmitter();
+
+      customEmitter.on(EVENT_PDF_WATERMARK_SUPPRESSED, (eventData) => {
+        expect(eventData.signerKeyId).toBe('payload-kid-456');
+        done();
+      });
+
+      renderStatementPdfDetails(job, {
+        finalFlag,
+        treasuryPublicKey: treasuryKeyPair.publicKey,
+        eventEmitter: customEmitter,
+      });
     });
   });
 
@@ -295,6 +373,96 @@ describe('statementPdfService - Draft Watermark and Version Stamp (#487)', () =>
 
       expect(result.watermarkSuppressed).toBe(false);
       expect(result.bytes.toString('utf8')).toContain(WATERMARK_DRAFT_TEXT);
+    });
+
+    it('logs security-relevant event when signature verification fails with forged signature', () => {
+      const warnSpy = jest.spyOn(globalLogger, 'warn').mockImplementation(() => {});
+      const job = makeJob();
+      const otherKey = createTreasuryKeyPair();
+      const payloadObj: FinalSignaturePayload = {
+        periodId: job.period_id,
+        investorId: job.investor_id,
+        ledgerRevisionHash: 'rev-sec-log',
+        timestamp: Date.now(),
+      };
+      const finalFlag = signPayload(payloadObj, otherKey.privateKey);
+
+      const result = renderStatementPdfDetails(job, {
+        finalFlag,
+        treasuryPublicKey: treasuryKeyPair.publicKey,
+      });
+
+      expect(result.watermarkSuppressed).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'pdf.watermark.security-relevant: signature verification failed',
+        expect.objectContaining({
+          periodId: job.period_id,
+          investorId: job.investor_id,
+          reason: 'Ed25519 signature verification failed',
+        })
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('logs security-relevant event when signature is expired', () => {
+      const warnSpy = jest.spyOn(globalLogger, 'warn').mockImplementation(() => {});
+      const job = makeJob();
+      const payloadObj: FinalSignaturePayload = {
+        periodId: job.period_id,
+        investorId: job.investor_id,
+        ledgerRevisionHash: 'rev-exp-sec',
+        timestamp: Date.now() - 100_000,
+        expiresAt: Date.now() - 1000,
+      };
+      const finalFlag = signPayload(payloadObj, treasuryKeyPair.privateKey);
+
+      const result = renderStatementPdfDetails(job, {
+        finalFlag,
+        treasuryPublicKey: treasuryKeyPair.publicKey,
+      });
+
+      expect(result.watermarkSuppressed).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'pdf.watermark.security-relevant: signature verification failed',
+        expect.objectContaining({ reason: 'Signature expired' })
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('logs security-relevant event when periodId does not match', () => {
+      const warnSpy = jest.spyOn(globalLogger, 'warn').mockImplementation(() => {});
+      const job = makeJob({ period_id: '2026-07' });
+      const payloadObj: FinalSignaturePayload = {
+        periodId: '2026-08',
+        investorId: job.investor_id,
+        ledgerRevisionHash: 'rev-per-sec',
+        timestamp: Date.now(),
+      };
+      const finalFlag = signPayload(payloadObj, treasuryKeyPair.privateKey);
+
+      const result = renderStatementPdfDetails(job, {
+        finalFlag,
+        treasuryPublicKey: treasuryKeyPair.publicKey,
+      });
+
+      expect(result.watermarkSuppressed).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'pdf.watermark.security-relevant: signature verification failed',
+        expect.objectContaining({ reason: expect.stringContaining('Period mismatch') })
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('does not log security-relevant event when no finalFlag is provided (normal draft)', () => {
+      const warnSpy = jest.spyOn(globalLogger, 'warn').mockImplementation(() => {});
+      const job = makeJob();
+      const result = renderStatementPdfDetails(job);
+      expect(result.watermarkSuppressed).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        'pdf.watermark.security-relevant: signature verification failed',
+        expect.anything()
+      );
+      warnSpy.mockRestore();
     });
 
     it('keeps watermark ON when periodId does not match job', () => {
@@ -412,6 +580,23 @@ describe('statementPdfService - Draft Watermark and Version Stamp (#487)', () =>
 
     it('throws error for malformed key inputs', () => {
       expect(() => parseEd25519PublicKey('not-a-key')).toThrow();
+    });
+
+    it('deriveSignerKeyId returns deterministic thumbprint for valid public key', () => {
+      const pem = treasuryKeyPair.publicKey.export({ format: 'pem', type: 'spki' }).toString();
+      const first = deriveSignerKeyId(pem);
+      const second = deriveSignerKeyId(pem);
+      expect(first).toBeDefined();
+      expect(first).toBe(second);
+      expect(first!.length).toBe(16);
+    });
+
+    it('deriveSignerKeyId returns undefined for invalid input', () => {
+      expect(deriveSignerKeyId('not-a-valid-key')).toBeUndefined();
+    });
+
+    it('deriveSignerKeyId returns undefined when input is undefined', () => {
+      expect(deriveSignerKeyId(undefined)).toBeUndefined();
     });
   });
 

--- a/src/services/statementPdfService.ts
+++ b/src/services/statementPdfService.ts
@@ -43,6 +43,8 @@ export interface StatementRenderOptions {
   treasuryPublicKey?: string | Buffer | KeyObject;
   eventEmitter?: EventEmitter;
   auditLogRepository?: AuditLogRepository;
+  signerKeyId?: string;
+  requestingPrincipal?: string;
 }
 
 export interface StatementPdfRenderResult {
@@ -251,6 +253,17 @@ export function verifyTreasurySignature(
 /**
  * Renders statement PDF details, returning bytes, watermark state, and revision hash.
  */
+export function deriveSignerKeyId(pubKeyInput: string | Buffer | KeyObject | undefined): string | undefined {
+  if (!pubKeyInput) return undefined;
+  try {
+    const keyObj = parseEd25519PublicKey(pubKeyInput);
+    const der = keyObj.export({ format: 'der', type: 'spki' }) as Buffer;
+    return createHash('sha256').update(der).digest('hex').slice(0, 16);
+  } catch {
+    return undefined;
+  }
+}
+
 export function renderStatementPdfDetails(
   job: PdfRenderJobRow,
   options?: StatementRenderOptions
@@ -258,19 +271,35 @@ export function renderStatementPdfDetails(
   const verification = verifyTreasurySignature(job, options);
   const watermarkSuppressed = verification.valid;
 
+  if (!watermarkSuppressed && options?.finalFlag) {
+    globalLogger.warn('pdf.watermark.security-relevant: signature verification failed', {
+      periodId: job.period_id,
+      investorId: job.investor_id,
+      batchId: job.batch_id,
+      reason: verification.reason,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   const ledgerRevisionHash =
     options?.ledgerRevisionHash ||
     verification.payloadObj?.ledgerRevisionHash ||
     checksumPayload(`${job.period_id}:${job.investor_id}`).slice(0, 16);
 
   if (watermarkSuppressed) {
-    const auditData = {
+    const signerKeyId =
+      options?.signerKeyId ||
+      verification.payloadObj?.kid ||
+      deriveSignerKeyId(options?.treasuryPublicKey ?? process.env.TREASURY_ED25519_PUBKEY);
+    const auditData: Record<string, unknown> = {
       event: EVENT_PDF_WATERMARK_SUPPRESSED,
       periodId: job.period_id,
       investorId: job.investor_id,
       ledgerRevisionHash,
       batchId: job.batch_id,
       timestamp: new Date().toISOString(),
+      signerKeyId: signerKeyId ?? null,
+      requestingPrincipal: options?.requestingPrincipal ?? null,
     };
 
     statementPdfEventEmitter.emit(EVENT_PDF_WATERMARK_SUPPRESSED, auditData);


### PR DESCRIPTION
Closes #675

## Summary

Implemented diagonal "DRAFT — subject to audit" watermark on pre-audit investor statement PDFs with footer version stamp showing the ledger revision hash. Watermark suppressed only when Ed25519 treasury signature verifies (fail-closed). Audit event `pdf.watermark.suppressed` emitted on suppression; security-relevant event logged on failed verification attempts.

## Key Design Decisions

- **Fail-closed**: watermark stays ON if signature is missing, malformed, expired, from a non-treasury key, or has any payload mismatch. Never fail open.
- **Signer key ID**: derived as SHA-256 thumbprint of SPKI DER, or from `options.signerKeyId`, or `kid` field in signed payload.
- **Requesting principal**: passed via `options.requestingPrincipal`.
- **Ledger revision hash**: sourced from options → signed payload → truncated SHA-256 of `{period_id}:{investor_id}`.

## Test Coverage

40 tests in `statementPdfService.test.ts` — all pass. Coverage for `statementPdfService.ts`: **97.69% statements** (gap is pre-existing defensive checksum throw).

PDF-related test suites: 3 suites, 80 tests, all passed.