### PR TITLE
feat: public witness for audit log Merkle roots (#721)

### DIFF
--- a/docs/audit-merkle-public-witness.md
+++ b/docs/audit-merkle-public-witness.md
@@ -1,0 +1,91 @@
+# Audit Log Public Witness (Merkle Root)
+
+**Issue:** [#721](https://github.com/RevoraOrg/Revora-Backend/issues/721) — Audit-log integrity proofs: publish Merkle root to a public witness periodically  
+**Status:** Implemented
+
+---
+
+## Overview
+
+`auditHashChain` provides **internal** tamper-evidence. This feature adds a
+periodic job that:
+
+1. Computes the **Merkle root of the day's** audit `row_hash` values.
+2. Posts the root to a public timestamping witness (Stellar memo / mock / injectable Rekor).
+3. Persists the receipt in `audit_witness_receipts` for later verification.
+4. Emits `audit.witness.published` on success.
+
+Failed publishes retry with bounded exponential backoff and raise an ALARM on
+exhaustion. **Witness downtime never breaks local integrity verification.**
+
+---
+
+## Architecture
+
+```
+  AuditIntegrityScheduler (nightly)
+            │
+            ├─ verifyAuditLogIntegrity()   ← local hash chain
+            │
+            └─ AuditWitnessPublisher
+                   │
+                   ├─ load day's row_hash values
+                   ├─ computeMerkleRoot(leaves)
+                   ├─ WitnessClient.publish(root)   ← mock | stellar | custom
+                   └─ INSERT audit_witness_receipts
+```
+
+---
+
+## Components
+
+| File | Role |
+|------|------|
+| `src/security/auditMerkle.ts` | Pure Merkle helpers (`computeMerkleRoot`, `utcDayBounds`) |
+| `src/security/witnessClient.ts` | `WitnessClient` interface + `MockWitnessClient` + `StellarMemoWitnessClient` |
+| `src/security/auditWitnessPublisher.ts` | Day-root + chain-head publish with retry/backoff |
+| `src/security/auditIntegrityScheduler.ts` | Nightly job wires verification → witness publish |
+| `src/db/migrations/018_create_audit_witness_receipts.sql` | Receipt storage |
+
+---
+
+## Metrics
+
+| Metric | Type | When |
+|--------|------|------|
+| `audit.witness.published` | counter | Root successfully published + receipt saved |
+| `audit.witness.publish_errors` | counter | Retry budget exhausted (ALARM also logged) |
+
+---
+
+## Security assumptions
+
+1. Only already-hashed `row_hash` values leave the system — no raw audit details
+   are posted to the public witness.
+2. Stellar text memos are truncated to 28 bytes; the full root is stored in the
+   receipt for offline verification.
+3. `STELLAR_SERVER_SECRET` (if used by an injected Horizon submitter) is never logged.
+4. Publish failures are swallowed so local integrity checks always complete.
+
+---
+
+## Abuse / failure paths
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Empty day (no audit rows) | Skip publish; debug log |
+| Root already published | Skip (idempotent) |
+| Witness transient failure | Retry with exponential backoff |
+| Witness downtime / exhausted retries | ALARM + `audit.witness.publish_errors`; local integrity unaffected |
+| DB error loading day hashes | ALARM; local integrity unaffected |
+
+---
+
+## Testing
+
+```bash
+npx jest src/security/auditMerkle.test.ts src/security/auditWitnessPublisher.test.ts src/security/auditIntegrityScheduler.test.ts --forceExit
+```
+
+Covers Merkle construction (empty / single / odd leaf), day publish, retry,
+exhaustion isolation, and Stellar dry-run receipts.

--- a/src/security/auditIntegrityScheduler.ts
+++ b/src/security/auditIntegrityScheduler.ts
@@ -103,9 +103,10 @@ export class AuditIntegrityScheduler {
           headHash: result.headHash,
         });
 
+        // Publish the day's Merkle root AND the chain head to the public witness.
+        // Errors are caught internally and never fail the scheduler / local integrity.
+        void this.witnessPublisher.publishDayRoot();
         if (result.headHash) {
-          // Publish the root hash to the public witness in the background
-          // (Errors are caught internally and won't fail the scheduler)
           void this.witnessPublisher.publishLatest(result.headHash);
         }
       } else {

--- a/src/security/auditMerkle.test.ts
+++ b/src/security/auditMerkle.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for auditMerkle.ts — day-scoped Merkle root helpers (issue #721).
+ */
+
+import { computeMerkleRoot, hashPair, utcDayBounds } from './auditMerkle';
+import { createHash } from 'crypto';
+
+describe('auditMerkle', () => {
+  describe('hashPair', () => {
+    it('is deterministic and order-sensitive', () => {
+      const a = hashPair('aa', 'bb');
+      const b = hashPair('aa', 'bb');
+      const c = hashPair('bb', 'aa');
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
+      expect(a).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  describe('computeMerkleRoot', () => {
+    it('returns null for an empty leaf list', () => {
+      expect(computeMerkleRoot([])).toBeNull();
+    });
+
+    it('returns the single leaf unchanged', () => {
+      const leaf = createHash('sha256').update('only').digest('hex');
+      expect(computeMerkleRoot([leaf])).toBe(leaf);
+    });
+
+    it('builds a two-leaf root', () => {
+      const left = createHash('sha256').update('L').digest('hex');
+      const right = createHash('sha256').update('R').digest('hex');
+      expect(computeMerkleRoot([left, right])).toBe(hashPair(left, right));
+    });
+
+    it('promotes an odd leaf unchanged', () => {
+      const a = createHash('sha256').update('a').digest('hex');
+      const b = createHash('sha256').update('b').digest('hex');
+      const c = createHash('sha256').update('c').digest('hex');
+      // Level1: hash(a,b), c  →  root: hash(hash(a,b), c)
+      expect(computeMerkleRoot([a, b, c])).toBe(hashPair(hashPair(a, b), c));
+    });
+
+    it('is order-sensitive across the full list', () => {
+      const leaves = ['a', 'b', 'c', 'd'].map((x) =>
+        createHash('sha256').update(x).digest('hex'),
+      );
+      const root = computeMerkleRoot(leaves)!;
+      const reversed = computeMerkleRoot([...leaves].reverse())!;
+      expect(root).not.toBe(reversed);
+    });
+  });
+
+  describe('utcDayBounds', () => {
+    it('returns a half-open UTC day interval', () => {
+      const { start, end } = utcDayBounds(new Date('2026-07-31T15:30:00Z'));
+      expect(start.toISOString()).toBe('2026-07-31T00:00:00.000Z');
+      expect(end.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    });
+  });
+});

--- a/src/security/auditMerkle.ts
+++ b/src/security/auditMerkle.ts
@@ -1,0 +1,54 @@
+/**
+ * @file auditMerkle.ts
+ *
+ * @notice Pure helpers for building a Merkle root over audit log row hashes.
+ *
+ * @dev Used by `AuditWitnessPublisher` to compute the Merkle root of a single
+ *      day's audit rows before publishing to a public witness (issue #721).
+ *      Leaves are the existing per-row `row_hash` values from the hash chain;
+ *      the tree is binary, left-to-right, with odd nodes promoted unchanged.
+ *      An empty day yields `null` (nothing to witness).
+ */
+
+import { createHash } from 'crypto';
+
+/** Hash two sibling nodes into their parent. */
+export function hashPair(left: string, right: string): string {
+  return createHash('sha256').update(`${left}|${right}`).digest('hex');
+}
+
+/**
+ * Compute the Merkle root of an ordered list of leaf hashes.
+ *
+ * @param leaves Ordered leaf hashes (typically audit `row_hash` values for a day).
+ * @returns The root hash, or `null` when `leaves` is empty.
+ */
+export function computeMerkleRoot(leaves: string[]): string | null {
+  if (leaves.length === 0) return null;
+  if (leaves.length === 1) return leaves[0];
+
+  let level = [...leaves];
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 < level.length) {
+        next.push(hashPair(level[i], level[i + 1]));
+      } else {
+        // Odd leaf: promote unchanged so the tree stays deterministic.
+        next.push(level[i]);
+      }
+    }
+    level = next;
+  }
+  return level[0];
+}
+
+/**
+ * UTC calendar day bounds `[start, end)` for `day`.
+ */
+export function utcDayBounds(day: Date): { start: Date; end: Date } {
+  const start = new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate()));
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { start, end };
+}

--- a/src/security/auditWitnessPublisher.test.ts
+++ b/src/security/auditWitnessPublisher.test.ts
@@ -1,8 +1,19 @@
+/**
+ * Tests for AuditWitnessPublisher (issue #721).
+ *
+ * Covers:
+ *   - publishLatest skip / publish / retry / exhaustion isolation
+ *   - publishDayRoot Merkle construction + empty day + downtime isolation
+ *   - StellarMemoWitnessClient validation + dry-run receipt
+ */
+
 import { Pool } from 'pg';
 import { AuditWitnessPublisher } from './auditWitnessPublisher';
-import { MockWitnessClient } from './witnessClient';
+import { MockWitnessClient, StellarMemoWitnessClient } from './witnessClient';
 import { MetricsCollector } from '../lib/metrics';
 import { Logger } from '../lib/logger';
+import { createHash } from 'crypto';
+import { hashPair } from './auditMerkle';
 
 describe('AuditWitnessPublisher', () => {
   let pool: jest.Mocked<Pick<Pool, 'query'>>;
@@ -12,13 +23,9 @@ describe('AuditWitnessPublisher', () => {
   let publisher: AuditWitnessPublisher;
 
   beforeEach(() => {
-    pool = {
-      query: jest.fn(),
-    } as unknown as jest.Mocked<Pick<Pool, 'query'>>;
-
+    pool = { query: jest.fn() } as unknown as jest.Mocked<Pick<Pool, 'query'>>;
     witnessClient = new MockWitnessClient();
     metrics = new MetricsCollector({ enabled: true });
-    
     logger = {
       info: jest.fn(),
       warn: jest.fn(),
@@ -32,11 +39,14 @@ describe('AuditWitnessPublisher', () => {
       logger,
       metrics,
       maxRetries: 2,
-      baseBackoffMs: 10, // fast for tests
+      baseBackoffMs: 10,
+      now: () => new Date('2026-08-01T12:00:00Z'),
     });
 
     pool.query.mockResolvedValue({ rows: [] } as any);
   });
+
+  // ── publishLatest ──────────────────────────────────────────────────────────
 
   it('does nothing if headHash is null', async () => {
     await publisher.publishLatest(null);
@@ -47,32 +57,35 @@ describe('AuditWitnessPublisher', () => {
   it('does not publish if the hash is already the last published', async () => {
     pool.query.mockResolvedValueOnce({ rows: [{ root_hash: 'hash123' }] } as any);
     await publisher.publishLatest('hash123');
-    
-    expect(pool.query).toHaveBeenCalledTimes(1); // Only checking last published
-    expect(logger.debug).toHaveBeenCalledWith('Hash already published', expect.objectContaining({ headHash: 'hash123' }));
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Hash already published',
+      expect.objectContaining({ rootHash: 'hash123' }),
+    );
   });
 
   it('publishes and saves receipt successfully', async () => {
     pool.query
-      .mockResolvedValueOnce({ rows: [] } as any) // getLastPublishedHash
-      .mockResolvedValueOnce({ rowCount: 1 } as any); // saveReceipt
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rowCount: 1 } as any);
 
     await publisher.publishLatest('newhash456');
 
     expect(pool.query).toHaveBeenCalledTimes(2);
-    expect(pool.query).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO audit_witness_receipts'), [
-      'newhash456',
-      'mock',
-      expect.any(String),
-      expect.any(Date),
-    ]);
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('INSERT INTO audit_witness_receipts'),
+      ['newhash456', 'mock', expect.any(String), expect.any(Date)],
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Audit log Merkle root published to witness',
+      expect.objectContaining({ rootHash: 'newhash456' }),
+    );
 
-    expect(logger.info).toHaveBeenCalledWith('Audit log Merkle root published to witness', expect.objectContaining({
-      headHash: 'newhash456',
-    }));
-    
-    // Test that the metric was recorded (this relies on your metrics collector implementation in tests)
-    // You could assert internal state of metrics or just trust it.
+    const snapshot = await metrics.getSnapshot();
+    const published = snapshot.custom.find((m) => m.name === 'audit_witness_published');
+    expect(published?.value).toBe(1);
   });
 
   it('retries on failure and eventually succeeds', async () => {
@@ -80,29 +93,101 @@ describe('AuditWitnessPublisher', () => {
       .mockResolvedValueOnce({ rows: [] } as any)
       .mockResolvedValueOnce({ rowCount: 1 } as any);
 
-    witnessClient.simulateFailureAttempts = 2; // Will fail twice, succeed on third attempt
-    
+    witnessClient.simulateFailureAttempts = 2;
+
     await publisher.publishLatest('hash-retry');
 
     expect(logger.warn).toHaveBeenCalledTimes(2);
-    expect(logger.warn).toHaveBeenNthCalledWith(1, expect.stringContaining('Witness publish attempt 1 failed'), expect.any(Object));
-    expect(logger.warn).toHaveBeenNthCalledWith(2, expect.stringContaining('Witness publish attempt 2 failed'), expect.any(Object));
-    
-    expect(pool.query).toHaveBeenCalledTimes(2);
-    expect(logger.info).toHaveBeenCalledWith('Audit log Merkle root published to witness', expect.any(Object));
+    expect(logger.info).toHaveBeenCalledWith(
+      'Audit log Merkle root published to witness',
+      expect.any(Object),
+    );
   });
 
   it('emits error alarm and fails gracefully on exhaustion', async () => {
     pool.query.mockResolvedValueOnce({ rows: [] } as any);
-    
-    witnessClient.simulateFailureAttempts = 5; // More than maxRetries
-    
-    await publisher.publishLatest('hash-fail');
+    witnessClient.simulateFailureAttempts = 5;
 
-    expect(logger.warn).toHaveBeenCalledTimes(2); // attempt 1, 2
-    expect(logger.error).toHaveBeenCalledWith('ALARM: Failed to publish audit root to witness', expect.objectContaining({
-      alarm: 'audit_witness_publish_failure',
-    }));
-    // Should NOT throw
+    await expect(publisher.publishLatest('hash-fail')).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'ALARM: Failed to publish audit root to witness',
+      expect.objectContaining({ alarm: 'audit_witness_publish_failure' }),
+    );
+
+    const snapshot = await metrics.getSnapshot();
+    const errors = snapshot.custom.find((m) => m.name === 'audit_witness_publish_errors');
+    expect(errors?.value).toBe(1);
+  });
+
+  // ── publishDayRoot ─────────────────────────────────────────────────────────
+
+  it('computes the day Merkle root and publishes it', async () => {
+    const a = createHash('sha256').update('a').digest('hex');
+    const b = createHash('sha256').update('b').digest('hex');
+    const expectedRoot = hashPair(a, b);
+
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ row_hash: a }, { row_hash: b }] } as any) // loadDayRowHashes
+      .mockResolvedValueOnce({ rows: [] } as any) // getLastPublishedHash
+      .mockResolvedValueOnce({ rowCount: 1 } as any); // saveReceipt
+
+    await publisher.publishDayRoot(new Date('2026-07-31T00:00:00Z'));
+
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('FROM audit_logs'),
+      [new Date('2026-07-31T00:00:00.000Z'), new Date('2026-08-01T00:00:00.000Z')],
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('INSERT INTO audit_witness_receipts'),
+      [expectedRoot, 'mock', expect.any(String), expect.any(Date)],
+    );
+  });
+
+  it('skips publish when the day has no audit rows', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] } as any);
+    await publisher.publishDayRoot(new Date('2026-07-31T00:00:00Z'));
+    expect(logger.debug).toHaveBeenCalledWith(
+      'No audit rows for day — nothing to witness',
+      expect.objectContaining({ day: '2026-07-31' }),
+    );
+  });
+
+  it('witness downtime does not break local integrity (day root)', async () => {
+    pool.query.mockRejectedValueOnce(new Error('db down'));
+    await expect(publisher.publishDayRoot()).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'ALARM: Failed to publish audit root to witness',
+      expect.objectContaining({ alarm: 'audit_witness_publish_failure' }),
+    );
+  });
+});
+
+describe('StellarMemoWitnessClient', () => {
+  it('rejects a non-hex root', async () => {
+    const client = new StellarMemoWitnessClient();
+    await expect(client.publish('not-a-hash')).rejects.toThrow(/64-char hex/);
+  });
+
+  it('returns a dry-run stellar receipt when no submitter is configured', async () => {
+    const root = createHash('sha256').update('root').digest('hex');
+    const client = new StellarMemoWitnessClient({ network: 'testnet' });
+    const receipt = await client.publish(root);
+    expect(receipt.witnessType).toBe('stellar');
+    expect(receipt.rootHash).toBe(root);
+    expect(receipt.receiptData.dryRun).toBe(true);
+    expect(String(receipt.receiptData.memo)).toContain(root.slice(0, 20));
+  });
+
+  it('uses the injected Horizon submitter when provided', async () => {
+    const root = createHash('sha256').update('root').digest('hex');
+    const submitMemo = jest.fn().mockResolvedValue({ txHash: 'tx-abc' });
+    const client = new StellarMemoWitnessClient({ submitMemo, network: 'public' });
+    const receipt = await client.publish(root);
+    expect(submitMemo).toHaveBeenCalled();
+    expect(receipt.receiptData.txHash).toBe('tx-abc');
+    expect(receipt.receiptData.dryRun).toBeUndefined();
   });
 });

--- a/src/security/auditWitnessPublisher.ts
+++ b/src/security/auditWitnessPublisher.ts
@@ -1,13 +1,34 @@
+/**
+ * @file auditWitnessPublisher.ts
+ *
+ * @notice Publishes the Merkle root of the day's audit log to a public witness
+ *         and persists the receipt (issue #721).
+ *
+ * @dev Flow:
+ *        1. Load that day's `row_hash` values from `audit_logs` (ordered).
+ *        2. Compute the Merkle root via `computeMerkleRoot`.
+ *        3. Skip if the same root was already published.
+ *        4. Publish with bounded exponential backoff; alert on exhaustion.
+ *        5. Persist the receipt in `audit_witness_receipts`.
+ *        6. Emit `audit.witness.published`.
+ *
+ *      Witness downtime must NEVER break local integrity verification — all
+ *      publish errors are caught, logged as ALARMs, and swallowed.
+ */
+
 import { Pool } from 'pg';
 import { globalMetrics } from '../lib/metrics';
 import { globalLogger, Logger } from '../lib/logger';
 import { WitnessClient, WitnessReceipt } from './witnessClient';
+import { computeMerkleRoot, utcDayBounds } from './auditMerkle';
 
 export interface AuditWitnessPublisherOptions {
   maxRetries?: number;
   baseBackoffMs?: number;
   logger?: Logger;
   metrics?: typeof globalMetrics;
+  /** Clock override for deterministic tests. */
+  now?: () => Date;
 }
 
 const DEFAULT_MAX_RETRIES = 3;
@@ -18,6 +39,7 @@ export class AuditWitnessPublisher {
   private readonly metrics: typeof globalMetrics;
   private readonly maxRetries: number;
   private readonly baseBackoffMs: number;
+  private readonly now: () => Date;
 
   constructor(
     private readonly pool: Pick<Pool, 'query'>,
@@ -28,46 +50,101 @@ export class AuditWitnessPublisher {
     this.metrics = options.metrics ?? globalMetrics;
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.baseBackoffMs = options.baseBackoffMs ?? DEFAULT_BASE_BACKOFF_MS;
+    this.now = options.now ?? (() => new Date());
   }
 
   /**
-   * Check if the headHash needs publishing, and if so, publish and record receipt.
-   * Tolerates witness downtime by catching errors and alerting.
+   * Compute the Merkle root of yesterday's (or `day`'s) audit rows and publish
+   * it to the configured public witness.
+   *
+   * @param day Optional UTC day to witness. Defaults to the previous UTC day
+   *            so the nightly job always witnesses a complete day.
+   */
+  async publishDayRoot(day?: Date): Promise<void> {
+    const target = day ?? this.previousUtcDay();
+    try {
+      const leaves = await this.loadDayRowHashes(target);
+      const root = computeMerkleRoot(leaves);
+
+      if (!root) {
+        this.logger.debug('No audit rows for day — nothing to witness', {
+          day: target.toISOString().slice(0, 10),
+        });
+        return;
+      }
+
+      await this.publishRoot(root, {
+        day: target.toISOString().slice(0, 10),
+        leafCount: leaves.length,
+      });
+    } catch (error) {
+      // Local integrity must survive witness/DB failures.
+      this.recordPublishFailure(error, null);
+    }
+  }
+
+  /**
+   * Publish an already-known head/root hash (used by the integrity scheduler
+   * after a successful full-chain verification).
    */
   async publishLatest(headHash: string | null): Promise<void> {
     if (!headHash) {
       this.logger.debug('No head hash to publish');
       return;
     }
-
     try {
-      const lastPublished = await this.getLastPublishedHash();
-      
-      if (lastPublished === headHash) {
-        this.logger.debug('Hash already published', { headHash });
-        return;
-      }
-
-      const receipt = await this.publishWithRetry(headHash);
-      await this.saveReceipt(receipt);
-      
-      this.metrics.incrementCounter('audit.witness.published');
-      this.logger.info('Audit log Merkle root published to witness', {
-        headHash,
-        witnessType: receipt.witnessType,
-      });
-
+      await this.publishRoot(headHash, { source: 'chain_head' });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.metrics.incrementCounter('audit.witness.publish_errors');
-      this.logger.error('ALARM: Failed to publish audit root to witness', {
-        severity: 'high',
-        alarm: 'audit_witness_publish_failure',
-        headHash,
-        error: message,
-      });
-      // We do not rethrow the error because witness downtime should not break local integrity checks.
+      this.recordPublishFailure(error, headHash);
     }
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────────
+
+  private previousUtcDay(): Date {
+    const now = this.now();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+  }
+
+  private async loadDayRowHashes(day: Date): Promise<string[]> {
+    const { start, end } = utcDayBounds(day);
+    const res = await this.pool.query<{ row_hash: string }>(
+      `
+      SELECT row_hash
+        FROM audit_logs
+       WHERE created_at >= $1 AND created_at < $2
+         AND row_hash IS NOT NULL
+       ORDER BY created_at ASC, id ASC
+      `,
+      [start, end],
+    );
+    return res.rows.map((r) => r.row_hash);
+  }
+
+  private async publishRoot(
+    rootHash: string,
+    context: Record<string, unknown>,
+  ): Promise<void> {
+    const lastPublished = await this.getLastPublishedHash();
+    if (lastPublished === rootHash) {
+      this.logger.debug('Hash already published', { rootHash, ...context });
+      return;
+    }
+
+    const receipt = await this.publishWithRetry(rootHash);
+    await this.saveReceipt(receipt);
+
+    this.metrics.incrementCounter(
+      'audit.witness.published',
+      undefined,
+      1,
+      'Number of audit Merkle roots successfully published to a public witness',
+    );
+    this.logger.info('Audit log Merkle root published to witness', {
+      rootHash,
+      witnessType: receipt.witnessType,
+      ...context,
+    });
   }
 
   private async getLastPublishedHash(): Promise<string | null> {
@@ -91,26 +168,43 @@ export class AuditWitnessPublisher {
         receipt.witnessType,
         JSON.stringify(receipt.receiptData),
         receipt.publishedAt,
-      ]
+      ],
     );
   }
 
-  private async publishWithRetry(headHash: string): Promise<WitnessReceipt> {
+  private async publishWithRetry(rootHash: string): Promise<WitnessReceipt> {
     let attempt = 0;
     while (attempt <= this.maxRetries) {
       try {
-        return await this.witnessClient.publish(headHash);
+        return await this.witnessClient.publish(rootHash);
       } catch (error) {
         attempt++;
         if (attempt > this.maxRetries) {
-          throw error; // exhausted
+          throw error;
         }
-        
         const delay = this.baseBackoffMs * Math.pow(2, attempt - 1);
-        this.logger.warn(`Witness publish attempt ${attempt} failed, retrying in ${delay}ms`, { error: String(error) });
-        await new Promise(resolve => setTimeout(resolve, delay));
+        this.logger.warn(`Witness publish attempt ${attempt} failed, retrying in ${delay}ms`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
     throw new Error('Unreachable');
+  }
+
+  private recordPublishFailure(error: unknown, rootHash: string | null): void {
+    const message = error instanceof Error ? error.message : String(error);
+    this.metrics.incrementCounter(
+      'audit.witness.publish_errors',
+      undefined,
+      1,
+      'Number of exhausted audit witness publish attempts',
+    );
+    this.logger.error('ALARM: Failed to publish audit root to witness', {
+      severity: 'high',
+      alarm: 'audit_witness_publish_failure',
+      rootHash,
+      error: message,
+    });
   }
 }

--- a/src/security/witnessClient.ts
+++ b/src/security/witnessClient.ts
@@ -1,5 +1,11 @@
 /**
- * Interface for publishing audit log integrity roots to a public witness.
+ * @file witnessClient.ts
+ *
+ * @notice Interface + clients for publishing audit Merkle roots to a public
+ *         witness (Sigstore Rekor, Stellar memo, or mock for tests).
+ *
+ * @dev Witness downtime must never break local audit integrity verification —
+ *      callers catch publish errors and alert without rethrowing.
  */
 
 export interface WitnessReceipt {
@@ -24,7 +30,7 @@ export interface WitnessClient {
 }
 
 /**
- * A mock witness client for testing and development.
+ * Mock witness client for testing and local development.
  */
 export class MockWitnessClient implements WitnessClient {
   private publishAttempts = 0;
@@ -44,6 +50,64 @@ export class MockWitnessClient implements WitnessClient {
       receiptData: {
         attempt: this.publishAttempts,
         txId: `mock-tx-${Date.now()}`,
+      },
+    };
+  }
+}
+
+/**
+ * Stellar memo witness: posts the Merkle root as a transaction memo on the
+ * configured network.  Production deployments inject a real Horizon submitter;
+ * the default implementation records a deterministic receipt without network I/O
+ * so local integrity checks never depend on Horizon availability.
+ *
+ * Security assumptions:
+ * - The root hash is hex; memo text is truncated to Stellar's 28-byte memo limit
+ *   by storing a short prefix + full hash in `receiptData` for verification.
+ * - Secrets (`STELLAR_SERVER_SECRET`) are never logged.
+ */
+export class StellarMemoWitnessClient implements WitnessClient {
+  constructor(
+    private readonly options: {
+      /** Optional Horizon submitter. When omitted, a dry-run receipt is returned. */
+      submitMemo?: (memo: string) => Promise<{ txHash: string }>;
+      network?: string;
+    } = {},
+  ) {}
+
+  async publish(rootHash: string): Promise<WitnessReceipt> {
+    if (!/^[a-f0-9]{64}$/i.test(rootHash)) {
+      throw new Error('StellarMemoWitnessClient expects a 64-char hex Merkle root');
+    }
+
+    // Stellar text memos are limited to 28 bytes — store a short prefix on-chain
+    // and keep the full root in the receipt for offline verification.
+    const memo = `audit:${rootHash.slice(0, 20)}`;
+    const publishedAt = new Date();
+
+    if (this.options.submitMemo) {
+      const { txHash } = await this.options.submitMemo(memo);
+      return {
+        rootHash,
+        witnessType: 'stellar',
+        publishedAt,
+        receiptData: {
+          network: this.options.network ?? 'testnet',
+          memo,
+          txHash,
+        },
+      };
+    }
+
+    return {
+      rootHash,
+      witnessType: 'stellar',
+      publishedAt,
+      receiptData: {
+        network: this.options.network ?? 'testnet',
+        memo,
+        dryRun: true,
+        note: 'No Horizon submitter configured — receipt recorded locally only',
       },
     };
   }


### PR DESCRIPTION
## Overview

This PR publishes the **Merkle root of each day's audit log** to a public witness (Stellar memo / mock), persists the receipt, and retries with bounded backoff. Witness downtime never breaks local hash-chain integrity verification.

## Related Issue

Closes #721

## Changes

### 🔐 Public witness for audit Merkle roots

* **[ADD]** `src/security/auditMerkle.ts` — pure Merkle helpers (`computeMerkleRoot`, `utcDayBounds`).
* **[MODIFY]** `src/security/witnessClient.ts` — `MockWitnessClient` + `StellarMemoWitnessClient` (injectable Horizon submitter; dry-run by default).
* **[MODIFY]** `src/security/auditWitnessPublisher.ts`
  * `publishDayRoot()` loads the day's `row_hash` values, computes the Merkle root, publishes with exponential backoff, persists receipt.
  * `publishLatest()` still publishes the chain head after a successful integrity check.
  * Failures emit `audit.witness.publish_errors` + ALARM and are swallowed.
* **[MODIFY]** `src/security/auditIntegrityScheduler.ts` — nightly job calls `publishDayRoot()` + `publishLatest()`.
* **[ADD]** tests + `docs/audit-merkle-public-witness.md`.

Receipts land in `audit_witness_receipts` (migration 018).

## Verification Results

```
npx jest src/security/auditMerkle.test.ts src/security/auditWitnessPublisher.test.ts src/security/auditIntegrityScheduler.test.ts --forceExit
✅ 24/24 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Periodic job computes day's Merkle root | ✅ `publishDayRoot()` |
| Posts to public witness (Stellar memo / mock) | ✅ |
| Persist receipts with root + timestamp | ✅ `audit_witness_receipts` |
| Emit `audit.witness.published` | ✅ |
| Failed publishes retry with bounded backoff + alert | ✅ |
| Witness downtime does not break local integrity | ✅ errors swallowed |

## Timeline

- Implemented day-scoped Merkle root + witness publisher + Stellar client + docs/tests.
